### PR TITLE
Prototype evaluation input recording and filesystem validation

### DIFF
--- a/src/Build.UnitTests/Evaluation/EvaluationInputRecording_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/EvaluationInputRecording_Tests.cs
@@ -1,0 +1,171 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Definition;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Evaluation.Context;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests.Evaluation;
+
+public sealed class EvaluationInputRecording_Tests : IDisposable
+{
+    private const string EnableVariable = "MSBUILDRECORDEVALUATIONINPUTS";
+
+    private readonly TestEnvironment _env;
+    private readonly TransientTestFolder _folder;
+
+    public EvaluationInputRecording_Tests(ITestOutputHelper output)
+    {
+        _env = TestEnvironment.Create(output);
+        _folder = _env.CreateFolder(createFolder: true);
+        SetRecording(enabled: true);
+    }
+
+    public void Dispose()
+    {
+        _env.Dispose();
+        Traits.UpdateFromEnvironment();
+    }
+
+    [Fact]
+    public void DisabledRecordingProducesNoInputs()
+    {
+        SetRecording(enabled: false);
+        string project = CreateProject("""
+            <Project>
+              <PropertyGroup>
+                <A>1</A>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        ProjectInstance instance = ProjectInstance.FromFile(project, CreateOptions());
+
+        instance.EvaluationInputs.ShouldBeNull();
+        instance.GetPropertyValue("A").ShouldBe("1");
+    }
+
+    [Fact]
+    public void InMemoryProjectIsNotCacheable()
+    {
+        ProjectCollection collection = _env.CreateProjectCollection().Collection;
+        ProjectRootElement xml = ProjectRootElement.Create(collection);
+
+        var instance = new ProjectInstance(xml, globalProperties: null, toolsVersion: null, collection);
+
+        instance.EvaluationInputs.ShouldNotBeNull().NonCacheable.ShouldBe(NonCacheableReason.InMemoryProject);
+    }
+
+    [Fact]
+    public void ThreadWorkingDirectoryIsTheWorkingDirectoryInTheKey()
+    {
+        // The in-process node gives each build thread its own working directory, which is what Path.GetFullPath resolves against.
+        string project = CreateProject("<Project />");
+        string? saved = FileUtilities.CurrentThreadWorkingDirectory;
+        try
+        {
+            FileUtilities.CurrentThreadWorkingDirectory = _folder.Path;
+
+            Evaluate(project).Key.WorkingDirectory.ShouldBe(_folder.Path);
+        }
+        finally
+        {
+            FileUtilities.CurrentThreadWorkingDirectory = saved;
+        }
+    }
+
+    [Fact]
+    public void WorkingDirectoryIsInTheKeySoRelativeGetFullPathIsCacheable()
+    {
+        string project = CreateProject("""
+            <Project>
+              <PropertyGroup>
+                <Relative>$([System.IO.Path]::GetFullPath('a.txt'))</Relative>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        EvaluationInputs inputs = Evaluate(project);
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
+        inputs.Key.WorkingDirectory.ShouldBe(Directory.GetCurrentDirectory());
+    }
+
+    [Fact]
+    public void ParserConfigurationIsRecordedAndInTheKey()
+    {
+        // The parser skips what Directory.Parse.config allows, so the files are inputs and their content is in the key.
+        string project = CreateProject("<Project />");
+        EvaluationInputs without = Evaluate(project);
+        string config = _env.CreateFile(_folder, ParserIgnoreConfiguration.ConfigFileName, """<ParseConfig><IgnoreAttributes><Ignore Element="Target" Name="Foo" /></IgnoreAttributes></ParseConfig>""").Path;
+        _env.SetEnvironmentVariable(ParserIgnoreConfiguration.EnvironmentVariableName, config);
+
+        EvaluationInputs with = Evaluate(project);
+
+        with.NonCacheable.ShouldBe(NonCacheableReason.None);
+        with.Key.ParserConfigurationFingerprint.ShouldNotBe(without.Key.ParserConfigurationFingerprint);
+    }
+
+    [Fact]
+    public void KeysOfEqualEvaluationsAreEqual()
+    {
+        string project = CreateProject("<Project />");
+        ProjectOptions options = CreateOptions();
+        options.GlobalProperties = new Dictionary<string, string> { ["Configuration"] = "Release", ["Platform"] = "x64" };
+
+        EvaluationInputKey first = Evaluate(project, options).Key;
+        EvaluationInputKey second = Evaluate(project, options).Key;
+
+        second.ShouldBe(first);
+        second.GetHashCode().ShouldBe(first.GetHashCode());
+    }
+
+    [Fact]
+    public void KeyDistinguishesToolsetsWithTheSameVersion()
+    {
+        string project = CreateProject("<Project />");
+
+        EvaluationInputKey first = EvaluateWithToolsetProperty(project, "1").Key;
+        EvaluationInputKey same = EvaluateWithToolsetProperty(project, "1").Key;
+        EvaluationInputKey other = EvaluateWithToolsetProperty(project, "2").Key;
+
+        same.ShouldBe(first);
+        other.ShouldNotBe(first);
+    }
+
+    private EvaluationInputs EvaluateWithToolsetProperty(string project, string value)
+    {
+        ProjectCollection collection = _env.CreateProjectCollection().Collection;
+        Toolset current = collection.GetToolset(ObjectModelHelpers.MSBuildDefaultToolsVersion);
+        collection.AddToolset(new Toolset("Custom", current.ToolsPath, new Dictionary<string, string> { ["Contoso"] = value }, collection, msbuildOverrideTasksPath: null));
+        return Evaluate(project, new ProjectOptions { ProjectCollection = collection, ToolsVersion = "Custom" });
+    }
+
+    private void SetRecording(bool enabled)
+    {
+        _env.SetEnvironmentVariable(EnableVariable, enabled ? "1" : null);
+        Traits.UpdateFromEnvironment();
+    }
+
+    private string CreateProject(string xml, string name = "test.proj") =>
+        _env.CreateFile(_folder, name, xml.Cleanup()).Path;
+
+    private ProjectOptions CreateOptions() =>
+        new() { ProjectCollection = _env.CreateProjectCollection().Collection };
+
+    private EvaluationInputs Evaluate(string project, ProjectOptions? options = null)
+    {
+        ProjectInstance instance = ProjectInstance.FromFile(project, options ?? CreateOptions());
+        EvaluationInputs inputs = instance.EvaluationInputs.ShouldNotBeNull();
+        return inputs;
+    }
+}

--- a/src/Build.UnitTests/Evaluation/EvaluationInputRecording_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/EvaluationInputRecording_Tests.cs
@@ -5,12 +5,16 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Definition;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Evaluation.Context;
 using Microsoft.Build.Execution;
+using Microsoft.Build.FileSystem;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Unittest;
 using Shouldly;
 using Xunit;
 
@@ -20,11 +24,13 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
 {
     private const string EnableVariable = "MSBUILDRECORDEVALUATIONINPUTS";
 
+    private readonly ITestOutputHelper _output;
     private readonly TestEnvironment _env;
     private readonly TransientTestFolder _folder;
 
     public EvaluationInputRecording_Tests(ITestOutputHelper output)
     {
+        _output = output;
         _env = TestEnvironment.Create(output);
         _folder = _env.CreateFolder(createFolder: true);
         SetRecording(enabled: true);
@@ -55,6 +61,331 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
     }
 
     [Fact]
+    public void RecordsRootProjectAsExistingFile()
+    {
+        string project = CreateProject("<Project />");
+
+        EvaluationInputs inputs = Evaluate(project);
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
+        inputs.Key.ProjectFullPath.ShouldBe(project);
+        inputs.Key.Culture.ShouldBe(CultureInfo.CurrentCulture.Name);
+        inputs.Key.ToolsPath.ShouldNotBeNullOrEmpty();
+        FileDependency root = inputs.Files[project];
+        root.Kind.ShouldBe(PathKind.File);
+        root.LastWriteTimeUtc.ShouldBe(File.GetLastWriteTimeUtc(project));
+        root.Length.ShouldBe(new FileInfo(project).Length);
+    }
+
+    [Fact]
+    public void IgnoredMissingImportIsRecordedAsMissing()
+    {
+        string project = CreateProject("""
+            <Project>
+              <Import Project="missing.props" />
+            </Project>
+            """);
+        ProjectOptions options = CreateOptions();
+        options.LoadSettings = ProjectLoadSettings.IgnoreMissingImports;
+
+        EvaluationInputs inputs = Evaluate(project, options);
+
+        inputs.Files[Path.Combine(_folder.Path, "missing.props")].Kind.ShouldBe(PathKind.Missing);
+    }
+
+    [Theory]
+    [InlineData("FileExists", "optional.props")]
+    [InlineData("DirectoryExists", "generated")]
+    public void IntrinsicExistsProbeIsRecorded(string function, string name)
+    {
+        string project = CreateProject($"""
+            <Project>
+              <PropertyGroup>
+                <Found>$([MSBuild]::{function}('$(MSBuildThisFileDirectory){name}'))</Found>
+              </PropertyGroup>
+            </Project>
+            """);
+        string probed = Path.Combine(_folder.Path, name);
+
+        EvaluationInputs inputs = Evaluate(project);
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
+        inputs.Files[probed].Kind.ShouldBe(PathKind.Missing);
+    }
+
+    [Fact]
+    public void ExistsOnLoadedProjectIsRecorded()
+    {
+        // Only design-time evaluation consults the loaded projects, and only for import conditions; ProjectInstance
+        // evaluation always asks the file system.
+        ProjectCollection collection = _env.CreateProjectCollection().Collection;
+        string loaded = _env.CreateFile(_folder, "loaded.proj", "<Project />").Path;
+        ProjectRootElement loadedElement = ProjectRootElement.Open(loaded, collection);
+        _env.CreateFile(_folder, "other.props", "<Project><PropertyGroup><HasOther>true</HasOther></PropertyGroup></Project>");
+        string project = CreateProject("""
+            <Project>
+              <Import Project="other.props" Condition="Exists('$(MSBuildThisFileDirectory)loaded.proj')" />
+            </Project>
+            """);
+
+        var evaluated = new Project(project, globalProperties: null, toolsVersion: null, collection);
+
+        evaluated.GetPropertyValue("HasOther").ShouldBe("true");
+        evaluated.EvaluationInputs.ShouldNotBeNull().Files[loaded].Kind.ShouldBe(PathKind.File);
+        GC.KeepAlive(loadedElement);
+    }
+
+    [Fact]
+    public void IgnoredEmptyImportIsRecordedWithItsLength()
+    {
+        string empty = _env.CreateFile(_folder, "empty.props", string.Empty).Path;
+        string project = CreateProject("""
+            <Project>
+              <Import Project="empty.props" />
+            </Project>
+            """);
+        ProjectOptions options = CreateOptions();
+        options.LoadSettings = ProjectLoadSettings.IgnoreEmptyImports;
+        EvaluationInputs inputs = Evaluate(project, options);
+        inputs.Files[empty].ShouldBe(new FileDependency(PathKind.File, File.GetLastWriteTimeUtc(empty), 0));
+    }
+
+    [Fact]
+    public void UnsavedProjectChangesAreNotCacheable()
+    {
+        ProjectCollection collection = _env.CreateProjectCollection().Collection;
+        string project = CreateProject("<Project />");
+        ProjectRootElement xml = ProjectRootElement.Open(project, collection);
+        xml.AddProperty("Edited", "true");
+
+        var instance = new ProjectInstance(xml, globalProperties: null, toolsVersion: null, collection);
+
+        instance.EvaluationInputs.ShouldNotBeNull().NonCacheable.ShouldBe(NonCacheableReason.InMemoryProject);
+    }
+
+    [Fact]
+    public void ProjectSourceChangedAfterItWasReadIsNotCacheable()
+    {
+        ProjectCollection collection = _env.CreateProjectCollection().Collection;
+        string project = CreateProject("<Project />");
+        ProjectRootElement xml = ProjectRootElement.Open(project, collection);
+        Touch(project, "<Project><PropertyGroup /></Project>");
+
+        var instance = new ProjectInstance(xml, globalProperties: null, toolsVersion: null, collection);
+
+        instance.EvaluationInputs.ShouldNotBeNull().NonCacheable.ShouldBe(NonCacheableReason.ConflictingObservation);
+    }
+
+    [Fact]
+    public void FileReadPropertyFunctionRecordsTheFile()
+    {
+        string version = _env.CreateFile(_folder, "version.txt", "1.0").Path;
+        string project = CreateProject("""
+            <Project>
+              <PropertyGroup>
+                <Version>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)/version.txt'))</Version>
+              </PropertyGroup>
+            </Project>
+            """);
+        EvaluationInputs inputs = Evaluate(project);
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
+        inputs.Files[version].Kind.ShouldBe(PathKind.File);
+    }
+
+    [Theory]
+    [InlineData("$([System.DateTime]::Now)")]
+    [InlineData("$([System.Guid]::NewGuid())")]
+    [InlineData("$([System.DateTime]::Parse('12:34'))")]
+    [InlineData("$([System.Convert]::ToDateTime('12:34'))")]
+    public void VolatilePropertyFunctionIsNotCacheable(string expression)
+    {
+        string project = CreateProject($"""
+            <Project>
+              <PropertyGroup>
+                <Value>{expression}</Value>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        EvaluationInputs inputs = Evaluate(project);
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.VolatilePropertyFunction);
+    }
+
+    [Theory]
+    [InlineData("$([System.IO.File]::GetCreationTime('$(MSBuildProjectFullPath)'))")]
+    [InlineData("$([System.IO.File]::GetAttributes('$(MSBuildProjectFullPath)'))")]
+    [InlineData("$([System.IO.Directory]::GetLastAccessTime('$(MSBuildProjectDirectory)'))")]
+    public void ReadsOfFieldsTheManifestDoesNotHoldAreNotCacheable(string expression)
+    {
+        string project = CreateProject($"""
+            <Project>
+              <PropertyGroup>
+                <Value>{expression}</Value>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        Evaluate(project).NonCacheable.ShouldBe(NonCacheableReason.UnclassifiedPropertyFunction);
+    }
+
+    [Fact]
+    public void PurePropertyFunctionsAreCacheable()
+    {
+        string project = CreateProject("""
+            <Project>
+              <PropertyGroup>
+                <A>value</A>
+                <B>$(A.ToUpper())_$([System.String]::Join('-', 'x', 'y'))_$([MSBuild]::Add(1, 2))</B>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        EvaluationInputs inputs = Evaluate(project);
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
+    }
+
+    [Fact]
+    public void UnclassifiedPropertyFunctionIsNotCacheable()
+    {
+        string project = CreateProject("""
+            <Project>
+              <PropertyGroup>
+                <Drives>$([System.Environment]::GetLogicalDrives())</Drives>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        EvaluationInputs inputs = Evaluate(project);
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.UnclassifiedPropertyFunction);
+        inputs.NonCacheableDetail.ShouldNotBeNull().ShouldContain("GetLogicalDrives");
+    }
+
+    [Fact]
+    public void AllPropertyFunctionsSwitchIsNotCacheable()
+    {
+        // The AppContext switch overrides the variable when a previous test left it set, so honor whichever is active.
+        const string switchName = "Microsoft.Build.EnableAllPropertyFunctions";
+        bool switchWasSet = AppContext.TryGetSwitch(switchName, out bool original);
+        _env.SetEnvironmentVariable("MSBUILDENABLEALLPROPERTYFUNCTIONS", "1");
+        if (switchWasSet)
+        {
+            AppContext.SetSwitch(switchName, true);
+        }
+
+        try
+        {
+            EvaluationInputs inputs = Evaluate(CreateProject("<Project />"));
+
+            inputs.NonCacheable.ShouldBe(NonCacheableReason.AllPropertyFunctionsEnabled);
+        }
+        finally
+        {
+            if (switchWasSet)
+            {
+                AppContext.SetSwitch(switchName, original);
+            }
+        }
+    }
+
+    [Theory]
+    [InlineData("<Stamp Include=\"@(Compile->'%(ModifiedTime)')\" />")]
+    [InlineData("<Stamp Include=\"@(Compile->ModifiedTime())\" />")]
+    [InlineData("<Stamp Include=\"@(Compile)\"><Time>%(CreatedTime)</Time></Stamp>")]
+    public void ItemTimestampMetadataIsNotCacheable(string stampItem)
+    {
+        _env.CreateFile(_folder, "a.cs", string.Empty);
+        string project = CreateProject($"""
+            <Project>
+              <ItemGroup>
+                <Compile Include="a.cs" />
+                {stampItem}
+              </ItemGroup>
+            </Project>
+            """);
+
+        EvaluationInputs inputs = Evaluate(project);
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.ItemTimestampMetadata);
+    }
+
+    [Fact]
+    public void NamesContainingTimestampModifiersAreCacheable()
+    {
+        string project = CreateProject("""
+            <Project>
+              <PropertyGroup>
+                <LastModifiedTime>never</LastModifiedTime>
+                <Value>$(LastModifiedTime)</Value>
+              </PropertyGroup>
+              <ItemGroup>
+                <Compile Include="a.cs">
+                  <CreatedTimeZone>UTC</CreatedTimeZone>
+                </Compile>
+                <Stamp Include="@(Compile->'%(CreatedTimeZone)')" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        EvaluationInputs inputs = Evaluate(project);
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
+    }
+
+    [WindowsOnlyFact]
+    public void RecorderFailureMarksNonCacheableWithoutChangingEvaluation()
+    {
+        // Path.GetFullPath rejects paths over 32,767 characters on Windows; File.Exists just returns false.
+        string project = CreateProject("""
+            <Project>
+              <PropertyGroup>
+                <Name>a</Name>
+                <LongPath>$(Name.PadLeft(40000, 'a'))</LongPath>
+                <Found>$([System.IO.File]::Exists('$(LongPath)'))</Found>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        ProjectInstance instance = ProjectInstance.FromFile(project, CreateOptions());
+
+        instance.GetPropertyValue("Found").ShouldBe("False");
+        instance.EvaluationInputs.ShouldNotBeNull().NonCacheable.ShouldBe(NonCacheableReason.RecorderFailure);
+    }
+
+    [Fact]
+    public void ConcurrentEvaluationsOnSharedContextRecordIndependently()
+    {
+        const string xml = """
+            <Project>
+              <ItemGroup>
+                <Compile Include="*.cs" />
+              </ItemGroup>
+            </Project>
+            """;
+        string first = CreateProject(xml, "first.proj");
+        TransientTestFolder secondFolder = _env.CreateFolder(createFolder: true);
+        string second = _env.CreateFile(secondFolder, "second.proj", xml.Cleanup()).Path;
+        EvaluationContext shared = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
+        ProjectCollection collection = _env.CreateProjectCollection().Collection;
+        var instances = new ProjectInstance[2];
+
+        Parallel.Invoke(
+            () => instances[0] = ProjectInstance.FromFile(first, new ProjectOptions { ProjectCollection = collection, EvaluationContext = shared }),
+            () => instances[1] = ProjectInstance.FromFile(second, new ProjectOptions { ProjectCollection = collection, EvaluationContext = shared }));
+
+        EvaluationInputs firstInputs = instances[0].EvaluationInputs.ShouldNotBeNull();
+        EvaluationInputs secondInputs = instances[1].EvaluationInputs.ShouldNotBeNull();
+        firstInputs.Files.ContainsKey(first).ShouldBeTrue();
+        firstInputs.Files.ContainsKey(_folder.Path).ShouldBeTrue();
+        firstInputs.Files.ContainsKey(second).ShouldBeFalse();
+        firstInputs.Files.ContainsKey(secondFolder.Path).ShouldBeFalse();
+        secondInputs.Files.ContainsKey(second).ShouldBeTrue();
+        secondInputs.Files.ContainsKey(first).ShouldBeFalse();
+    }
+
+    [Fact]
     public void InMemoryProjectIsNotCacheable()
     {
         ProjectCollection collection = _env.CreateProjectCollection().Collection;
@@ -63,6 +394,263 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         var instance = new ProjectInstance(xml, globalProperties: null, toolsVersion: null, collection);
 
         instance.EvaluationInputs.ShouldNotBeNull().NonCacheable.ShouldBe(NonCacheableReason.InMemoryProject);
+    }
+
+    [Fact]
+    public void CommonTargetsProjectIsCacheableAndValidatesAsCurrent()
+    {
+        string project = CreateCommonTargetsProject();
+
+        EvaluationInputs inputs = Evaluate(project);
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.None, inputs.NonCacheableDetail);
+        inputs.Files.Count.ShouldBeGreaterThan(5);
+        Evaluate(project).Files.Keys.ShouldBe(inputs.Files.Keys, ignoreOrder: true);
+    }
+
+    [Fact]
+    public void RecordingDoesNotChangeEvaluationResult()
+    {
+        string project = CreateCommonTargetsProject();
+        SetRecording(enabled: false);
+        ProjectInstance plain = ProjectInstance.FromFile(project, CreateOptions());
+        SetRecording(enabled: true);
+        ProjectInstance recorded = ProjectInstance.FromFile(project, CreateOptions());
+
+        plain.EvaluationInputs.ShouldBeNull();
+        recorded.EvaluationInputs.ShouldNotBeNull();
+        List<string> plainSnapshot = Snapshot(plain);
+        List<string> recordedSnapshot = Snapshot(recorded);
+        recordedSnapshot.Except(plainSnapshot).ShouldBeEmpty();
+        plainSnapshot.Except(recordedSnapshot).ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void RecordingThroughASharedContextDoesNotChangeEvaluationResult()
+    {
+        // The recording copy shares the context's glob cache, so the second evaluation reuses the expansions and must still
+        // record every traversed directory, replayed from the cache, as a dependency a new file invalidates.
+        string project = CreateCommonTargetsProject();
+        SetRecording(enabled: false);
+        ProjectInstance plain = ProjectInstance.FromFile(project, CreateOptions());
+        SetRecording(enabled: true);
+        EvaluationContext shared = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
+        ProjectInstance first = ProjectInstance.FromFile(project, new ProjectOptions { ProjectCollection = CreateOptions().ProjectCollection, EvaluationContext = shared });
+        ProjectInstance second = ProjectInstance.FromFile(project, new ProjectOptions { ProjectCollection = CreateOptions().ProjectCollection, EvaluationContext = shared });
+
+        List<string> plainSnapshot = Snapshot(plain);
+        Snapshot(first).Except(plainSnapshot).ShouldBeEmpty();
+        Snapshot(second).Except(plainSnapshot).ShouldBeEmpty();
+        plainSnapshot.Except(Snapshot(second)).ShouldBeEmpty();
+        EvaluationInputs firstInputs = first.EvaluationInputs.ShouldNotBeNull();
+        EvaluationInputs secondInputs = second.EvaluationInputs.ShouldNotBeNull();
+        secondInputs.NonCacheable.ShouldBe(NonCacheableReason.None);
+        secondInputs.Files.Keys.Except(firstInputs.Files.Keys, StringComparer.OrdinalIgnoreCase).ShouldBeEmpty();
+        firstInputs.Files.Keys.Except(secondInputs.Files.Keys, StringComparer.OrdinalIgnoreCase).ShouldBeEmpty();
+    }
+
+#if FEATURE_SYMLINK_TARGET
+    [RequiresSymbolicLinksFact]
+    public void LinkedFileIsNotCacheable()
+    {
+        string target = _env.CreateFile(_folder, "target.props", "<Project />").Path;
+        string link = Path.Combine(_folder.Path, "linked.props");
+        File.CreateSymbolicLink(link, target);
+        string project = CreateProject("""
+            <Project>
+              <Import Project="linked.props" Condition="Exists('linked.props')" />
+            </Project>
+            """);
+
+        EvaluationInputs inputs = Evaluate(project);
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.Link);
+        inputs.NonCacheableDetail.ShouldBe(link);
+    }
+
+    [RequiresSymbolicLinksFact]
+    public void LinkedDirectoryIsNotCacheable()
+    {
+        string target = _env.CreateFolder(Path.Combine(_folder.Path, "target"), createFolder: true).Path;
+        File.WriteAllText(Path.Combine(target, "a.cs"), string.Empty);
+        string link = Path.Combine(_folder.Path, "linked");
+        Directory.CreateSymbolicLink(link, target);
+        string project = CreateProject("""
+            <Project>
+              <ItemGroup>
+                <Compile Include="linked\**\*.cs" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        EvaluationInputs inputs = Evaluate(project);
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.Link);
+        inputs.NonCacheableDetail.ShouldBe(link);
+    }
+#endif
+
+    [Fact]
+    public void RecordedPathsShareOneStringAcrossEvaluations()
+    {
+        _env.CreateFile(_folder, "shared.props", "<Project />");
+        string project = CreateProject("""
+            <Project>
+              <Import Project="shared.props" />
+              <ItemGroup>
+                <None Include="**/*.txt" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        EvaluationInputs first = Evaluate(project);
+        EvaluationInputs second = Evaluate(project);
+
+        first.Files.Count.ShouldBeGreaterThan(1);
+        foreach (string path in first.Files.Keys)
+        {
+            string counterpart = second.Files.Keys.Single(key => string.Equals(key, path, StringComparison.OrdinalIgnoreCase));
+            ReferenceEquals(path, counterpart).ShouldBeTrue($"{path} was allocated again");
+        }
+    }
+
+    [Fact]
+    public void ItemExistsTransformRecordsProbes()
+    {
+        _env.CreateFile(_folder, "present.txt", "x");
+        string missing = Path.Combine(_folder.Path, "missing.txt");
+        string project = CreateProject("""
+            <Project>
+              <ItemGroup>
+                <Candidate Include="present.txt;missing.txt" />
+                <Kept Include="@(Candidate->Exists())" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        ProjectInstance instance = ProjectInstance.FromFile(project, CreateOptions());
+        EvaluationInputs inputs = instance.EvaluationInputs.ShouldNotBeNull();
+
+        instance.GetItems("Kept").Select(item => item.EvaluatedInclude).ShouldBe(["present.txt"]);
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
+        inputs.Files[Path.Combine(_folder.Path, "present.txt")].Kind.ShouldBe(PathKind.File);
+        inputs.Files[missing].Kind.ShouldBe(PathKind.Missing);
+    }
+
+    [Theory]
+    [InlineData("Metadata('ModifiedTime')")]
+    [InlineData("HasMetadata('CreatedTime')")]
+    [InlineData("WithMetadataValue('AccessedTime', '')")]
+    [InlineData("WithoutMetadataValue('ModifiedTime', '')")]
+    [InlineData("AnyHaveMetadataValue('ModifiedTime', '')")]
+    public void TransformsReadingTimestampMetadataByNameAreNotCacheable(string transform)
+    {
+        _env.CreateFile(_folder, "a.cs", "class A {}");
+        string project = CreateProject($$"""
+            <Project>
+              <ItemGroup>
+                <Compile Include="a.cs" />
+                <Stamp Include="@(Compile->{{transform}})" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        Evaluate(project).NonCacheable.ShouldBe(NonCacheableReason.ItemTimestampMetadata);
+    }
+
+    [Fact]
+    public void MetadataReferenceWithWhitespaceReadingTimestampIsNotCacheable()
+    {
+        _env.CreateFile(_folder, "a.cs", "class A {}");
+        string project = CreateProject("""
+            <Project>
+              <ItemGroup>
+                <Compile Include="a.cs" />
+                <Stamp Include="@(Compile->'%( ModifiedTime )')" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        Evaluate(project).NonCacheable.ShouldBe(NonCacheableReason.ItemTimestampMetadata);
+    }
+
+    [Fact]
+    public void RemoveMatchingOnTimestampMetadataIsNotCacheable()
+    {
+        _env.CreateFile(_folder, "a.cs", "class A {}");
+        string project = CreateProject("""
+            <Project>
+              <ItemGroup>
+                <Compile Include="a.cs" />
+                <Old Include="a.cs" />
+                <Compile Remove="@(Old)" MatchOnMetadata="ModifiedTime" />
+              </ItemGroup>
+            </Project>
+            """);
+
+        Evaluate(project).NonCacheable.ShouldBe(NonCacheableReason.ItemTimestampMetadata);
+    }
+
+    [Fact]
+    public void ExistsOnLoadedProjectDeletedFromDiskIsNotCacheable()
+    {
+        ProjectCollection collection = _env.CreateProjectCollection().Collection;
+        string loaded = _env.CreateFile(_folder, "loaded.props", "<Project />").Path;
+        ProjectRootElement loadedElement = ProjectRootElement.Open(loaded, collection);
+        File.Delete(loaded);
+        collection.ProjectRootElementCache.TryGet(loaded).ShouldBeSameAs(loadedElement);
+        _env.CreateFile(_folder, "other.props", "<Project><PropertyGroup><Loaded>true</Loaded></PropertyGroup></Project>");
+        string project = CreateProject("""
+            <Project>
+              <Import Project="other.props" Condition="Exists('loaded.props')" />
+            </Project>
+            """);
+
+        var evaluated = new Project(project, globalProperties: null, toolsVersion: null, collection);
+        EvaluationInputs inputs = evaluated.EvaluationInputs.ShouldNotBeNull();
+
+        evaluated.GetPropertyValue("Loaded").ShouldBe("true");
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.ConflictingObservation);
+        inputs.NonCacheableDetail.ShouldBe(loaded);
+        GC.KeepAlive(loadedElement);
+    }
+
+    [Fact]
+    public void ToolLocationHelperProbingCallerPathsIsNotCacheable()
+    {
+        _env.CreateFile(_folder, "a.txt", "x");
+        string project = CreateProject("""
+            <Project>
+              <PropertyGroup>
+                <Root>$([Microsoft.Build.Utilities.ToolLocationHelper]::FindRootFolderWhereAllFilesExist('$(MSBuildProjectDirectory)', 'a.txt'))</Root>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        EvaluationInputs inputs = Evaluate(project);
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.UnclassifiedPropertyFunction);
+        inputs.NonCacheableDetail.ShouldNotBeNull().ShouldContain("FindRootFolderWhereAllFilesExist");
+    }
+
+    [Theory]
+    [InlineData(@"custom\root")]
+    [InlineData("custom/root")]
+    public void ToolLocationHelperGivenARelativeRootIsNotCacheable(string root)
+    {
+        string project = CreateProject($"""
+            <Project>
+              <PropertyGroup>
+                <Assemblies>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToReferenceAssemblies('.NETFramework', 'v4.7.2', '', '{root}'))</Assemblies>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        ProjectInstance instance = EvaluateWithAndWithoutRecording(project);
+        EvaluationInputs inputs = instance.EvaluationInputs.ShouldNotBeNull();
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.UnclassifiedPropertyFunction);
+        inputs.NonCacheableDetail.ShouldNotBeNull().ShouldContain("GetPathToReferenceAssemblies");
     }
 
     [Fact]
@@ -81,6 +669,52 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         {
             FileUtilities.CurrentThreadWorkingDirectory = saved;
         }
+    }
+
+    [Fact]
+    public void ToolLocationHelperInstalledStateIsCacheable()
+    {
+        string project = CreateProject("""
+            <Project>
+              <PropertyGroup>
+                <Libraries>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetPathToStandardLibraries('.NETFramework', 'v4.7.2', ''))</Libraries>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        Evaluate(project).NonCacheable.ShouldBe(NonCacheableReason.None);
+    }
+
+    [Fact]
+    public void HostDirectoryCacheIsNotCacheable()
+    {
+        string project = CreateProject("<Project />");
+        ProjectOptions options = CreateOptions();
+        options.DirectoryCacheFactory = new PassThroughDirectoryCache();
+
+        Evaluate(project, options).NonCacheable.ShouldBe(NonCacheableReason.HostFileSystem);
+    }
+
+    [Fact]
+    public void HostFileSystemIsNotCacheable()
+    {
+        string project = CreateProject("<Project />");
+        ProjectOptions options = CreateOptions();
+        options.EvaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared, new PassThroughFileSystem());
+
+        Evaluate(project, options).NonCacheable.ShouldBe(NonCacheableReason.HostFileSystem);
+    }
+
+    [Theory]
+    [InlineData("MsBuildCacheFileExistence")]
+    [InlineData("MsBuildCacheFileEnumerations")]
+    public void ProcessWideFileCachesAreNotCacheable(string variable)
+    {
+        _env.SetEnvironmentVariable(variable, "1");
+        Traits.UpdateFromEnvironment();
+        string project = CreateProject("<Project />");
+
+        Evaluate(project).NonCacheable.ShouldBe(NonCacheableReason.ProcessWideCache);
     }
 
     [Fact]
@@ -112,6 +746,7 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         EvaluationInputs with = Evaluate(project);
 
         with.NonCacheable.ShouldBe(NonCacheableReason.None);
+        with.Files[config].Kind.ShouldBe(PathKind.File);
         with.Key.ParserConfigurationFingerprint.ShouldNotBe(without.Key.ParserConfigurationFingerprint);
     }
 
@@ -150,6 +785,82 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         return Evaluate(project, new ProjectOptions { ProjectCollection = collection, ToolsVersion = "Custom" });
     }
 
+    private string CreateCommonTargetsProject()
+    {
+        _env.CreateFile(_folder, "Class1.cs", "class C {}");
+        // Keep this cacheable fixture independent of the .NET Framework Windows SDK registry probe.
+        return CreateProject("""
+            <Project>
+              <Import Project="$(MSBuildBinPath)\Microsoft.Common.props" />
+              <PropertyGroup>
+                <_EnableDefaultWindowsPlatform>false</_EnableDefaultWindowsPlatform>
+                <OutputType>Library</OutputType>
+                <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+              </PropertyGroup>
+              <ItemGroup>
+                <Compile Include="**/*.cs" />
+              </ItemGroup>
+              <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+            </Project>
+            """);
+    }
+
+    /// <summary>
+    /// Evaluated properties, items with their metadata, item definitions, imports, and targets, without the environment
+    /// variable that turns recording on.
+    /// </summary>
+    private static List<string> Snapshot(ProjectInstance instance)
+    {
+        List<string> snapshot = [];
+        foreach (ProjectPropertyInstance property in instance.Properties)
+        {
+            if (!string.Equals(property.Name, EnableVariable, StringComparison.OrdinalIgnoreCase))
+            {
+                snapshot.Add($"{property.Name}={property.EvaluatedValue}");
+            }
+        }
+
+        foreach (ProjectItemInstance item in instance.Items)
+        {
+            snapshot.Add($"{item.ItemType}:{item.EvaluatedInclude}");
+            foreach (ProjectMetadataInstance metadata in item.Metadata)
+            {
+                snapshot.Add($"{item.ItemType}:{item.EvaluatedInclude}:{metadata.Name}={metadata.EvaluatedValue}");
+            }
+        }
+
+        foreach (KeyValuePair<string, ProjectItemDefinitionInstance> definition in instance.ItemDefinitions)
+        {
+            foreach (ProjectMetadataInstance metadata in definition.Value.Metadata)
+            {
+                snapshot.Add($"definition {definition.Key}:{metadata.Name}={metadata.EvaluatedValue}");
+            }
+        }
+
+        foreach (string import in instance.ImportPaths)
+        {
+            snapshot.Add($"import {import}");
+        }
+
+        foreach (string target in instance.Targets.Keys)
+        {
+            snapshot.Add($"target {target}");
+        }
+
+        return snapshot;
+    }
+
+    private ProjectInstance EvaluateWithAndWithoutRecording(string project)
+    {
+        SetRecording(enabled: false);
+        ProjectInstance plain = ProjectInstance.FromFile(project, CreateOptions());
+        SetRecording(enabled: true);
+        ProjectInstance recorded = ProjectInstance.FromFile(project, CreateOptions());
+
+        Snapshot(recorded).ShouldBe(Snapshot(plain), ignoreOrder: true);
+        return recorded;
+    }
+
     private void SetRecording(bool enabled)
     {
         _env.SetEnvironmentVariable(EnableVariable, enabled ? "1" : null);
@@ -166,6 +877,50 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
     {
         ProjectInstance instance = ProjectInstance.FromFile(project, options ?? CreateOptions());
         EvaluationInputs inputs = instance.EvaluationInputs.ShouldNotBeNull();
+        _output.WriteLine($"{inputs.Files.Count} files, non-cacheable: {inputs.NonCacheable} {inputs.NonCacheableDetail}");
         return inputs;
+    }
+
+    /// <summary>
+    /// Rewrites a file and moves its timestamp forward so the change is visible on file systems with coarse timestamps.
+    /// </summary>
+    private static void Touch(string path, string contents)
+    {
+        File.WriteAllText(path, contents);
+        File.SetLastWriteTimeUtc(path, File.GetLastWriteTimeUtc(path).AddSeconds(2));
+    }
+
+    private sealed class PassThroughFileSystem : MSBuildFileSystemBase
+    {
+    }
+
+    private sealed class PassThroughDirectoryCache : IDirectoryCacheFactory, IDirectoryCache
+    {
+        public IDirectoryCache GetDirectoryCacheForEvaluation(int evaluationId) => this;
+
+        public bool FileExists(string path) => File.Exists(path);
+
+        public bool DirectoryExists(string path) => Directory.Exists(path);
+
+        public IEnumerable<TResult> EnumerateFiles<TResult>(string path, string pattern, FindPredicate predicate, FindTransform<TResult> transform) =>
+            Select(Directory.EnumerateFiles(path, pattern), predicate, transform);
+
+        public IEnumerable<TResult> EnumerateDirectories<TResult>(string path, string pattern, FindPredicate predicate, FindTransform<TResult> transform) =>
+            Select(Directory.EnumerateDirectories(path, pattern), predicate, transform);
+
+        private static List<TResult> Select<TResult>(IEnumerable<string> paths, FindPredicate predicate, FindTransform<TResult> transform)
+        {
+            List<TResult> results = [];
+            foreach (string path in paths)
+            {
+                ReadOnlySpan<char> name = Path.GetFileName(path).AsSpan();
+                if (predicate(ref name))
+                {
+                    results.Add(transform(ref name));
+                }
+            }
+
+            return results;
+        }
     }
 }

--- a/src/Build.UnitTests/Evaluation/EvaluationInputRecording_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/EvaluationInputRecording_Tests.cs
@@ -20,6 +20,7 @@ using Microsoft.Build.Unittest;
 using Microsoft.Win32;
 using Shouldly;
 using Xunit;
+using SdkResult = Microsoft.Build.BackEnd.SdkResolution.SdkResult;
 
 namespace Microsoft.Build.UnitTests.Evaluation;
 
@@ -641,6 +642,30 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
 
         inputs.NonCacheable.ShouldBe(NonCacheableReason.UnsupportedRegistryValue);
         inputs.RegistryReads.ShouldBeEmpty();
+    }
+
+    [Fact]
+    public void SdkResolutionIsRecordedAndImportedFilesAreValidated()
+    {
+        TransientTestFolder sdkFolder = _env.CreateFolder(Path.Combine(_folder.Path, "sdk"), createFolder: true);
+        string sdkProps = _env.CreateFile(sdkFolder, "Sdk.props", "<Project><PropertyGroup><FromSdk>props</FromSdk></PropertyGroup></Project>").Path;
+        _env.CreateFile(sdkFolder, "Sdk.targets", "<Project />");
+        string project = CreateProject("""
+            <Project Sdk="TestSdk">
+              <PropertyGroup>
+                <A>$(FromSdk)</A>
+              </PropertyGroup>
+            </Project>
+            """);
+        var recorded = new SdkResult(new SdkReference("TestSdk", null, null), sdkFolder.Path, "1.0", warnings: null);
+        ProjectOptions options = SdkUtilities.CreateProjectOptionsWithResolver(new SdkUtilities.ConfigurableMockSdkResolver(recorded));
+        options.ProjectCollection = _env.CreateProjectCollection().Collection;
+
+        EvaluationInputs inputs = Evaluate(project, options);
+
+        inputs.SdkResolutions.ShouldHaveSingleItem().Reference.Name.ShouldBe("TestSdk");
+        inputs.Files[sdkProps].Kind.ShouldBe(PathKind.File);
+        inputs.SdkResolutions[0].Result.ShouldBe(recorded);
     }
 
     [Theory]

--- a/src/Build.UnitTests/Evaluation/EvaluationInputRecording_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/EvaluationInputRecording_Tests.cs
@@ -193,6 +193,27 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
     }
 
     [Theory]
+    [InlineData("second")]
+    [InlineData(null)]
+    public void EnvironmentReadIsRecordedButNotRevalidated(string? currentValue)
+    {
+        _env.SetEnvironmentVariable("MSBUILD_TEST_INPUT", "first");
+        string project = CreateProject("""
+            <Project>
+              <PropertyGroup>
+                <Value>$([System.Environment]::GetEnvironmentVariable('MSBUILD_TEST_INPUT'))</Value>
+              </PropertyGroup>
+            </Project>
+            """);
+        EvaluationInputs inputs = Evaluate(project);
+        inputs.EnvironmentReads["MSBUILD_TEST_INPUT"].ShouldBe("first");
+
+        _env.SetEnvironmentVariable("MSBUILD_TEST_INPUT", currentValue);
+
+        inputs.EnvironmentReads["MSBUILD_TEST_INPUT"].ShouldBe("first");
+    }
+
+    [Theory]
     [InlineData("$([System.DateTime]::Now)")]
     [InlineData("$([System.Guid]::NewGuid())")]
     [InlineData("$([System.DateTime]::Parse('12:34'))")]
@@ -489,6 +510,30 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         inputs.NonCacheableDetail.ShouldBe(link);
     }
 #endif
+
+    [Fact]
+    public void ExpandEnvironmentVariablesRecordsEachReferencedVariable()
+    {
+        _env.SetEnvironmentVariable("MSBUILD_TEST_EXPAND_ROOT", "first");
+        _env.SetEnvironmentVariable("MSBUILD_TEST_EXPAND_MISSING", null);
+        string project = CreateProject("""
+            <Project>
+              <PropertyGroup>
+                <Value>$([System.Environment]::ExpandEnvironmentVariables('%MSBUILD_TEST_EXPAND_ROOT%\src\%MSBUILD_TEST_EXPAND_MISSING%'))</Value>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        EvaluationInputs inputs = Evaluate(project);
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
+        inputs.EnvironmentReads["MSBUILD_TEST_EXPAND_ROOT"].ShouldBe("first");
+        inputs.EnvironmentReads["MSBUILD_TEST_EXPAND_MISSING"].ShouldBeNull();
+
+        _env.SetEnvironmentVariable("MSBUILD_TEST_EXPAND_MISSING", "now set");
+
+        inputs.EnvironmentReads["MSBUILD_TEST_EXPAND_MISSING"].ShouldBeNull();
+    }
 
     [Fact]
     public void RecordedPathsShareOneStringAcrossEvaluations()

--- a/src/Build.UnitTests/Evaluation/EvaluationInputRecording_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/EvaluationInputRecording_Tests.cs
@@ -82,6 +82,93 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
     }
 
     [Fact]
+    public void EditingRootProjectInvalidates()
+    {
+        string project = CreateProject("<Project />");
+        EvaluationInputs inputs = Evaluate(project);
+        IsCurrent(inputs, out _).ShouldBeTrue();
+
+        Touch(project, "<Project><PropertyGroup /></Project>");
+
+        IsCurrent(inputs, out string? reason).ShouldBeFalse();
+        reason.ShouldNotBeNull().ShouldContain(project);
+    }
+
+    [Fact]
+    public void DeletingRecordedFileInvalidates()
+    {
+        string project = CreateProject("<Project />");
+        EvaluationInputs inputs = Evaluate(project);
+        IsCurrent(inputs, out _).ShouldBeTrue();
+
+        File.Delete(project);
+
+        IsCurrent(inputs, out string? reason).ShouldBeFalse();
+        reason.ShouldBe(project);
+    }
+
+    [Fact]
+    public void ChangedLengthWithPreservedTimestampInvalidates()
+    {
+        string project = CreateProject("<Project />");
+        EvaluationInputs inputs = Evaluate(project);
+        DateTime timestamp = inputs.Files[project].LastWriteTimeUtc;
+
+        File.WriteAllText(project, "<Project><PropertyGroup /></Project>");
+        File.SetLastWriteTimeUtc(project, timestamp);
+        File.GetLastWriteTimeUtc(project).ShouldBe(timestamp);
+        new FileInfo(project).Length.ShouldNotBe(inputs.Files[project].Length);
+
+        IsCurrent(inputs, out string? reason).ShouldBeFalse();
+        reason.ShouldBe(project);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void FileDirectoryKindReplacementInvalidates(bool initiallyDirectory)
+    {
+        string candidate = Path.Combine(_folder.Path, "candidate");
+        if (initiallyDirectory)
+        {
+            Directory.CreateDirectory(candidate);
+        }
+        else
+        {
+            File.WriteAllText(candidate, string.Empty);
+        }
+
+        string project = CreateProject("""
+            <Project>
+              <PropertyGroup>
+                <Found Condition="Exists('candidate')">true</Found>
+              </PropertyGroup>
+            </Project>
+            """);
+        EvaluationInputs inputs = Evaluate(project);
+        inputs.Files[candidate].Kind.ShouldBe(initiallyDirectory ? PathKind.Directory : PathKind.File);
+        DateTime timestamp = inputs.Files[candidate].LastWriteTimeUtc;
+        IsCurrent(inputs, out _).ShouldBeTrue();
+
+        if (initiallyDirectory)
+        {
+            Directory.Delete(candidate);
+            File.WriteAllText(candidate, string.Empty);
+            File.SetLastWriteTimeUtc(candidate, timestamp);
+        }
+        else
+        {
+            File.Delete(candidate);
+            Directory.CreateDirectory(candidate);
+            Directory.SetLastWriteTimeUtc(candidate, timestamp);
+        }
+
+        File.GetLastWriteTimeUtc(candidate).ShouldBe(timestamp);
+        IsCurrent(inputs, out string? reason).ShouldBeFalse();
+        reason.ShouldBe(candidate);
+    }
+
+    [Fact]
     public void IgnoredMissingImportIsRecordedAsMissing()
     {
         string project = CreateProject("""
@@ -95,6 +182,72 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         EvaluationInputs inputs = Evaluate(project, options);
 
         inputs.Files[Path.Combine(_folder.Path, "missing.props")].Kind.ShouldBe(PathKind.Missing);
+    }
+
+    [Fact]
+    public void CreatingProbedMissingFileInvalidates()
+    {
+        string project = CreateProject("""
+            <Project>
+              <Import Project="optional.props" Condition="Exists('optional.props')" />
+            </Project>
+            """);
+        string optional = Path.Combine(_folder.Path, "optional.props");
+        EvaluationInputs inputs = Evaluate(project);
+        inputs.Files[optional].Kind.ShouldBe(PathKind.Missing);
+        IsCurrent(inputs, out _).ShouldBeTrue();
+
+        File.WriteAllText(optional, "<Project />");
+
+        IsCurrent(inputs, out string? reason).ShouldBeFalse();
+        reason.ShouldBe(optional);
+    }
+
+    [Fact]
+    public void GlobMembershipChangeInvalidates()
+    {
+        _env.CreateFile(_folder, "a.cs", string.Empty);
+        string project = CreateProject("""
+            <Project>
+              <ItemGroup>
+                <Compile Include="**/*.cs" />
+              </ItemGroup>
+            </Project>
+            """);
+        EvaluationInputs inputs = Evaluate(project);
+        inputs.Files[_folder.Path].Kind.ShouldBe(PathKind.Directory);
+        IsCurrent(inputs, out _).ShouldBeTrue();
+
+        File.WriteAllText(Path.Combine(_env.CreateFolder(createFolder: true).Path, "outside.cs"), string.Empty);
+        IsCurrent(inputs, out _).ShouldBeTrue();
+
+        AddFile(_folder.Path, "b.cs");
+
+        IsCurrent(inputs, out string? reason).ShouldBeFalse();
+        reason.ShouldBe(_folder.Path);
+    }
+
+    [Fact]
+    public void NearerFileAboveCandidateInvalidates()
+    {
+        TransientTestFolder child = _env.CreateFolder(Path.Combine(_folder.Path, "child"), createFolder: true);
+        _env.CreateFile(_folder, "Marker.props", "<Project />");
+        string project = _env.CreateFile(child, "test.proj", """
+            <Project>
+              <PropertyGroup>
+                <Marker>$([MSBuild]::GetPathOfFileAbove('Marker.props'))</Marker>
+              </PropertyGroup>
+            </Project>
+            """.Cleanup()).Path;
+        string nearer = Path.Combine(child.Path, "Marker.props");
+        EvaluationInputs inputs = Evaluate(project);
+        inputs.Files[nearer].Kind.ShouldBe(PathKind.Missing);
+        inputs.Files[Path.Combine(_folder.Path, "Marker.props")].Kind.ShouldBe(PathKind.File);
+
+        File.WriteAllText(nearer, "<Project />");
+
+        IsCurrent(inputs, out string? reason).ShouldBeFalse();
+        reason.ShouldBe(nearer);
     }
 
     [Theory]
@@ -115,6 +268,9 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
 
         inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
         inputs.Files[probed].Kind.ShouldBe(PathKind.Missing);
+        Directory.CreateDirectory(probed);
+        IsCurrent(inputs, out string? reason).ShouldBeFalse();
+        reason.ShouldBe(probed);
     }
 
     [Fact]
@@ -152,6 +308,11 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         options.LoadSettings = ProjectLoadSettings.IgnoreEmptyImports;
         EvaluationInputs inputs = Evaluate(project, options);
         inputs.Files[empty].ShouldBe(new FileDependency(PathKind.File, File.GetLastWriteTimeUtc(empty), 0));
+
+        Touch(empty, "<Project />");
+
+        IsCurrent(inputs, out string? reason).ShouldBeFalse();
+        reason.ShouldBe(empty);
     }
 
     [Fact]
@@ -194,6 +355,11 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         EvaluationInputs inputs = Evaluate(project);
         inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
         inputs.Files[version].Kind.ShouldBe(PathKind.File);
+
+        Touch(version, "2.0");
+
+        IsCurrent(inputs, out string? reason).ShouldBeFalse();
+        reason.ShouldBe(version);
     }
 
     [Theory]
@@ -211,9 +377,12 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
             """);
         EvaluationInputs inputs = Evaluate(project);
         inputs.EnvironmentReads["MSBUILD_TEST_INPUT"].ShouldBe("first");
+        IsCurrent(inputs, out _).ShouldBeTrue();
 
         _env.SetEnvironmentVariable("MSBUILD_TEST_INPUT", currentValue);
 
+        IsCurrent(inputs, out string? reason).ShouldBeTrue();
+        reason.ShouldBeNull();
         inputs.EnvironmentReads["MSBUILD_TEST_INPUT"].ShouldBe("first");
     }
 
@@ -235,6 +404,8 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         EvaluationInputs inputs = Evaluate(project);
 
         inputs.NonCacheable.ShouldBe(NonCacheableReason.VolatilePropertyFunction);
+        IsCurrent(inputs, out string? reason).ShouldBeFalse();
+        reason.ShouldNotBeNull().ShouldContain(nameof(NonCacheableReason.VolatilePropertyFunction));
     }
 
     [Theory]
@@ -364,6 +535,7 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         registry.Key.SetValue("Value", "changed", RegistryValueKind.String);
 
         inputs.RegistryReads[0].Value.ShouldBe("first;value%");
+        IsCurrent(inputs, out _).ShouldBeTrue();
     }
 
     [WindowsOnlyFact]
@@ -642,6 +814,7 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
 
         inputs.NonCacheable.ShouldBe(NonCacheableReason.UnsupportedRegistryValue);
         inputs.RegistryReads.ShouldBeEmpty();
+        IsCurrent(inputs, out _).ShouldBeFalse();
     }
 
     [Fact]
@@ -666,6 +839,12 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         inputs.SdkResolutions.ShouldHaveSingleItem().Reference.Name.ShouldBe("TestSdk");
         inputs.Files[sdkProps].Kind.ShouldBe(PathKind.File);
         inputs.SdkResolutions[0].Result.ShouldBe(recorded);
+        IsCurrent(inputs, out _).ShouldBeTrue();
+
+        Touch(sdkProps, "<Project><PropertyGroup><FromSdk>changed</FromSdk></PropertyGroup></Project>");
+
+        IsCurrent(inputs, out string? reason).ShouldBeFalse();
+        reason.ShouldBe(sdkProps);
     }
 
     [Theory]
@@ -783,6 +962,7 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
 
         inputs.NonCacheable.ShouldBe(NonCacheableReason.None, inputs.NonCacheableDetail);
         inputs.Files.Count.ShouldBeGreaterThan(5);
+        IsCurrent(inputs, out string? reason).ShouldBeTrue(reason);
         Evaluate(project).Files.Keys.ShouldBe(inputs.Files.Keys, ignoreOrder: true);
     }
 
@@ -825,6 +1005,12 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         secondInputs.NonCacheable.ShouldBe(NonCacheableReason.None);
         secondInputs.Files.Keys.Except(firstInputs.Files.Keys, StringComparer.OrdinalIgnoreCase).ShouldBeEmpty();
         firstInputs.Files.Keys.Except(secondInputs.Files.Keys, StringComparer.OrdinalIgnoreCase).ShouldBeEmpty();
+        IsCurrent(secondInputs, out _).ShouldBeTrue();
+
+        AddFile(_folder.Path, "Class2.cs");
+
+        IsCurrent(secondInputs, out string? reason).ShouldBeFalse();
+        reason.ShouldBe(_folder.Path);
     }
 
 #if FEATURE_SYMLINK_TARGET
@@ -886,9 +1072,12 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
         inputs.EnvironmentReads["MSBUILD_TEST_EXPAND_ROOT"].ShouldBe("first");
         inputs.EnvironmentReads["MSBUILD_TEST_EXPAND_MISSING"].ShouldBeNull();
+        IsCurrent(inputs, out _).ShouldBeTrue();
 
         _env.SetEnvironmentVariable("MSBUILD_TEST_EXPAND_MISSING", "now set");
 
+        IsCurrent(inputs, out string? reason).ShouldBeTrue();
+        reason.ShouldBeNull();
         inputs.EnvironmentReads["MSBUILD_TEST_EXPAND_MISSING"].ShouldBeNull();
     }
 
@@ -937,6 +1126,12 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
         inputs.Files[Path.Combine(_folder.Path, "present.txt")].Kind.ShouldBe(PathKind.File);
         inputs.Files[missing].Kind.ShouldBe(PathKind.Missing);
+        IsCurrent(inputs, out _).ShouldBeTrue();
+
+        File.WriteAllText(missing, string.Empty);
+
+        IsCurrent(inputs, out string? reason).ShouldBeFalse();
+        reason.ShouldBe(missing);
     }
 
     [Theory]
@@ -1150,6 +1345,12 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         with.NonCacheable.ShouldBe(NonCacheableReason.None);
         with.Files[config].Kind.ShouldBe(PathKind.File);
         with.Key.ParserConfigurationFingerprint.ShouldNotBe(without.Key.ParserConfigurationFingerprint);
+        IsCurrent(with, out _).ShouldBeTrue();
+
+        Touch(config, """<ParseConfig><IgnoreAttributes><Ignore Element="Target" Name="Bar" /></IgnoreAttributes></ParseConfig>""");
+
+        IsCurrent(with, out string? reason).ShouldBeFalse();
+        reason.ShouldBe(config);
     }
 
     [Fact]
@@ -1283,6 +1484,9 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
         return inputs;
     }
 
+    private static bool IsCurrent(EvaluationInputs inputs, out string? reason) =>
+        EvaluationInputValidator.IsFileSystemCurrent(inputs, out reason);
+
     /// <summary>
     /// Rewrites a file and moves its timestamp forward so the change is visible on file systems with coarse timestamps.
     /// </summary>
@@ -1290,6 +1494,19 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
     {
         File.WriteAllText(path, contents);
         File.SetLastWriteTimeUtc(path, File.GetLastWriteTimeUtc(path).AddSeconds(2));
+    }
+
+    /// <summary>
+    /// Adds a file to a directory, which moves the directory's timestamp forward; forced on file systems with coarse timestamps.
+    /// </summary>
+    private static void AddFile(string directory, string name)
+    {
+        DateTime before = Directory.GetLastWriteTimeUtc(directory);
+        File.WriteAllText(Path.Combine(directory, name), string.Empty);
+        if (Directory.GetLastWriteTimeUtc(directory) == before)
+        {
+            Directory.SetLastWriteTimeUtc(directory, before.AddSeconds(2));
+        }
     }
 
     [SupportedOSPlatform("windows")]

--- a/src/Build.UnitTests/Evaluation/EvaluationInputRecording_Tests.cs
+++ b/src/Build.UnitTests/Evaluation/EvaluationInputRecording_Tests.cs
@@ -3,9 +3,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Threading.Tasks;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Definition;
@@ -15,6 +17,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.FileSystem;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Unittest;
+using Microsoft.Win32;
 using Shouldly;
 using Xunit;
 
@@ -309,6 +312,335 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
                 AppContext.SetSwitch(switchName, original);
             }
         }
+    }
+
+    [WindowsOnlyTheory]
+    [InlineData("$(Registry:{0}@Value)")]
+    [InlineData("$([MSBuild]::GetRegistryValue('{0}', 'Value'))")]
+    [InlineData("$([MSBuild]::GetRegistryValueFromView('{0}', 'Value', null, RegistryView.Default, RegistryView.Registry32))")]
+    [SupportedOSPlatform("windows")]
+    public void RegistryReadsAreRecordedWithoutStoppingObservation(string expression)
+    {
+        TestRegistryKey registry = _env.WithTransientTestState(new TestRegistryKey());
+        registry.Key.SetValue("Value", "first;value%", RegistryValueKind.String);
+        _env.SetEnvironmentVariable("MSBUILD_TEST_AFTER_REGISTRY", "observed");
+        string import = _env.CreateFile(_folder, "after.props", "<Project />").Path;
+        expression = string.Format(CultureInfo.InvariantCulture, expression, registry.Key.Name);
+        string project = CreateProject($"""
+            <Project>
+              <PropertyGroup>
+                <First>{expression}</First>
+                <Second>{expression}</Second>
+                <After>$([System.Environment]::GetEnvironmentVariable('MSBUILD_TEST_AFTER_REGISTRY'))</After>
+              </PropertyGroup>
+              <Import Project="after.props" />
+            </Project>
+            """);
+
+        ProjectInstance recorded = EvaluateWithAndWithoutRecording(project);
+        EvaluationInputs inputs = recorded.EvaluationInputs.ShouldNotBeNull();
+
+        recorded.GetPropertyValue("First").ShouldBe("first;value%");
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
+        inputs.RegistryReads.Length.ShouldBe(2);
+        foreach (RegistryRead read in inputs.RegistryReads)
+        {
+            read.KeyName.ShouldBe(registry.Key.Name);
+            read.ValueName.ShouldBe("Value");
+            read.Value.ShouldBe("first;value%");
+            if (expression.Contains("GetRegistryValueFromView"))
+            {
+                read.RequestedViews.ShouldBe(["RegistryView.Default", "RegistryView.Registry32"]);
+            }
+            else
+            {
+                read.RequestedViews.ShouldBeEmpty();
+            }
+        }
+        inputs.EnvironmentReads["MSBUILD_TEST_AFTER_REGISTRY"].ShouldBe("observed");
+        inputs.Files.ContainsKey(import).ShouldBeTrue();
+
+        registry.Key.SetValue("Value", "changed", RegistryValueKind.String);
+
+        inputs.RegistryReads[0].Value.ShouldBe("first;value%");
+    }
+
+    [WindowsOnlyFact]
+    [SupportedOSPlatform("windows")]
+    public void MissingDefaultAndFallbackRegistryValuesAreRecorded()
+    {
+        TestRegistryKey registry = _env.WithTransientTestState(new TestRegistryKey());
+        registry.Key.SetValue(string.Empty, "default", RegistryValueKind.String);
+        registry.Key.SetValue("Empty", string.Empty, RegistryValueKind.String);
+        string keyName = registry.Key.Name;
+        string project = CreateProject($"""
+            <Project>
+              <PropertyGroup>
+                <Default>$(Registry:{keyName})</Default>
+                <Empty>$(Registry:{keyName}@Empty)</Empty>
+                <Missing>$(Registry:{keyName}@Missing)</Missing>
+                <MissingFunction>$([MSBuild]::GetRegistryValue('{keyName}', 'Missing'))</MissingFunction>
+                <Fallback>$([MSBuild]::GetRegistryValue('{keyName}', 'Missing', 'fallback'))</Fallback>
+                <ViewFallback>$([MSBuild]::GetRegistryValueFromView('{keyName}\MissingKey', 'Missing', 'view fallback', RegistryView.Default))</ViewFallback>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        EvaluationInputs inputs = Evaluate(project);
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
+        inputs.RegistryReads.Length.ShouldBe(6);
+        inputs.RegistryReads[0].ValueName.ShouldBe(string.Empty);
+        inputs.RegistryReads[0].Value.ShouldBe("default");
+        inputs.RegistryReads[1].Value.ShouldBe(string.Empty);
+        inputs.RegistryReads[2].Value.ShouldBeNull();
+        inputs.RegistryReads[3].Value.ShouldBeNull();
+        inputs.RegistryReads[4].Value.ShouldBe("fallback");
+        inputs.RegistryReads[5].KeyName.ShouldBe(keyName + @"\MissingKey");
+        inputs.RegistryReads[5].Value.ShouldBe("view fallback");
+    }
+
+    [WindowsOnlyTheory]
+    [InlineData(RegistryValueKind.DWord)]
+    [InlineData(RegistryValueKind.QWord)]
+    [InlineData(RegistryValueKind.Binary)]
+    [InlineData(RegistryValueKind.MultiString)]
+    [InlineData(RegistryValueKind.ExpandString)]
+    [SupportedOSPlatform("windows")]
+    public void RegistryObservationsPreserveReturnedValueTypes(RegistryValueKind kind)
+    {
+        TestRegistryKey registry = _env.WithTransientTestState(new TestRegistryKey());
+        _env.SetEnvironmentVariable("MSBUILD_TEST_REGISTRY_EXPANSION", "expanded");
+        object value = kind switch
+        {
+            RegistryValueKind.DWord => 123,
+            RegistryValueKind.QWord => 123456789123456789L,
+            RegistryValueKind.Binary => (byte[])[1, 2, 3],
+            RegistryValueKind.MultiString => (string[])["one;two", "three"],
+            RegistryValueKind.ExpandString => "%MSBUILD_TEST_REGISTRY_EXPANSION%",
+            _ => throw new ArgumentOutOfRangeException(nameof(kind)),
+        };
+        registry.Key.SetValue("Value", value, kind);
+        string project = CreateProject($"""
+            <Project>
+              <PropertyGroup>
+                <Direct>$(Registry:{registry.Key.Name}@Value)</Direct>
+                <Function>$([MSBuild]::GetRegistryValue('{registry.Key.Name}', 'Value'))</Function>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        EvaluationInputs inputs = Evaluate(project);
+
+        inputs.RegistryReads.Length.ShouldBe(2);
+        foreach (RegistryRead read in inputs.RegistryReads)
+        {
+            if (value is byte[] bytes)
+            {
+                read.Value.ShouldBeOfType<ImmutableArray<byte>>().ToArray().ShouldBe(bytes);
+            }
+            else if (value is string[] strings)
+            {
+                read.Value.ShouldBeOfType<ImmutableArray<string>>().ToArray().ShouldBe(strings);
+            }
+            else
+            {
+                read.Value.ShouldBe(kind == RegistryValueKind.ExpandString ? "expanded" : value);
+            }
+        }
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
+    }
+
+    [Fact]
+    public void RegistryObservationCopiesArraysAndPreservesRepeatedReads()
+    {
+        var recorder = new EvaluationInputRecorder();
+        byte[] bytes = [1, 2];
+        string[] strings = ["first", "second"];
+        recorder.RecordRegistryRead("key", "bytes", bytes);
+        recorder.RecordRegistryRead("key", "strings", strings);
+        bytes[0] = 3;
+        strings[0] = "changed";
+        recorder.RecordRegistryRead("key", "bytes", bytes);
+        EvaluationInputKey key = Evaluate(CreateProject("<Project />")).Key;
+        EvaluationInputs inputs = recorder.Freeze(key);
+        recorder.RecordRegistryRead("key", "after-freeze", "ignored");
+
+        inputs.RegistryReads.Length.ShouldBe(3);
+        inputs.RegistryReads[0].Value.ShouldBeOfType<ImmutableArray<byte>>().ToArray().ShouldBe([1, 2]);
+        inputs.RegistryReads[1].Value.ShouldBeOfType<ImmutableArray<string>>().ToArray().ShouldBe(["first", "second"]);
+        inputs.RegistryReads[2].Value.ShouldBeOfType<ImmutableArray<byte>>().ToArray().ShouldBe([3, 2]);
+    }
+
+    [WindowsOnlyFact]
+    [SupportedOSPlatform("windows")]
+    public void RegistryObservationUsesDecodedKeyAndValueNames()
+    {
+        TestRegistryKey registry = _env.WithTransientTestState(new TestRegistryKey());
+        using RegistryKey nested = registry.Key.CreateSubKey("key@part");
+        nested.SetValue("value@part", "value", RegistryValueKind.String);
+        string expressionKey = nested.Name.Replace("@", "%40");
+        string project = CreateProject($"""
+            <Project>
+              <PropertyGroup>
+                <Value>$(Registry:{expressionKey}@value%40part)</Value>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        RegistryRead read = Evaluate(project).RegistryReads.ShouldHaveSingleItem();
+
+        read.KeyName.ShouldBe(nested.Name);
+        read.ValueName.ShouldBe("value@part");
+        read.Value.ShouldBe("value");
+    }
+
+    [WindowsOnlyFact]
+    [SupportedOSPlatform("windows")]
+    public void RegistryObservationUsesCoercedValueName()
+    {
+        TestRegistryKey registry = _env.WithTransientTestState(new TestRegistryKey());
+        registry.Key.SetValue("123", "numbered value", RegistryValueKind.String);
+        string project = CreateProject($"""
+            <Project>
+              <PropertyGroup>
+                <Value>$([MSBuild]::GetRegistryValue('{registry.Key.Name}', $([System.Int32]::Parse('123')), 'fallback'))</Value>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        ProjectInstance instance = EvaluateWithAndWithoutRecording(project);
+        RegistryRead read = instance.EvaluationInputs.ShouldNotBeNull().RegistryReads.ShouldHaveSingleItem();
+
+        instance.GetPropertyValue("Value").ShouldBe("numbered value");
+        read.KeyName.ShouldBe(registry.Key.Name);
+        read.ValueName.ShouldBe("123");
+        read.Value.ShouldBe("numbered value");
+    }
+
+    [WindowsOnlyTheory]
+    [InlineData("$([MSBuild]::GetRegistryValueFromView('{0}', 'Value', 'fallback'))", "fallback", false)]
+    [InlineData("$([MSBuild]::GetRegistryValueFromView('{0}', 'Value', null))", null, false)]
+    [InlineData("$([MSBuild]::GetRegistryValueFromView(null, null, 'fallback'))", "fallback", true)]
+    [SupportedOSPlatform("windows")]
+    public void RegistryRequestsWithoutExplicitViewsPreserveExistingBehavior(string expression, string? expected, bool nullKey)
+    {
+        TestRegistryKey registry = _env.WithTransientTestState(new TestRegistryKey());
+        registry.Key.SetValue("Value", "stored", RegistryValueKind.String);
+        expression = string.Format(CultureInfo.InvariantCulture, expression, registry.Key.Name);
+        string project = CreateProject($"""
+            <Project>
+              <PropertyGroup>
+                <Value>{expression}</Value>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        ProjectInstance instance = EvaluateWithAndWithoutRecording(project);
+        EvaluationInputs inputs = instance.EvaluationInputs.ShouldNotBeNull();
+        RegistryRead read = inputs.RegistryReads.ShouldHaveSingleItem();
+
+        instance.GetPropertyValue("Value").ShouldBe(expected ?? string.Empty);
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
+        read.KeyName.ShouldBe(nullKey ? null : registry.Key.Name);
+        read.ValueName.ShouldBe(nullKey ? string.Empty : "Value");
+        read.Value.ShouldBe(expected);
+        read.RequestedViews.ShouldBeEmpty();
+    }
+
+    [WindowsOnlyTheory]
+    [InlineData(false)]
+    [InlineData(true)]
+    [SupportedOSPlatform("windows")]
+    public void RegistryViewParamsArrayIsNotConfusedWithANestedArray(bool nested)
+    {
+        TestRegistryKey registry = _env.WithTransientTestState(new TestRegistryKey());
+        registry.Key.SetValue("Value", "stored", RegistryValueKind.String);
+        string views = "$([System.String]::Copy('RegistryView.Default;RegistryView.Registry32').Split(';'))";
+        if (nested)
+        {
+            views += ", RegistryView.Registry64";
+        }
+        string project = CreateProject($"""
+            <Project>
+              <PropertyGroup>
+                <Value>$([MSBuild]::GetRegistryValueFromView('{registry.Key.Name}', 'Value', null, {views}))</Value>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        ProjectInstance instance = EvaluateWithAndWithoutRecording(project);
+        EvaluationInputs inputs = instance.EvaluationInputs.ShouldNotBeNull();
+        RegistryRead read = inputs.RegistryReads.ShouldHaveSingleItem();
+
+        instance.GetPropertyValue("Value").ShouldBe("stored");
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
+        read.Value.ShouldBe("stored");
+        read.RequestedViews.ShouldBe(nested
+            ? ["RegistryView.Registry64"]
+            : ["RegistryView.Default", "RegistryView.Registry32"]);
+    }
+
+    [WindowsOnlyFact]
+    [SupportedOSPlatform("windows")]
+    public void IgnoredRegistryViewDoesNotInvokeToString()
+    {
+        TestRegistryKey registry = _env.WithTransientTestState(new TestRegistryKey());
+        string project = CreateProject($"""
+            <Project>
+              <PropertyGroup>
+                <Value>$([MSBuild]::GetRegistryValueFromView('{registry.Key.Name}', 'Missing', 'fallback', $([System.UriBuilder]::new('http://:x@localhost'))))</Value>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        ProjectInstance instance = EvaluateWithAndWithoutRecording(project);
+        EvaluationInputs inputs = instance.EvaluationInputs.ShouldNotBeNull();
+        RegistryRead read = inputs.RegistryReads.ShouldHaveSingleItem();
+
+        instance.GetPropertyValue("Value").ShouldBe("fallback");
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.None);
+        read.Value.ShouldBe("fallback");
+        read.RequestedViews.ShouldBeEmpty();
+    }
+
+    [WindowsOnlyFact]
+    [SupportedOSPlatform("windows")]
+    public void RegistryFallbackIsCapturedBeforeChainedMutation()
+    {
+        TestRegistryKey registry = _env.WithTransientTestState(new TestRegistryKey());
+        string project = CreateProject($"""
+            <Project>
+              <PropertyGroup>
+                <Value>$([MSBuild]::GetRegistryValue('{registry.Key.Name}', 'Missing', $([System.String]::Copy('ab').ToCharArray())).SetValue($([System.Char]::Parse('z')), 0))</Value>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        ProjectInstance instance = EvaluateWithAndWithoutRecording(project);
+        RegistryRead read = instance.EvaluationInputs.ShouldNotBeNull().RegistryReads.ShouldHaveSingleItem();
+
+        read.Value.ShouldBeOfType<ImmutableArray<char>>().ToArray().ShouldBe(['a', 'b']);
+    }
+
+    [WindowsOnlyFact]
+    [SupportedOSPlatform("windows")]
+    public void UnsupportedRegistryFallbackRejectsRecordingWithoutChangingEvaluation()
+    {
+        TestRegistryKey registry = _env.WithTransientTestState(new TestRegistryKey());
+        string project = CreateProject($"""
+            <Project>
+              <PropertyGroup>
+                <Value>$([MSBuild]::GetRegistryValue('{registry.Key.Name}', 'Missing', $([System.UriBuilder]::new('https://example.invalid/path'))))</Value>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        ProjectInstance instance = EvaluateWithAndWithoutRecording(project);
+        EvaluationInputs inputs = instance.EvaluationInputs.ShouldNotBeNull();
+
+        inputs.NonCacheable.ShouldBe(NonCacheableReason.UnsupportedRegistryValue);
+        inputs.RegistryReads.ShouldBeEmpty();
     }
 
     [Theory]
@@ -933,6 +1265,25 @@ public sealed class EvaluationInputRecording_Tests : IDisposable
     {
         File.WriteAllText(path, contents);
         File.SetLastWriteTimeUtc(path, File.GetLastWriteTimeUtc(path).AddSeconds(2));
+    }
+
+    [SupportedOSPlatform("windows")]
+    private sealed class TestRegistryKey : TransientTestState
+    {
+        private readonly string _subKey = $@"Software\MSBuild_EvaluationInputs_{Guid.NewGuid():N}";
+
+        internal TestRegistryKey()
+        {
+            Key = Registry.CurrentUser.CreateSubKey(_subKey);
+        }
+
+        internal RegistryKey Key { get; }
+
+        public override void Revert()
+        {
+            Key.Dispose();
+            Registry.CurrentUser.DeleteSubKeyTree(_subKey, throwOnMissingSubKey: false);
+        }
     }
 
     private sealed class PassThroughFileSystem : MSBuildFileSystemBase

--- a/src/Build/Construction/ProjectRootElement.cs
+++ b/src/Build/Construction/ProjectRootElement.cs
@@ -640,6 +640,11 @@ namespace Microsoft.Build.Construction
         /// </summary>
         public DateTime LastWriteTimeWhenRead => Link != null ? RootLink.LastWriteTimeWhenRead : _lastWriteTimeWhenReadUtc.ToLocalTime();
 
+        /// <summary>
+        /// The UTC last write time of the file when it was read, or default when this element was not read from a file.
+        /// </summary>
+        internal DateTime LastWriteTimeWhenReadUtc => Link != null ? RootLink.LastWriteTimeWhenRead.ToUniversalTime() : _lastWriteTimeWhenReadUtc;
+
         internal DateTime? StreamTimeUtc = null;
 
         /// <summary>
@@ -2094,6 +2099,10 @@ namespace Microsoft.Build.Construction
             try
             {
                 MSBuildEventSource.Log.LoadDocumentStart(fullPath);
+
+                // Take the timestamp before reading the content, so a write that lands during the read shows up as a
+                // change after it and the element is reloaded rather than trusted.
+                FileInfo fileInfoBeforeRead = FileUtilities.GetFileInfoNoThrow(fullPath);
                 using (XmlReaderExtension xtr = XmlReaderExtension.Create(fullPath, loadAsReadOnly))
                 {
                     _encoding = xtr.Encoding;
@@ -2109,7 +2118,7 @@ namespace Microsoft.Build.Construction
                     XmlDocument.FullPath = fullPath;
                 }
 
-                _lastWriteTimeWhenReadUtc = FileUtilities.GetFileInfoNoThrow(fullPath).LastWriteTimeUtc;
+                _lastWriteTimeWhenReadUtc = (fileInfoBeforeRead ?? FileUtilities.GetFileInfoNoThrow(fullPath)).LastWriteTimeUtc;
                 if (StreamTimeUtc < _lastWriteTimeWhenReadUtc)
                 {
                     StreamTimeUtc = null;

--- a/src/Build/Definition/Project.cs
+++ b/src/Build/Definition/Project.cs
@@ -62,6 +62,11 @@ namespace Microsoft.Build.Evaluation
 
         internal bool IsLinked => implementationInternal.IsLinked;
         internal ProjectLink Link => implementation;
+
+        /// <summary>
+        /// Inputs the last evaluation recorded when MSBUILDRECORDEVALUATIONINPUTS is set; null when recording is off or the project is linked.
+        /// </summary>
+        internal Context.EvaluationInputs EvaluationInputs => (implementation as ProjectImpl)?.EvaluationInputs;
         object ILinkableObject.Link => IsLinked ? Link : null;
 
         /// <summary>
@@ -3588,6 +3593,11 @@ namespace Microsoft.Build.Evaluation
                 return new ProjectInstance(_data, DirectoryPath, FullPath, ProjectCollection.HostServices, ProjectCollection.EnvironmentProperties, settings);
             }
 
+            /// <summary>
+            /// Inputs the last evaluation recorded when MSBUILDRECORDEVALUATIONINPUTS is set, otherwise null.
+            /// </summary>
+            internal Context.EvaluationInputs EvaluationInputs { get; private set; }
+
             private void Reevaluate(
                 ILoggingService loggingServiceForEvaluation,
                 ProjectLoadSettings loadSettings,
@@ -3595,7 +3605,7 @@ namespace Microsoft.Build.Evaluation
             {
                 evaluationContext = evaluationContext?.ContextForNewProject() ?? EvaluationContext.Create(EvaluationContext.SharingPolicy.Isolated);
 
-                Evaluator<ProjectProperty, ProjectItem, ProjectMetadata, ProjectItemDefinition>.Evaluate(
+                EvaluationInputs = Evaluator<ProjectProperty, ProjectItem, ProjectMetadata, ProjectItemDefinition>.Evaluate(
                     _data,
                     Owner,
                     Xml,

--- a/src/Build/Evaluation/Conditionals/FunctionCallExpressionNode.cs
+++ b/src/Build/Evaluation/Conditionals/FunctionCallExpressionNode.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using Microsoft.Build.Evaluation.Context;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
@@ -50,7 +51,18 @@ namespace Microsoft.Build.Evaluation
 
                     foreach (var item in list)
                     {
-                        if (item == null || !(state.LoadedProjectsCache?.TryGet(item) != null || FileUtilities.FileOrDirectoryExistsNoThrow(item, state.FileSystem)))
+                        if (item == null)
+                        {
+                            return false;
+                        }
+
+                        if (state.LoadedProjectsCache?.TryGet(item) != null)
+                        {
+                            // A loaded project counts as existing without touching the file system. Recording the answer
+                            // rather than the path lets a file deleted behind the cache conflict with what evaluation saw.
+                            state.PropertiesUseTracker.InputRecorder?.RecordProbe(item, ProbeKind.FileOrDirectory, exists: true);
+                        }
+                        else if (!FileUtilities.FileOrDirectoryExistsNoThrow(item, state.FileSystem))
                         {
                             return false;
                         }

--- a/src/Build/Evaluation/Context/EvaluationContext.cs
+++ b/src/Build/Evaluation/Context/EvaluationContext.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Microsoft.Build.BackEnd.SdkResolution;
 using Microsoft.Build.FileSystem;
+using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
 
@@ -56,19 +57,30 @@ namespace Microsoft.Build.Evaluation.Context
         internal FileMatcher FileMatcher { get; }
 
         /// <summary>
+        /// Records the inputs of the evaluation this context was created for; null when recording is off.
+        /// </summary>
+        internal EvaluationInputRecorder InputRecorder { get; private init; }
+
+        /// <summary>
         /// Key to file entry list. Example usages: cache glob expansion and intermediary directory expansions during glob expansion.
         /// </summary>
         private ConcurrentDictionary<string, IReadOnlyList<string>> FileEntryExpansionCache { get; }
 
         private EvaluationContext(SharingPolicy policy, IFileSystem fileSystem, ISdkResolverService sdkResolverService = null,
-            ConcurrentDictionary<string, IReadOnlyList<string>> fileEntryExpansionCache = null)
+            ConcurrentDictionary<string, IReadOnlyList<string>> fileEntryExpansionCache = null, Action<string> directoryTraversed = null)
         {
             Policy = policy;
 
             SdkResolverService = sdkResolverService ?? new CachingSdkResolverService();
             FileEntryExpansionCache = fileEntryExpansionCache ?? new ConcurrentDictionary<string, IReadOnlyList<string>>();
             FileSystem = fileSystem ?? new CachingFileSystemWrapper(FileSystems.Default);
-            FileMatcher = new FileMatcher(FileSystem, FileEntryExpansionCache);
+            // Only a shared cache outlives the evaluation, so only there is it worth storing the directories an expansion
+            // depends on for the recorders of later evaluations.
+            FileMatcher = new FileMatcher(
+                FileSystem,
+                FileEntryExpansionCache,
+                directoryTraversed: directoryTraversed,
+                cacheTraversedDirectories: policy == SharingPolicy.Shared && Traits.Instance.RecordEvaluationInputs);
         }
 
         /// <summary>
@@ -138,12 +150,17 @@ namespace Microsoft.Build.Evaluation.Context
         /// Creates a copy of this <see cref="EvaluationContext"/> with a given <see cref="IFileSystem"/> swapped in.
         /// </summary>
         /// <param name="fileSystem">The file system to use by the new evaluation context.</param>
+        /// <param name="inputRecorder">
+        /// Recorder for the evaluation the copy serves, or null. A recording copy shares the glob expansion cache; its
+        /// matcher reports every directory a glob traverses, replaying the cached record when the expansion is reused.
+        /// </param>
         /// <returns>The new evaluation context.</returns>
-        internal EvaluationContext ContextWithFileSystem(IFileSystem fileSystem)
+        internal EvaluationContext ContextWithFileSystem(IFileSystem fileSystem, EvaluationInputRecorder inputRecorder = null)
         {
-            return new EvaluationContext(Policy, fileSystem, SdkResolverService, FileEntryExpansionCache)
+            return new EvaluationContext(Policy, fileSystem, SdkResolverService, FileEntryExpansionCache, inputRecorder is null ? null : inputRecorder.RecordPath)
             {
                 _used = 1,
+                InputRecorder = inputRecorder,
             };
         }
     }

--- a/src/Build/Evaluation/Context/EvaluationInputRecorder.cs
+++ b/src/Build/Evaluation/Context/EvaluationInputRecorder.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Internal;
 using Microsoft.NET.StringTools;
 
 namespace Microsoft.Build.Evaluation.Context;
@@ -20,6 +21,7 @@ internal sealed class EvaluationInputRecorder
     // Guarded by its own lock: glob expansion enumerates directories in parallel, every other seam runs on the
     // evaluation thread. SDK-style projects record 150 to 250 paths, so one growth covers them.
     private readonly Dictionary<string, FileDependency> _files = new(128, FileUtilities.PathComparer);
+    private readonly Dictionary<string, string?> _environmentReads = new(CommunicationsUtilities.EnvironmentVariableComparer);
     private NonCacheableReason _nonCacheable;
     private string? _nonCacheableDetail;
     private bool _frozen;
@@ -105,6 +107,39 @@ internal sealed class EvaluationInputRecorder
         }
     }
 
+    internal void RecordEnvironmentRead(string name, string? value)
+    {
+        if (IsRecording)
+        {
+            _environmentReads[name] = value;
+        }
+    }
+
+    /// <summary>
+    /// Records every variable a <c>%NAME%</c> reference in <paramref name="text"/> resolves, which is exactly what
+    /// <c>Environment.ExpandEnvironmentVariables</c> depends on. An undefined variable is recorded as missing.
+    /// </summary>
+    private void RecordEnvironmentReferences(string text)
+    {
+        int start = text.IndexOf('%');
+        while (start >= 0)
+        {
+            int end = text.IndexOf('%', start + 1);
+            if (end < 0)
+            {
+                return;
+            }
+
+            if (end > start + 1)
+            {
+                string name = text.Substring(start + 1, end - start - 1);
+                RecordEnvironmentRead(name, Environment.GetEnvironmentVariable(name));
+            }
+
+            start = text.IndexOf('%', end + 1);
+        }
+    }
+
     /// <summary>
     /// Records what a property function read from the file system, environment, or registry, or marks the evaluation
     /// non-cacheable when the function is volatile or not classified.
@@ -139,6 +174,12 @@ internal sealed class EvaluationInputRecorder
                 break;
             case PropertyFunctionEffect.ReadDirectory when firstArgument is not null:
                 RecordPath(firstArgument);
+                break;
+            case PropertyFunctionEffect.ReadEnvironment when firstArgument is not null:
+                RecordEnvironmentRead(firstArgument, result as string);
+                break;
+            case PropertyFunctionEffect.ExpandEnvironment when firstArgument is not null:
+                RecordEnvironmentReferences(firstArgument);
                 break;
             case PropertyFunctionEffect.PureUnlessPathArgument when !HasPathArgument(arguments):
                 break;
@@ -200,6 +241,7 @@ internal sealed class EvaluationInputRecorder
         return new EvaluationInputs(
             key,
             new ReadOnlyDictionary<string, FileDependency>(_files),
+            new ReadOnlyDictionary<string, string?>(_environmentReads),
             _nonCacheable,
             _nonCacheableDetail);
     }

--- a/src/Build/Evaluation/Context/EvaluationInputRecorder.cs
+++ b/src/Build/Evaluation/Context/EvaluationInputRecorder.cs
@@ -1,0 +1,48 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Evaluation.Context;
+
+/// <summary>
+/// Collects the inputs one evaluation consumes. Created only when <see cref="Traits.RecordEvaluationInputs"/> is set,
+/// so the rest of the engine pays one null check per seam when recording is off.
+/// Once the evaluation is known to be non-cacheable, further observations are skipped: the manifest will not be used.
+/// </summary>
+internal sealed class EvaluationInputRecorder
+{
+    private NonCacheableReason _nonCacheable;
+    private string? _nonCacheableDetail;
+    private bool _frozen;
+
+    /// <summary>
+    /// False once the evaluation is non-cacheable, since the manifest will not be used, or once <see cref="Freeze"/>
+    /// handed the collections out.
+    /// </summary>
+    private bool IsRecording => !_frozen && _nonCacheable == NonCacheableReason.None;
+
+    internal static EvaluationInputRecorder? CreateIfEnabled() =>
+        Traits.Instance.RecordEvaluationInputs ? new EvaluationInputRecorder() : null;
+
+    internal void MarkNonCacheable(NonCacheableReason reason, string? detail = null)
+    {
+        if (IsRecording)
+        {
+            _nonCacheable = reason;
+            _nonCacheableDetail = detail;
+        }
+    }
+
+    /// <summary>
+    /// Ends recording and hands the collected inputs over without copying them.
+    /// </summary>
+    internal EvaluationInputs Freeze(EvaluationInputKey key)
+    {
+        _frozen = true;
+        return new EvaluationInputs(
+            key,
+            _nonCacheable,
+            _nonCacheableDetail);
+    }
+}

--- a/src/Build/Evaluation/Context/EvaluationInputRecorder.cs
+++ b/src/Build/Evaluation/Context/EvaluationInputRecorder.cs
@@ -9,6 +9,7 @@ using System.IO;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Internal;
 using Microsoft.NET.StringTools;
+using SdkResult = Microsoft.Build.BackEnd.SdkResolution.SdkResult;
 
 namespace Microsoft.Build.Evaluation.Context;
 
@@ -23,6 +24,7 @@ internal sealed class EvaluationInputRecorder
     // evaluation thread. SDK-style projects record 150 to 250 paths, so one growth covers them.
     private readonly Dictionary<string, FileDependency> _files = new(128, FileUtilities.PathComparer);
     private readonly Dictionary<string, string?> _environmentReads = new(CommunicationsUtilities.EnvironmentVariableComparer);
+    private readonly Dictionary<SdkReference, SdkResult> _sdkResolutions = [];
     private List<RegistryRead>? _registryReads;
     private NonCacheableReason _nonCacheable;
     private string? _nonCacheableDetail;
@@ -183,6 +185,15 @@ internal sealed class EvaluationInputRecorder
         }
     }
 
+    internal void RecordSdkResolution(SdkReference reference, SdkResult result)
+    {
+        // Sdk.props and Sdk.targets resolve the same reference; one entry validates both.
+        if (IsRecording && !_sdkResolutions.ContainsKey(reference))
+        {
+            _sdkResolutions.Add(reference, result);
+        }
+    }
+
     /// <summary>
     /// Records what a property function read from the file system, environment, or registry, or marks the evaluation
     /// non-cacheable when the function is volatile or not classified.
@@ -323,10 +334,18 @@ internal sealed class EvaluationInputRecorder
     internal EvaluationInputs Freeze(EvaluationInputKey key)
     {
         _frozen = true;
+        var sdkResolutions = new SdkDependency[_sdkResolutions.Count];
+        int index = 0;
+        foreach (KeyValuePair<SdkReference, SdkResult> resolution in _sdkResolutions)
+        {
+            sdkResolutions[index++] = new SdkDependency(resolution.Key, resolution.Value);
+        }
+
         return new EvaluationInputs(
             key,
             new ReadOnlyDictionary<string, FileDependency>(_files),
             new ReadOnlyDictionary<string, string?>(_environmentReads),
+            [.. sdkResolutions],
             _registryReads is null ? [] : [.. _registryReads],
             _nonCacheable,
             _nonCacheableDetail);

--- a/src/Build/Evaluation/Context/EvaluationInputRecorder.cs
+++ b/src/Build/Evaluation/Context/EvaluationInputRecorder.cs
@@ -1,7 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.IO;
 using Microsoft.Build.Framework;
+using Microsoft.NET.StringTools;
 
 namespace Microsoft.Build.Evaluation.Context;
 
@@ -12,6 +17,9 @@ namespace Microsoft.Build.Evaluation.Context;
 /// </summary>
 internal sealed class EvaluationInputRecorder
 {
+    // Guarded by its own lock: glob expansion enumerates directories in parallel, every other seam runs on the
+    // evaluation thread. SDK-style projects record 150 to 250 paths, so one growth covers them.
+    private readonly Dictionary<string, FileDependency> _files = new(128, FileUtilities.PathComparer);
     private NonCacheableReason _nonCacheable;
     private string? _nonCacheableDetail;
     private bool _frozen;
@@ -24,6 +32,155 @@ internal sealed class EvaluationInputRecorder
 
     internal static EvaluationInputRecorder? CreateIfEnabled() =>
         Traits.Instance.RecordEvaluationInputs ? new EvaluationInputRecorder() : null;
+
+    /// <summary>
+    /// Records a path evaluation read or enumerated.
+    /// </summary>
+    internal void RecordPath(string? path)
+    {
+        if (path is null || path.Length == 0 || !IsRecording)
+        {
+            return;
+        }
+
+        try
+        {
+            TryGetOrObserve(Canonicalize(path), out _);
+        }
+        catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+        {
+            MarkNonCacheable(NonCacheableReason.RecorderFailure, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Records a project file whose content evaluation consumed as read at <paramref name="lastWriteTimeUtcWhenRead"/>.
+    /// A file that changed since it was read, for example behind a cached <c>ProjectRootElement</c>, cannot be reused.
+    /// </summary>
+    internal void RecordProjectSource(string? fullPath, DateTime lastWriteTimeUtcWhenRead)
+    {
+        if (fullPath is null || fullPath.Length == 0 || !IsRecording)
+        {
+            return;
+        }
+
+        try
+        {
+            // A probe may have recorded the file moments earlier; its stat serves as well as a new one.
+            string path = Canonicalize(fullPath);
+            if (TryGetOrObserve(path, out FileDependency current)
+                && (current.Kind != PathKind.File || current.LastWriteTimeUtc != lastWriteTimeUtcWhenRead))
+            {
+                MarkNonCacheable(NonCacheableReason.ConflictingObservation, path);
+            }
+        }
+        catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+        {
+            MarkNonCacheable(NonCacheableReason.RecorderFailure, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Records an existence probe. A result that contradicts the recorded state of the same path means
+    /// evaluation saw the file system change under it, so the result cannot be reused.
+    /// </summary>
+    internal void RecordProbe(string? path, ProbeKind kind, bool exists)
+    {
+        if (path is null || path.Length == 0 || !IsRecording)
+        {
+            return;
+        }
+
+        try
+        {
+            string fullPath = Canonicalize(path);
+            if (TryGetOrObserve(fullPath, out FileDependency recorded) && exists != Satisfies(recorded.Kind, kind))
+            {
+                MarkNonCacheable(NonCacheableReason.ConflictingObservation, fullPath);
+            }
+        }
+        catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+        {
+            MarkNonCacheable(NonCacheableReason.RecorderFailure, ex.Message);
+        }
+    }
+
+    /// <summary>
+    /// Records what a property function read from the file system, environment, or registry, or marks the evaluation
+    /// non-cacheable when the function is volatile or not classified.
+    /// </summary>
+    internal void RecordPropertyFunction(Type receiverType, string member, bool isInstance, object?[] arguments, object? result)
+    {
+        if (!IsRecording)
+        {
+            return;
+        }
+
+        PropertyFunctionEffect effect = PropertyFunctionEffects.Classify(receiverType, member, isInstance, arguments.Length);
+        if (effect == PropertyFunctionEffect.Pure)
+        {
+            return;
+        }
+
+        string? firstArgument = arguments.Length > 0 ? arguments[0] as string : null;
+        switch (effect)
+        {
+            case PropertyFunctionEffect.ProbeFile when firstArgument is not null:
+                RecordProbe(firstArgument, ProbeKind.File, result is true);
+                break;
+            case PropertyFunctionEffect.ProbeDirectory when firstArgument is not null:
+                RecordProbe(firstArgument, ProbeKind.Directory, result is true);
+                break;
+            case PropertyFunctionEffect.ProbePath when firstArgument is not null:
+                RecordProbe(firstArgument, ProbeKind.FileOrDirectory, result is true);
+                break;
+            case PropertyFunctionEffect.ReadFile when firstArgument is not null:
+                RecordPath(firstArgument);
+                break;
+            case PropertyFunctionEffect.ReadDirectory when firstArgument is not null:
+                RecordPath(firstArgument);
+                break;
+            case PropertyFunctionEffect.PureUnlessPathArgument when !HasPathArgument(arguments):
+                break;
+            case PropertyFunctionEffect.Volatile:
+                MarkNonCacheable(NonCacheableReason.VolatilePropertyFunction, $"{receiverType.FullName}::{member}");
+                break;
+            default:
+                MarkNonCacheable(NonCacheableReason.UnclassifiedPropertyFunction, $"{receiverType.FullName}::{member}");
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Marks the evaluation non-cacheable when an expression reads item timestamps, as <c>%(ModifiedTime)</c> or
+    /// <c>%(Compile.CreatedTime)</c>. Those reads happen deep inside static expansion code, so the expression is
+    /// checked instead of the read.
+    /// </summary>
+    internal void RecordMetadataExpression(string expression)
+    {
+        if (IsRecording
+            && ExpressionShredder.IndexOfMetadataMarker(expression) >= 0
+            && (ReferencesModifier(expression, ItemSpecModifiers.ModifiedTime)
+                || ReferencesModifier(expression, ItemSpecModifiers.CreatedTime)
+                || ReferencesModifier(expression, ItemSpecModifiers.AccessedTime)))
+        {
+            MarkNonCacheable(NonCacheableReason.ItemTimestampMetadata, expression);
+        }
+    }
+
+    /// <summary>
+    /// Marks the evaluation non-cacheable when an item function or a metadata name reads timestamps, as
+    /// <c>@(Compile->ModifiedTime())</c>, <c>@(Compile->Metadata('ModifiedTime'))</c>, or <c>MatchOnMetadata="ModifiedTime"</c>.
+    /// </summary>
+    internal void RecordMetadataName(string name)
+    {
+        if (IsRecording
+            && ItemSpecModifiers.TryGetModifierKind(name, out ItemSpecModifierKind kind)
+            && kind is ItemSpecModifierKind.ModifiedTime or ItemSpecModifierKind.CreatedTime or ItemSpecModifierKind.AccessedTime)
+        {
+            MarkNonCacheable(NonCacheableReason.ItemTimestampMetadata, name);
+        }
+    }
 
     internal void MarkNonCacheable(NonCacheableReason reason, string? detail = null)
     {
@@ -42,7 +199,178 @@ internal sealed class EvaluationInputRecorder
         _frozen = true;
         return new EvaluationInputs(
             key,
+            new ReadOnlyDictionary<string, FileDependency>(_files),
             _nonCacheable,
             _nonCacheableDetail);
+    }
+
+    /// <summary>
+    /// Reads the current state of a path with one system call. Returns false for a symbolic link or junction: its own
+    /// timestamp does not change when its target does, so it cannot be validated.
+    /// </summary>
+    internal static bool TryStat(string fullPath, out FileDependency dependency)
+    {
+        if (!NativeMethodsShared.TryGetFileSystemEntry(fullPath, out bool isDirectory, out bool isReparsePoint, out DateTime lastWriteTimeUtc, out long length))
+        {
+            dependency = default;
+            return true;
+        }
+
+        if (isReparsePoint && IsLink(fullPath, isDirectory))
+        {
+            dependency = default;
+            return false;
+        }
+
+        dependency = new FileDependency(isDirectory ? PathKind.Directory : PathKind.File, lastWriteTimeUtc, length);
+        return true;
+    }
+
+    private bool TryObserve(string fullPath, out FileDependency dependency)
+    {
+        if (TryStat(fullPath, out dependency))
+        {
+            return true;
+        }
+
+        MarkNonCacheable(NonCacheableReason.Link, fullPath);
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the recorded state of a path, observing it first when it is new. The stat runs outside the lock so
+    /// parallel glob enumeration does not serialize on it.
+    /// </summary>
+    private bool TryGetOrObserve(string fullPath, out FileDependency recorded)
+    {
+        lock (_files)
+        {
+            if (_files.TryGetValue(fullPath, out recorded))
+            {
+                return true;
+            }
+        }
+
+        if (!TryObserve(fullPath, out FileDependency current))
+        {
+            return false;
+        }
+
+        lock (_files)
+        {
+            if (!_files.TryGetValue(fullPath, out recorded))
+            {
+                _files.Add(fullPath, current);
+                recorded = current;
+            }
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Only symbolic links and junctions redirect to another path; cloud placeholders and other reparse points are ordinary entries.
+    /// </summary>
+    private static bool IsLink(string fullPath, bool isDirectory)
+    {
+        if (NativeMethodsShared.IsWindows)
+        {
+            return NativeMethodsShared.IsSymbolicLinkOrJunction(fullPath);
+        }
+
+#if NET
+        FileSystemInfo entry = isDirectory ? new DirectoryInfo(fullPath) : new FileInfo(fullPath);
+        return entry.LinkTarget is not null;
+#else
+        return true;
+#endif
+    }
+
+    private static bool Satisfies(PathKind recorded, ProbeKind probed) =>
+        probed switch
+        {
+            ProbeKind.File => recorded == PathKind.File,
+            ProbeKind.Directory => recorded == PathKind.Directory,
+            _ => recorded != PathKind.Missing,
+        };
+
+    /// <summary>
+    /// True when the modifier name appears as a metadata reference, not as part of a longer name. The reference grammar
+    /// allows whitespace around the name, as in <c>%( ModifiedTime )</c>.
+    /// </summary>
+    private static bool ReferencesModifier(string expression, string modifier)
+    {
+        int index = expression.IndexOf(modifier, StringComparison.OrdinalIgnoreCase);
+        while (index >= 0)
+        {
+            int before = index - 1;
+            while (before >= 0 && char.IsWhiteSpace(expression[before]))
+            {
+                before--;
+            }
+
+            int after = index + modifier.Length;
+            while (after < expression.Length && char.IsWhiteSpace(expression[after]))
+            {
+                after++;
+            }
+
+            if (before >= 0 && expression[before] is '(' or '.' && after < expression.Length && expression[after] == ')')
+            {
+                return true;
+            }
+
+            index = expression.IndexOf(modifier, index + modifier.Length, StringComparison.OrdinalIgnoreCase);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// True when an argument names a location: a rooted path, or a relative one with a directory separator, which the
+    /// callee resolves against the working directory. Identifiers and versions contain neither.
+    /// </summary>
+    private static bool HasPathArgument(object?[] arguments)
+    {
+        foreach (object? argument in arguments)
+        {
+            if (argument is string path && path.Length > 0 && (path.IndexOfAny(s_directorySeparators) >= 0 || IsRooted(path)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static readonly char[] s_directorySeparators = ['/', '\\'];
+
+    private static bool IsRooted(string path)
+    {
+        try
+        {
+            return Path.IsPathRooted(path);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Full path without a trailing separator, so a directory is one entry however it was spelled. The result is
+    /// interned so manifests of different projects share one string per SDK file instead of each holding its own.
+    /// </summary>
+    private static string Canonicalize(string path)
+    {
+        string fullPath = FileUtilities.NormalizePath(path);
+        int last = fullPath.Length - 1;
+        bool endsWithSeparator = fullPath[last] == Path.DirectorySeparatorChar || fullPath[last] == Path.AltDirectorySeparatorChar;
+        if (endsWithSeparator && !string.Equals(Path.GetPathRoot(fullPath), fullPath, StringComparison.Ordinal))
+        {
+            fullPath = fullPath.Substring(0, last);
+        }
+
+        return Strings.WeakIntern(fullPath);
     }
 }

--- a/src/Build/Evaluation/Context/EvaluationInputRecorder.cs
+++ b/src/Build/Evaluation/Context/EvaluationInputRecorder.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.IO;
 using Microsoft.Build.Framework;
@@ -22,6 +23,7 @@ internal sealed class EvaluationInputRecorder
     // evaluation thread. SDK-style projects record 150 to 250 paths, so one growth covers them.
     private readonly Dictionary<string, FileDependency> _files = new(128, FileUtilities.PathComparer);
     private readonly Dictionary<string, string?> _environmentReads = new(CommunicationsUtilities.EnvironmentVariableComparer);
+    private List<RegistryRead>? _registryReads;
     private NonCacheableReason _nonCacheable;
     private string? _nonCacheableDetail;
     private bool _frozen;
@@ -115,6 +117,47 @@ internal sealed class EvaluationInputRecorder
         }
     }
 
+    internal void RecordRegistryRead(string? keyName, string? valueName, object? value, ImmutableArray<string> requestedViews = default)
+    {
+        if (!IsRecording)
+        {
+            return;
+        }
+
+        object? recordedValue;
+        switch (value)
+        {
+            case byte[] bytes:
+                recordedValue = ImmutableArray.CreateRange(bytes);
+                break;
+            case string[] strings:
+                recordedValue = ImmutableArray.CreateRange(strings);
+                break;
+            case char[] characters:
+                recordedValue = ImmutableArray.CreateRange(characters);
+                break;
+            case null or string or decimal or DateTime or DateTimeOffset or TimeSpan or Guid:
+                recordedValue = value;
+                break;
+            default:
+                Type valueType = value.GetType();
+                if (!valueType.IsPrimitive && !valueType.IsEnum)
+                {
+                    MarkNonCacheable(NonCacheableReason.UnsupportedRegistryValue, valueType.FullName);
+                    return;
+                }
+
+                recordedValue = value;
+                break;
+        }
+
+        (_registryReads ??= []).Add(new RegistryRead(
+            keyName,
+            valueName ?? string.Empty,
+            recordedValue,
+            requestedViews.IsDefault ? [] : requestedViews));
+    }
+
     /// <summary>
     /// Records every variable a <c>%NAME%</c> reference in <paramref name="text"/> resolves, which is exactly what
     /// <c>Environment.ExpandEnvironmentVariables</c> depends on. An undefined variable is recorded as missing.
@@ -144,7 +187,7 @@ internal sealed class EvaluationInputRecorder
     /// Records what a property function read from the file system, environment, or registry, or marks the evaluation
     /// non-cacheable when the function is volatile or not classified.
     /// </summary>
-    internal void RecordPropertyFunction(Type receiverType, string member, bool isInstance, object?[] arguments, object? result)
+    internal void RecordPropertyFunction(Type receiverType, string member, bool isInstance, object?[] arguments, object? result, object?[]? invocationArguments = null)
     {
         if (!IsRecording)
         {
@@ -183,6 +226,26 @@ internal sealed class EvaluationInputRecorder
                 break;
             case PropertyFunctionEffect.PureUnlessPathArgument when !HasPathArgument(arguments):
                 break;
+            case PropertyFunctionEffect.Registry:
+                object?[] registryArguments = invocationArguments ?? arguments;
+                if (registryArguments.Length >= 2
+                    && registryArguments[0] is null or string
+                    && registryArguments[1] is null or string)
+                {
+                    RecordRegistryRead(
+                        registryArguments[0] as string,
+                        registryArguments[1] as string,
+                        result,
+                        string.Equals(member, nameof(IntrinsicFunctions.GetRegistryValueFromView), StringComparison.OrdinalIgnoreCase)
+                            ? GetRequestedRegistryViews(registryArguments)
+                            : []);
+                }
+                else
+                {
+                    MarkNonCacheable(NonCacheableReason.RecorderFailure, $"{receiverType.FullName}::{member}");
+                }
+
+                break;
             case PropertyFunctionEffect.Volatile:
                 MarkNonCacheable(NonCacheableReason.VolatilePropertyFunction, $"{receiverType.FullName}::{member}");
                 break;
@@ -190,6 +253,28 @@ internal sealed class EvaluationInputRecorder
                 MarkNonCacheable(NonCacheableReason.UnclassifiedPropertyFunction, $"{receiverType.FullName}::{member}");
                 break;
         }
+    }
+
+    private static ImmutableArray<string> GetRequestedRegistryViews(object?[] arguments)
+    {
+        if (arguments.Length <= 3)
+        {
+            return [];
+        }
+
+        // A sole array argument is the params vector; with further arguments it is an ignored nested element.
+        object?[] values = arguments.Length == 4 && arguments[3] is object[] packedViews ? packedViews : arguments;
+        int start = ReferenceEquals(values, arguments) ? 3 : 0;
+        var views = ImmutableArray.CreateBuilder<string>();
+        for (int i = start; i < values.Length; i++)
+        {
+            if (values[i] is string view)
+            {
+                views.Add(view);
+            }
+        }
+
+        return views.ToImmutable();
     }
 
     /// <summary>
@@ -242,6 +327,7 @@ internal sealed class EvaluationInputRecorder
             key,
             new ReadOnlyDictionary<string, FileDependency>(_files),
             new ReadOnlyDictionary<string, string?>(_environmentReads),
+            _registryReads is null ? [] : [.. _registryReads],
             _nonCacheable,
             _nonCacheableDetail);
     }

--- a/src/Build/Evaluation/Context/EvaluationInputValidator.cs
+++ b/src/Build/Evaluation/Context/EvaluationInputValidator.cs
@@ -1,0 +1,50 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Build.Evaluation.Context;
+
+/// <summary>
+/// Checks the recorded file and directory state for prototype invalidation experiments.
+/// Environment variables, SDK results, and request identity are not validated; success is not permission to reuse an evaluation result.
+/// </summary>
+internal static class EvaluationInputValidator
+{
+    /// <summary>
+    /// Returns true when recording completed without a non-cacheable reason and every recorded path still has the same kind, timestamp, and length.
+    /// </summary>
+    /// <param name="inputs">The recorded inputs.</param>
+    /// <param name="reason">The first input that differs, or the non-cacheable reason.</param>
+    internal static bool IsFileSystemCurrent(EvaluationInputs inputs, out string? reason)
+    {
+        if (!inputs.IsCacheable)
+        {
+            reason = $"{inputs.NonCacheable}: {inputs.NonCacheableDetail}";
+            return false;
+        }
+
+        try
+        {
+            foreach (KeyValuePair<string, FileDependency> file in inputs.Files)
+            {
+                if (!EvaluationInputRecorder.TryStat(file.Key, out FileDependency current) || current != file.Value)
+                {
+                    reason = file.Key;
+                    return false;
+                }
+            }
+        }
+        catch (Exception ex) when (!ExceptionHandling.IsCriticalException(ex))
+        {
+            // A failed check is a miss, never a failed build.
+            reason = ex.Message;
+            return false;
+        }
+
+        reason = null;
+        return true;
+    }
+}

--- a/src/Build/Evaluation/Context/EvaluationInputs.cs
+++ b/src/Build/Evaluation/Context/EvaluationInputs.cs
@@ -1,7 +1,30 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System;
+using System.Collections.Generic;
+
 namespace Microsoft.Build.Evaluation.Context;
+
+/// <summary>
+/// What evaluation found at a recorded path.
+/// </summary>
+internal enum PathKind
+{
+    Missing,
+    File,
+    Directory,
+}
+
+/// <summary>
+/// What an existence probe asked about.
+/// </summary>
+internal enum ProbeKind
+{
+    File,
+    Directory,
+    FileOrDirectory,
+}
 
 /// <summary>
 /// Why an evaluation result cannot be reused from a cache.
@@ -9,9 +32,24 @@ namespace Microsoft.Build.Evaluation.Context;
 internal enum NonCacheableReason
 {
     None,
+    VolatilePropertyFunction,
+    UnclassifiedPropertyFunction,
+    AllPropertyFunctionsEnabled,
+    ItemTimestampMetadata,
+    LazyWildcards,
     InMemoryProject,
     PartialEvaluation,
+    RecorderFailure,
+    ConflictingObservation,
+    Link,
+    HostFileSystem,
+    ProcessWideCache,
 }
+
+/// <summary>
+/// State of a path as evaluation observed it. A cache validates it by comparing against a fresh stat.
+/// </summary>
+internal readonly record struct FileDependency(PathKind Kind, DateTime LastWriteTimeUtc, long Length);
 
 /// <summary>
 /// Values known before evaluation starts. Two evaluations with different keys never share a cache entry.
@@ -43,10 +81,15 @@ internal sealed record EvaluationInputKey(
 /// The inputs one evaluation consumed, frozen when the evaluation completed.
 /// </summary>
 /// <param name="Key">Values that select a cache entry.</param>
+/// <param name="Files">
+/// Files and directories evaluation read, probed, or enumerated, keyed by full path.
+/// Missing paths matter as much as existing ones: their appearance changes the result.
+/// </param>
 /// <param name="NonCacheable">Why the result must never be reused, or <see cref="NonCacheableReason.None"/>.</param>
 /// <param name="NonCacheableDetail">The input that made the evaluation non-cacheable, for diagnostics.</param>
 internal sealed record EvaluationInputs(
     EvaluationInputKey Key,
+    IReadOnlyDictionary<string, FileDependency> Files,
     NonCacheableReason NonCacheable,
     string? NonCacheableDetail)
 {

--- a/src/Build/Evaluation/Context/EvaluationInputs.cs
+++ b/src/Build/Evaluation/Context/EvaluationInputs.cs
@@ -4,6 +4,8 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using Microsoft.Build.Framework;
+using SdkResult = Microsoft.Build.BackEnd.SdkResolution.SdkResult;
 
 namespace Microsoft.Build.Evaluation.Context;
 
@@ -54,6 +56,11 @@ internal enum NonCacheableReason
 internal readonly record struct FileDependency(PathKind Kind, DateTime LastWriteTimeUtc, long Length);
 
 /// <summary>
+/// An SDK resolution evaluation consumed. Retained for observation; SDK result validation is outside this prototype's scope.
+/// </summary>
+internal sealed record SdkDependency(SdkReference Reference, SdkResult Result);
+
+/// <summary>
 /// A registry request and the value it returned, before MSBuild string conversion or escaping.
 /// Views are string tokens the intrinsic considers; ignored non-string arguments are not included.
 /// An empty list does not identify a winning view. A null key is retained for accepted no-view requests.
@@ -100,6 +107,7 @@ internal sealed record EvaluationInputKey(
 /// Missing paths matter as much as existing ones: their appearance changes the result.
 /// </param>
 /// <param name="EnvironmentReads">Environment variables read through property functions; variables imported as properties are part of the key.</param>
+/// <param name="SdkResolutions">SDK references resolved during evaluation and their results.</param>
 /// <param name="RegistryReads">Registry keys, value names, requested views, and returned values, in observation order.</param>
 /// <param name="NonCacheable">Why the result must never be reused, or <see cref="NonCacheableReason.None"/>.</param>
 /// <param name="NonCacheableDetail">The input that made the evaluation non-cacheable, for diagnostics.</param>
@@ -107,6 +115,7 @@ internal sealed record EvaluationInputs(
     EvaluationInputKey Key,
     IReadOnlyDictionary<string, FileDependency> Files,
     IReadOnlyDictionary<string, string?> EnvironmentReads,
+    ImmutableArray<SdkDependency> SdkResolutions,
     ImmutableArray<RegistryRead> RegistryReads,
     NonCacheableReason NonCacheable,
     string? NonCacheableDetail)

--- a/src/Build/Evaluation/Context/EvaluationInputs.cs
+++ b/src/Build/Evaluation/Context/EvaluationInputs.cs
@@ -85,11 +85,13 @@ internal sealed record EvaluationInputKey(
 /// Files and directories evaluation read, probed, or enumerated, keyed by full path.
 /// Missing paths matter as much as existing ones: their appearance changes the result.
 /// </param>
+/// <param name="EnvironmentReads">Environment variables read through property functions; variables imported as properties are part of the key.</param>
 /// <param name="NonCacheable">Why the result must never be reused, or <see cref="NonCacheableReason.None"/>.</param>
 /// <param name="NonCacheableDetail">The input that made the evaluation non-cacheable, for diagnostics.</param>
 internal sealed record EvaluationInputs(
     EvaluationInputKey Key,
     IReadOnlyDictionary<string, FileDependency> Files,
+    IReadOnlyDictionary<string, string?> EnvironmentReads,
     NonCacheableReason NonCacheable,
     string? NonCacheableDetail)
 {

--- a/src/Build/Evaluation/Context/EvaluationInputs.cs
+++ b/src/Build/Evaluation/Context/EvaluationInputs.cs
@@ -1,0 +1,54 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Build.Evaluation.Context;
+
+/// <summary>
+/// Why an evaluation result cannot be reused from a cache.
+/// </summary>
+internal enum NonCacheableReason
+{
+    None,
+    InMemoryProject,
+    PartialEvaluation,
+}
+
+/// <summary>
+/// Values known before evaluation starts. Two evaluations with different keys never share a cache entry.
+/// <paramref name="GlobalProperties"/> lists the global properties sorted by name as <c>name=value</c> pairs, each ended by a
+/// NUL character, so the key compares by value. <paramref name="ToolsetFingerprint"/> covers what a toolset adds beyond its
+/// version and path, so two toolsets registered under one version do not collide.
+/// </summary>
+internal sealed record EvaluationInputKey(
+    string ProjectFullPath,
+    string GlobalProperties,
+    string ToolsVersion,
+    string ToolsPath,
+    string? SubToolsetVersion,
+    long ToolsetFingerprint,
+    ProjectEvaluationStage Stage,
+    ProjectLoadSettings LoadSettings,
+    bool Interactive,
+    int MaxNodeCount,
+    string StartupDirectory,
+    string WorkingDirectory,
+    string Culture,
+    string UICulture,
+    string EngineVersion,
+    string? DisabledChangeWave,
+    long EnvironmentFingerprint,
+    long ParserConfigurationFingerprint);
+
+/// <summary>
+/// The inputs one evaluation consumed, frozen when the evaluation completed.
+/// </summary>
+/// <param name="Key">Values that select a cache entry.</param>
+/// <param name="NonCacheable">Why the result must never be reused, or <see cref="NonCacheableReason.None"/>.</param>
+/// <param name="NonCacheableDetail">The input that made the evaluation non-cacheable, for diagnostics.</param>
+internal sealed record EvaluationInputs(
+    EvaluationInputKey Key,
+    NonCacheableReason NonCacheable,
+    string? NonCacheableDetail)
+{
+    internal bool IsCacheable => NonCacheable == NonCacheableReason.None;
+}

--- a/src/Build/Evaluation/Context/EvaluationInputs.cs
+++ b/src/Build/Evaluation/Context/EvaluationInputs.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.Build.Evaluation.Context;
 
@@ -35,6 +36,7 @@ internal enum NonCacheableReason
     VolatilePropertyFunction,
     UnclassifiedPropertyFunction,
     AllPropertyFunctionsEnabled,
+    UnsupportedRegistryValue,
     ItemTimestampMetadata,
     LazyWildcards,
     InMemoryProject,
@@ -50,6 +52,18 @@ internal enum NonCacheableReason
 /// State of a path as evaluation observed it. A cache validates it by comparing against a fresh stat.
 /// </summary>
 internal readonly record struct FileDependency(PathKind Kind, DateTime LastWriteTimeUtc, long Length);
+
+/// <summary>
+/// A registry request and the value it returned, before MSBuild string conversion or escaping.
+/// Views are string tokens the intrinsic considers; ignored non-string arguments are not included.
+/// An empty list does not identify a winning view. A null key is retained for accepted no-view requests.
+/// Binary, multi-string, and character arrays are copied to immutable arrays. Registry values are not revalidated.
+/// </summary>
+internal sealed record RegistryRead(
+    string? KeyName,
+    string ValueName,
+    object? Value,
+    ImmutableArray<string> RequestedViews);
 
 /// <summary>
 /// Values known before evaluation starts. Two evaluations with different keys never share a cache entry.
@@ -86,12 +100,14 @@ internal sealed record EvaluationInputKey(
 /// Missing paths matter as much as existing ones: their appearance changes the result.
 /// </param>
 /// <param name="EnvironmentReads">Environment variables read through property functions; variables imported as properties are part of the key.</param>
+/// <param name="RegistryReads">Registry keys, value names, requested views, and returned values, in observation order.</param>
 /// <param name="NonCacheable">Why the result must never be reused, or <see cref="NonCacheableReason.None"/>.</param>
 /// <param name="NonCacheableDetail">The input that made the evaluation non-cacheable, for diagnostics.</param>
 internal sealed record EvaluationInputs(
     EvaluationInputKey Key,
     IReadOnlyDictionary<string, FileDependency> Files,
     IReadOnlyDictionary<string, string?> EnvironmentReads,
+    ImmutableArray<RegistryRead> RegistryReads,
     NonCacheableReason NonCacheable,
     string? NonCacheableDetail)
 {

--- a/src/Build/Evaluation/Context/PropertyFunctionEffects.cs
+++ b/src/Build/Evaluation/Context/PropertyFunctionEffects.cs
@@ -1,0 +1,258 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Build.Evaluation.Context;
+
+/// <summary>
+/// How a property function depends on the world outside its arguments.
+/// </summary>
+internal enum PropertyFunctionEffect
+{
+    /// <summary>Depends only on its arguments or on state that does not change while the process lives.</summary>
+    Pure,
+    ProbeFile,
+    ProbeDirectory,
+    ProbePath,
+    ReadFile,
+    ReadDirectory,
+    /// <summary>Reads installed state, constant for the process, unless an argument names a directory or file to search.</summary>
+    PureUnlessPathArgument,
+    Volatile,
+    Unsupported,
+}
+
+/// <summary>
+/// Classifies the property functions MSBuild allows (see <c>AvailableStaticMethods</c>) so the recorder knows
+/// which argument is a file system or environment input and which results can never be cached.
+/// Anything not listed is unsupported: that keeps a new allowed function from silently going unrecorded.
+/// </summary>
+internal static class PropertyFunctionEffects
+{
+    private const string ToolLocationHelperTypeName = "Microsoft.Build.Utilities.ToolLocationHelper";
+
+    private static readonly FrozenDictionary<Type, TypeEffects> s_effectsByType = CreateEffectsByType();
+
+    private static readonly FrozenSet<string> s_pureFileSystemInfoMembers = FrozenSet.ToFrozenSet(
+        ["Name", "FullName", "Extension", "Parent", "Root", "DirectoryName", "ToString"],
+        StringComparer.OrdinalIgnoreCase);
+
+    // ToolLocationHelper members that read what the caller names rather than what is installed, or change state.
+    private static readonly FrozenSet<string> s_probingToolLocationHelperMembers = FrozenSet.ToFrozenSet(
+        ["FindRootFolderWhereAllFilesExist", "GetAssemblyFoldersFromConfigInfo", "ClearSDKStaticCache"],
+        StringComparer.OrdinalIgnoreCase);
+
+    internal static PropertyFunctionEffect Classify(Type receiverType, string member, bool isInstance, int argumentCount)
+    {
+        if (isInstance)
+        {
+            // Instance calls run on values evaluation already produced. Only file system objects reach the disk.
+            bool touchesFileSystem = typeof(FileSystemInfo).IsAssignableFrom(receiverType) || receiverType == typeof(DriveInfo);
+            return touchesFileSystem && !s_pureFileSystemInfoMembers.Contains(member)
+                ? PropertyFunctionEffect.Unsupported
+                : PropertyFunctionEffect.Pure;
+        }
+
+        if (!s_effectsByType.TryGetValue(receiverType, out TypeEffects? effects))
+        {
+            if (!string.Equals(receiverType.FullName, ToolLocationHelperTypeName, StringComparison.Ordinal))
+            {
+                return PropertyFunctionEffect.Unsupported;
+            }
+
+            // ToolLocationHelper reads installed SDK and framework locations, constant while the process lives, unless
+            // the caller names the roots to search or the file to read.
+            return s_probingToolLocationHelperMembers.Contains(member)
+                ? PropertyFunctionEffect.Unsupported
+                : PropertyFunctionEffect.PureUnlessPathArgument;
+        }
+
+        PropertyFunctionEffect effect = effects.Members.TryGetValue(member, out PropertyFunctionEffect known) ? known : effects.Default;
+        return effect switch
+        {
+            PropertyFunctionEffect.ReadDirectory when argumentCount > 2 => PropertyFunctionEffect.Unsupported, // a SearchOption argument may recurse
+            _ => effect,
+        };
+    }
+
+    private static FrozenDictionary<Type, TypeEffects> CreateEffectsByType()
+    {
+        var byType = new Dictionary<Type, TypeEffects>
+        {
+            [typeof(Environment)] = new(PropertyFunctionEffect.Unsupported, new()
+            {
+                ["StackTrace"] = PropertyFunctionEffect.Volatile,
+                ["TickCount"] = PropertyFunctionEffect.Volatile,
+                ["TickCount64"] = PropertyFunctionEffect.Volatile,
+                ["WorkingSet"] = PropertyFunctionEffect.Volatile,
+                ["CommandLine"] = PropertyFunctionEffect.Pure,
+                ["GetFolderPath"] = PropertyFunctionEffect.Pure,
+                ["Is64BitOperatingSystem"] = PropertyFunctionEffect.Pure,
+                ["Is64BitProcess"] = PropertyFunctionEffect.Pure,
+                ["MachineName"] = PropertyFunctionEffect.Pure,
+                ["NewLine"] = PropertyFunctionEffect.Pure,
+                ["OSVersion"] = PropertyFunctionEffect.Pure,
+                ["ProcessorCount"] = PropertyFunctionEffect.Pure,
+                ["SystemDirectory"] = PropertyFunctionEffect.Pure,
+                ["SystemPageSize"] = PropertyFunctionEffect.Pure,
+                ["UserDomainName"] = PropertyFunctionEffect.Pure,
+                ["UserInteractive"] = PropertyFunctionEffect.Pure,
+                ["UserName"] = PropertyFunctionEffect.Pure,
+                ["Version"] = PropertyFunctionEffect.Pure,
+            }),
+            // The manifest holds a path's kind, last write time, and length, so reads of other fields (attributes,
+            // creation and access times) stay unsupported: a change to them alone would validate as unchanged.
+            [typeof(File)] = new(PropertyFunctionEffect.Unsupported, new()
+            {
+                ["Exists"] = PropertyFunctionEffect.ProbeFile,
+                ["ReadAllText"] = PropertyFunctionEffect.ReadFile,
+                ["ReadAllBytes"] = PropertyFunctionEffect.ReadFile,
+                ["ReadAllLines"] = PropertyFunctionEffect.ReadFile,
+                ["GetLastWriteTime"] = PropertyFunctionEffect.ReadFile,
+                ["GetLastWriteTimeUtc"] = PropertyFunctionEffect.ReadFile,
+            }),
+            [typeof(Directory)] = new(PropertyFunctionEffect.Unsupported, new()
+            {
+                ["Exists"] = PropertyFunctionEffect.ProbeDirectory,
+                ["GetDirectories"] = PropertyFunctionEffect.ReadDirectory,
+                ["GetFiles"] = PropertyFunctionEffect.ReadDirectory,
+                ["GetFileSystemEntries"] = PropertyFunctionEffect.ReadDirectory,
+                ["EnumerateDirectories"] = PropertyFunctionEffect.ReadDirectory,
+                ["EnumerateFiles"] = PropertyFunctionEffect.ReadDirectory,
+                ["EnumerateFileSystemEntries"] = PropertyFunctionEffect.ReadDirectory,
+                ["GetLastWriteTime"] = PropertyFunctionEffect.ReadDirectory,
+                ["GetLastWriteTimeUtc"] = PropertyFunctionEffect.ReadDirectory,
+                ["GetParent"] = PropertyFunctionEffect.Pure,
+                ["GetDirectoryRoot"] = PropertyFunctionEffect.Pure,
+                ["GetCurrentDirectory"] = PropertyFunctionEffect.Pure,
+            }),
+            // The working directory is part of the key, so resolving a relative path against it is pure.
+            [typeof(Path)] = new(PropertyFunctionEffect.Pure, new()
+            {
+                ["Exists"] = PropertyFunctionEffect.ProbePath,
+                ["GetTempFileName"] = PropertyFunctionEffect.Unsupported,
+                ["GetRandomFileName"] = PropertyFunctionEffect.Volatile,
+            }),
+            // Parsing a time without a date fills in today's date, so the parse functions count as volatile.
+            [typeof(DateTime)] = new(PropertyFunctionEffect.Pure, new()
+            {
+                ["Now"] = PropertyFunctionEffect.Volatile,
+                ["UtcNow"] = PropertyFunctionEffect.Volatile,
+                ["Today"] = PropertyFunctionEffect.Volatile,
+                ["Parse"] = PropertyFunctionEffect.Volatile,
+                ["ParseExact"] = PropertyFunctionEffect.Volatile,
+                ["TryParse"] = PropertyFunctionEffect.Volatile,
+                ["TryParseExact"] = PropertyFunctionEffect.Volatile,
+            }),
+            [typeof(DateTimeOffset)] = new(PropertyFunctionEffect.Pure, new()
+            {
+                ["Now"] = PropertyFunctionEffect.Volatile,
+                ["UtcNow"] = PropertyFunctionEffect.Volatile,
+                ["Parse"] = PropertyFunctionEffect.Volatile,
+                ["ParseExact"] = PropertyFunctionEffect.Volatile,
+                ["TryParse"] = PropertyFunctionEffect.Volatile,
+                ["TryParseExact"] = PropertyFunctionEffect.Volatile,
+            }),
+            [typeof(Convert)] = new(PropertyFunctionEffect.Pure, new()
+            {
+                ["ToDateTime"] = PropertyFunctionEffect.Volatile,
+            }),
+            [typeof(Guid)] = new(PropertyFunctionEffect.Pure, new()
+            {
+                ["NewGuid"] = PropertyFunctionEffect.Volatile,
+            }),
+            // Every intrinsic is listed so that a new one fails closed until it is classified. GetPathOfFileAbove and
+            // GetDirectoryNameOfFileAbove probe through the evaluation file system, which the recording wrapper observes.
+            // Install-location getters and platform checks are constant for the process.
+            [typeof(IntrinsicFunctions)] = new(PropertyFunctionEffect.Unsupported, new()
+            {
+                ["FileExists"] = PropertyFunctionEffect.ProbeFile,
+                ["DirectoryExists"] = PropertyFunctionEffect.ProbeDirectory,
+                ["Add"] = PropertyFunctionEffect.Pure,
+                ["Subtract"] = PropertyFunctionEffect.Pure,
+                ["Multiply"] = PropertyFunctionEffect.Pure,
+                ["Divide"] = PropertyFunctionEffect.Pure,
+                ["Modulo"] = PropertyFunctionEffect.Pure,
+                ["BitwiseAnd"] = PropertyFunctionEffect.Pure,
+                ["BitwiseOr"] = PropertyFunctionEffect.Pure,
+                ["BitwiseXor"] = PropertyFunctionEffect.Pure,
+                ["BitwiseNot"] = PropertyFunctionEffect.Pure,
+                ["LeftShift"] = PropertyFunctionEffect.Pure,
+                ["RightShift"] = PropertyFunctionEffect.Pure,
+                ["RightShiftUnsigned"] = PropertyFunctionEffect.Pure,
+                ["AreFeaturesEnabled"] = PropertyFunctionEffect.Pure,
+                ["CheckFeatureAvailability"] = PropertyFunctionEffect.Pure,
+                ["ConvertFromBase64"] = PropertyFunctionEffect.Pure,
+                ["ConvertToBase64"] = PropertyFunctionEffect.Pure,
+                ["Escape"] = PropertyFunctionEffect.Pure,
+                ["Unescape"] = PropertyFunctionEffect.Pure,
+                ["EnsureTrailingSlash"] = PropertyFunctionEffect.Pure,
+                ["NormalizeDirectory"] = PropertyFunctionEffect.Pure,
+                ["NormalizePath"] = PropertyFunctionEffect.Pure,
+                ["MakeRelative"] = PropertyFunctionEffect.Pure,
+                ["ValueOrDefault"] = PropertyFunctionEffect.Pure,
+                ["StableStringHash"] = PropertyFunctionEffect.Pure,
+                ["SubstringByAsciiChars"] = PropertyFunctionEffect.Pure,
+                ["FilterTargetFrameworks"] = PropertyFunctionEffect.Pure,
+                ["GetTargetFrameworkIdentifier"] = PropertyFunctionEffect.Pure,
+                ["GetTargetFrameworkVersion"] = PropertyFunctionEffect.Pure,
+                ["GetTargetPlatformIdentifier"] = PropertyFunctionEffect.Pure,
+                ["GetTargetPlatformVersion"] = PropertyFunctionEffect.Pure,
+                ["IsTargetFrameworkCompatible"] = PropertyFunctionEffect.Pure,
+                ["VersionEquals"] = PropertyFunctionEffect.Pure,
+                ["VersionNotEquals"] = PropertyFunctionEffect.Pure,
+                ["VersionGreaterThan"] = PropertyFunctionEffect.Pure,
+                ["VersionGreaterThanOrEquals"] = PropertyFunctionEffect.Pure,
+                ["VersionLessThan"] = PropertyFunctionEffect.Pure,
+                ["VersionLessThanOrEquals"] = PropertyFunctionEffect.Pure,
+                ["GetPathOfFileAbove"] = PropertyFunctionEffect.Pure,
+                ["GetDirectoryNameOfFileAbove"] = PropertyFunctionEffect.Pure,
+                ["GetCurrentToolsDirectory"] = PropertyFunctionEffect.Pure,
+                ["GetToolsDirectory32"] = PropertyFunctionEffect.Pure,
+                ["GetToolsDirectory64"] = PropertyFunctionEffect.Pure,
+                ["GetMSBuildExtensionsPath"] = PropertyFunctionEffect.Pure,
+                ["GetMSBuildSDKsPath"] = PropertyFunctionEffect.Pure,
+                ["GetProgramFiles32"] = PropertyFunctionEffect.Pure,
+                ["GetVsInstallRoot"] = PropertyFunctionEffect.Pure,
+                ["IsRunningFromVisualStudio"] = PropertyFunctionEffect.Pure,
+                ["DoesTaskHostExist"] = PropertyFunctionEffect.Pure,
+                ["IsOSPlatform"] = PropertyFunctionEffect.Pure,
+                ["IsOsUnixLike"] = PropertyFunctionEffect.Pure,
+                ["IsOsBsdLike"] = PropertyFunctionEffect.Pure,
+            }),
+        };
+
+        foreach (Type pureType in (ReadOnlySpan<Type>)
+            [
+                typeof(string), typeof(char), typeof(bool), typeof(byte), typeof(sbyte), typeof(short), typeof(ushort),
+                typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal),
+                typeof(Math), typeof(Enum), typeof(Version), typeof(TimeSpan), typeof(Regex), typeof(Uri),
+                typeof(UriBuilder), typeof(StringComparer), typeof(CultureInfo), typeof(RuntimeInformation), typeof(OSPlatform),
+            ])
+        {
+            byType[pureType] = new TypeEffects(PropertyFunctionEffect.Pure, []);
+        }
+
+        return byType.ToFrozenDictionary();
+    }
+
+    private sealed class TypeEffects
+    {
+        internal TypeEffects(PropertyFunctionEffect defaultEffect, Dictionary<string, PropertyFunctionEffect> members)
+        {
+            Default = defaultEffect;
+            Members = members.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+        }
+
+        internal PropertyFunctionEffect Default { get; }
+
+        internal FrozenDictionary<string, PropertyFunctionEffect> Members { get; }
+    }
+}

--- a/src/Build/Evaluation/Context/PropertyFunctionEffects.cs
+++ b/src/Build/Evaluation/Context/PropertyFunctionEffects.cs
@@ -28,6 +28,7 @@ internal enum PropertyFunctionEffect
     ExpandEnvironment,
     /// <summary>Reads installed state, constant for the process, unless an argument names a directory or file to search.</summary>
     PureUnlessPathArgument,
+    Registry,
     Volatile,
     Unsupported,
 }
@@ -181,6 +182,8 @@ internal static class PropertyFunctionEffects
             {
                 ["FileExists"] = PropertyFunctionEffect.ProbeFile,
                 ["DirectoryExists"] = PropertyFunctionEffect.ProbeDirectory,
+                ["GetRegistryValue"] = PropertyFunctionEffect.Registry,
+                ["GetRegistryValueFromView"] = PropertyFunctionEffect.Registry,
                 ["Add"] = PropertyFunctionEffect.Pure,
                 ["Subtract"] = PropertyFunctionEffect.Pure,
                 ["Multiply"] = PropertyFunctionEffect.Pure,

--- a/src/Build/Evaluation/Context/PropertyFunctionEffects.cs
+++ b/src/Build/Evaluation/Context/PropertyFunctionEffects.cs
@@ -23,6 +23,9 @@ internal enum PropertyFunctionEffect
     ProbePath,
     ReadFile,
     ReadDirectory,
+    ReadEnvironment,
+    /// <summary>Reads every environment variable referenced as <c>%NAME%</c> in the first argument.</summary>
+    ExpandEnvironment,
     /// <summary>Reads installed state, constant for the process, unless an argument names a directory or file to search.</summary>
     PureUnlessPathArgument,
     Volatile,
@@ -77,6 +80,7 @@ internal static class PropertyFunctionEffects
         PropertyFunctionEffect effect = effects.Members.TryGetValue(member, out PropertyFunctionEffect known) ? known : effects.Default;
         return effect switch
         {
+            PropertyFunctionEffect.ReadEnvironment or PropertyFunctionEffect.ExpandEnvironment when argumentCount != 1 => PropertyFunctionEffect.Unsupported,
             PropertyFunctionEffect.ReadDirectory when argumentCount > 2 => PropertyFunctionEffect.Unsupported, // a SearchOption argument may recurse
             _ => effect,
         };
@@ -88,6 +92,8 @@ internal static class PropertyFunctionEffects
         {
             [typeof(Environment)] = new(PropertyFunctionEffect.Unsupported, new()
             {
+                ["GetEnvironmentVariable"] = PropertyFunctionEffect.ReadEnvironment,
+                ["ExpandEnvironmentVariables"] = PropertyFunctionEffect.ExpandEnvironment,
                 ["StackTrace"] = PropertyFunctionEffect.Volatile,
                 ["TickCount"] = PropertyFunctionEffect.Volatile,
                 ["TickCount64"] = PropertyFunctionEffect.Volatile,

--- a/src/Build/Evaluation/Context/RecordingFileSystem.cs
+++ b/src/Build/Evaluation/Context/RecordingFileSystem.cs
@@ -1,0 +1,100 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Microsoft.Build.Shared.FileSystem;
+
+namespace Microsoft.Build.Evaluation.Context;
+
+/// <summary>
+/// Forwards to the evaluation file system and records every path evaluation reads, probes, or enumerates.
+/// Reads are recorded before the read so the recorded timestamp cannot postdate the content evaluation consumed.
+/// </summary>
+internal sealed class RecordingFileSystem : IFileSystem
+{
+    private readonly IFileSystem _inner;
+    private readonly EvaluationInputRecorder _recorder;
+
+    internal RecordingFileSystem(IFileSystem inner, EvaluationInputRecorder recorder)
+    {
+        _inner = inner;
+        _recorder = recorder;
+    }
+
+    public TextReader ReadFile(string path)
+    {
+        _recorder.RecordPath(path);
+        return _inner.ReadFile(path);
+    }
+
+    public Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share)
+    {
+        _recorder.RecordPath(path);
+        return _inner.GetFileStream(path, mode, access, share);
+    }
+
+    public string ReadFileAllText(string path)
+    {
+        _recorder.RecordPath(path);
+        return _inner.ReadFileAllText(path);
+    }
+
+    public byte[] ReadFileAllBytes(string path)
+    {
+        _recorder.RecordPath(path);
+        return _inner.ReadFileAllBytes(path);
+    }
+
+    public IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+    {
+        _recorder.RecordPath(path);
+        return _inner.EnumerateFiles(path, searchPattern, searchOption);
+    }
+
+    public IEnumerable<string> EnumerateDirectories(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+    {
+        _recorder.RecordPath(path);
+        return _inner.EnumerateDirectories(path, searchPattern, searchOption);
+    }
+
+    public IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+    {
+        _recorder.RecordPath(path);
+        return _inner.EnumerateFileSystemEntries(path, searchPattern, searchOption);
+    }
+
+    public FileAttributes GetAttributes(string path)
+    {
+        _recorder.RecordPath(path);
+        return _inner.GetAttributes(path);
+    }
+
+    public DateTime GetLastWriteTimeUtc(string path)
+    {
+        _recorder.RecordPath(path);
+        return _inner.GetLastWriteTimeUtc(path);
+    }
+
+    public bool DirectoryExists(string path)
+    {
+        bool exists = _inner.DirectoryExists(path);
+        _recorder.RecordProbe(path, ProbeKind.Directory, exists);
+        return exists;
+    }
+
+    public bool FileExists(string path)
+    {
+        bool exists = _inner.FileExists(path);
+        _recorder.RecordProbe(path, ProbeKind.File, exists);
+        return exists;
+    }
+
+    public bool FileOrDirectoryExists(string path)
+    {
+        bool exists = _inner.FileOrDirectoryExists(path);
+        _recorder.RecordProbe(path, ProbeKind.FileOrDirectory, exists);
+        return exists;
+    }
+}

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -2086,6 +2086,8 @@ namespace Microsoft.Build.Evaluation
                     ProjectErrorUtilities.ThrowInvalidProject(importElement.SdkLocation, "SDKResolverCriticalFailure", e.Message);
                 }
 
+                _inputRecorder?.RecordSdkResolution(sdkReference, sdkResult);
+
                 if (!sdkResult.Success)
                 {
                     if (_loadSettings.HasFlag(ProjectLoadSettings.IgnoreMissingImports) && !_loadSettings.HasFlag(ProjectLoadSettings.FailOnUnresolvedSdk))

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -25,6 +25,7 @@ using Microsoft.Build.Framework.Profiler;
 using Microsoft.Build.Internal;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
+using Microsoft.NET.StringTools;
 using static Microsoft.Build.Execution.ProjectPropertyInstance;
 using Constants = Microsoft.Build.Framework.Constants;
 using EngineFileUtilities = Microsoft.Build.Internal.EngineFileUtilities;
@@ -178,6 +179,11 @@ namespace Microsoft.Build.Evaluation
         private readonly EvaluationContext _evaluationContext;
 
         /// <summary>
+        /// Records the inputs this evaluation consumes; null unless <see cref="Traits.RecordEvaluationInputs"/> is set.
+        /// </summary>
+        private readonly EvaluationInputRecorder _inputRecorder;
+
+        /// <summary>
         /// The environment properties with which evaluation should take place.
         /// </summary>
         private readonly PropertyDictionary<ProjectPropertyInstance> _environmentProperties;
@@ -267,6 +273,8 @@ namespace Microsoft.Build.Evaluation
                 _evaluationContext = evaluationContext.ContextWithFileSystem(fileSystem);
             }
 
+            _inputRecorder = CreateInputRecorder(projectRootElement, evaluationStage);
+
             // Create containers for the evaluation results
             data.InitializeForEvaluation(toolsetProvider, _evaluationContext, _evaluationLoggingContext);
 
@@ -307,6 +315,131 @@ namespace Microsoft.Build.Evaluation
             _streamImports.Add(string.Empty);
         }
 
+        private static EvaluationInputRecorder CreateInputRecorder(ProjectRootElement projectRootElement, ProjectEvaluationStage evaluationStage)
+        {
+            EvaluationInputRecorder recorder = EvaluationInputRecorder.CreateIfEnabled();
+            if (recorder is null)
+            {
+                return null;
+            }
+
+            if (projectRootElement.FullPath is null || projectRootElement.Link is not null)
+            {
+                recorder.MarkNonCacheable(NonCacheableReason.InMemoryProject);
+            }
+            else if (evaluationStage != ProjectEvaluationStage.Full)
+            {
+                recorder.MarkNonCacheable(NonCacheableReason.PartialEvaluation);
+            }
+            return recorder;
+        }
+
+        private EvaluationInputKey CreateInputKey() =>
+            new(
+                _projectRootElement.FullPath,
+                FormatGlobalProperties(),
+                _data.Toolset.ToolsVersion,
+                _data.Toolset.ToolsPath,
+                _data.SubToolsetVersion,
+                ComputeToolsetFingerprint(),
+                _evaluationStage,
+                _loadSettings,
+                _interactive,
+                _maxNodeCount,
+                BuildParameters.StartupDirectory,
+                FileUtilities.CurrentThreadWorkingDirectory ?? Directory.GetCurrentDirectory(),
+                CultureInfo.CurrentCulture.Name,
+                CultureInfo.CurrentUICulture.Name,
+                ProjectCollection.DisplayVersion,
+                ChangeWaves.DisabledWave?.ToString(),
+                ComputeEnvironmentFingerprint(),
+                _projectRootElementCache.ParserIgnoreConfiguration?.ComputeFingerprint() ?? 0);
+
+        /// <summary>
+        /// Global properties sorted by name as <c>name=value</c> pairs, each ended by a NUL character that values do not contain,
+        /// so the key compares by value.
+        /// </summary>
+        private string FormatGlobalProperties()
+        {
+            var properties = new ProjectPropertyInstance[_data.GlobalPropertiesDictionary.Count];
+            int index = 0;
+            foreach (ProjectPropertyInstance property in _data.GlobalPropertiesDictionary)
+            {
+                properties[index++] = property;
+            }
+
+            Array.Sort(properties, static (left, right) => string.Compare(left.Name, right.Name, StringComparison.OrdinalIgnoreCase));
+
+            var builder = new StringBuilder();
+            foreach (ProjectPropertyInstance property in properties)
+            {
+                builder.Append(property.Name).Append('=').Append(property.EvaluatedValue).Append('\0');
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Fingerprints what the toolset adds beyond its version and path: its properties, the selected sub-toolset's properties,
+        /// the import fallback search paths, and the override tasks path. Each group carries its own salt so a property present in
+        /// two groups does not cancel out.
+        /// </summary>
+        private long ComputeToolsetFingerprint()
+        {
+            Toolset toolset = _data.Toolset;
+            long fingerprint = FowlerNollVo1aHash.ComputeHash64Fast(toolset.OverrideTasksPath ?? string.Empty);
+            foreach (ProjectPropertyInstance property in toolset.Properties.Values)
+            {
+                fingerprint ^= HashProperty(1, property);
+            }
+
+            if (_data.SubToolsetVersion is not null && toolset.SubToolsets.TryGetValue(_data.SubToolsetVersion, out SubToolset subToolset))
+            {
+                foreach (ProjectPropertyInstance property in subToolset.Properties.Values)
+                {
+                    fingerprint ^= HashProperty(2, property);
+                }
+            }
+
+            if (toolset.ImportPropertySearchPathsTable is not null)
+            {
+                foreach (ProjectImportPathMatch match in toolset.ImportPropertySearchPathsTable.Values)
+                {
+                    long paths = FowlerNollVo1aHash.ComputeHash64Fast(match.PropertyName);
+                    foreach (string path in match.SearchPaths)
+                    {
+                        paths = FowlerNollVo1aHash.Combine64(paths, FowlerNollVo1aHash.ComputeHash64Fast(path));
+                    }
+
+                    fingerprint ^= FowlerNollVo1aHash.Combine64(3, paths);
+                }
+            }
+
+            return fingerprint;
+        }
+
+        /// <summary>
+        /// Fingerprints the environment variables imported as properties, so a different environment selects a different cache entry
+        /// and individual reads of those properties need no tracking. Combining with XOR keeps the result independent of enumeration order.
+        /// </summary>
+        private long ComputeEnvironmentFingerprint()
+        {
+            long fingerprint = _environmentProperties.Count;
+            foreach (ProjectPropertyInstance property in _environmentProperties)
+            {
+                fingerprint ^= HashProperty(0, property);
+            }
+
+            return fingerprint;
+        }
+
+        private static long HashProperty(long salt, ProjectPropertyInstance property) =>
+            FowlerNollVo1aHash.Combine64(
+                salt,
+                FowlerNollVo1aHash.Combine64(
+                    FowlerNollVo1aHash.ComputeHash64Fast(property.Name),
+                    FowlerNollVo1aHash.ComputeHash64Fast(property.EvaluatedValue)));
+
 
         /// <summary>
         /// Delegate passed to methods to provide basic expression evaluation
@@ -328,7 +461,7 @@ namespace Microsoft.Build.Evaluation
         /// This is a helper static method so that the caller can just do "Evaluator.Evaluate(..)" without
         /// newing one up, yet the whole class need not be static.
         /// </remarks>
-        internal static void Evaluate(
+        internal static EvaluationInputs Evaluate(
             IEvaluatorData<P, I, M, D> data,
             Project project,
             ProjectRootElement root,
@@ -371,9 +504,11 @@ namespace Microsoft.Build.Evaluation
                 buildEventContext,
                 evaluationStage);
 
+            EvaluationInputs inputs = null;
             try
             {
                 evaluator.Evaluate();
+                inputs = evaluator._inputRecorder?.Freeze(evaluator.CreateInputKey());
             }
             catch (PathTooLongException ex)
             {
@@ -403,6 +538,7 @@ namespace Microsoft.Build.Evaluation
             }
 
             MSBuildEventSource.Log.EvaluateStop(root.ProjectFileLocation.File);
+            return inputs;
         }
 
         /// <summary>

--- a/src/Build/Evaluation/Evaluator.cs
+++ b/src/Build/Evaluation/Evaluator.cs
@@ -273,7 +273,24 @@ namespace Microsoft.Build.Evaluation
                 _evaluationContext = evaluationContext.ContextWithFileSystem(fileSystem);
             }
 
-            _inputRecorder = CreateInputRecorder(projectRootElement, evaluationStage);
+            // A host file system or directory cache may answer from state the recorder cannot see, so such evaluations are not reusable.
+            bool hostFileSystem = directoryCache is not null || evaluationContext.FileSystem is not CachingFileSystemWrapper;
+            _inputRecorder = CreateInputRecorder(projectRootElement, evaluationStage, hostFileSystem);
+            if (_inputRecorder is not null)
+            {
+                _evaluationContext = _evaluationContext.ContextWithFileSystem(
+                    new RecordingFileSystem(_evaluationContext.FileSystem, _inputRecorder),
+                    _inputRecorder);
+
+                // The parser skips elements and attributes the Directory.Parse.config files allow, so their content is an input too.
+                if (projectRootElementCache.ParserIgnoreConfiguration is { } parserConfiguration)
+                {
+                    foreach (string configFile in parserConfiguration.LoadedConfigFiles)
+                    {
+                        _inputRecorder.RecordPath(configFile);
+                    }
+                }
+            }
 
             // Create containers for the evaluation results
             data.InitializeForEvaluation(toolsetProvider, _evaluationContext, _evaluationLoggingContext);
@@ -315,7 +332,7 @@ namespace Microsoft.Build.Evaluation
             _streamImports.Add(string.Empty);
         }
 
-        private static EvaluationInputRecorder CreateInputRecorder(ProjectRootElement projectRootElement, ProjectEvaluationStage evaluationStage)
+        private static EvaluationInputRecorder CreateInputRecorder(ProjectRootElement projectRootElement, ProjectEvaluationStage evaluationStage, bool hostFileSystem)
         {
             EvaluationInputRecorder recorder = EvaluationInputRecorder.CreateIfEnabled();
             if (recorder is null)
@@ -331,6 +348,24 @@ namespace Microsoft.Build.Evaluation
             {
                 recorder.MarkNonCacheable(NonCacheableReason.PartialEvaluation);
             }
+            else if (hostFileSystem)
+            {
+                recorder.MarkNonCacheable(NonCacheableReason.HostFileSystem);
+            }
+            else if (Traits.Instance.CacheFileExistence || Traits.Instance.MSBuildCacheFileEnumerations)
+            {
+                // Process-wide caches answer probes and globs without touching the file system the recorder watches.
+                recorder.MarkNonCacheable(NonCacheableReason.ProcessWideCache);
+            }
+            else if (Traits.Instance.UseLazyWildCardEvaluation)
+            {
+                recorder.MarkNonCacheable(NonCacheableReason.LazyWildcards);
+            }
+            else if (FeatureSwitches.EnableAllPropertyFunctions)
+            {
+                recorder.MarkNonCacheable(NonCacheableReason.AllPropertyFunctionsEnabled);
+            }
+
             return recorder;
         }
 
@@ -1084,6 +1119,18 @@ namespace Microsoft.Build.Evaluation
         /// </summary>
         private void PerformDepthFirstPass(ProjectRootElement currentProjectOrImport)
         {
+            if (_inputRecorder is not null && !currentProjectOrImport.IsEphemeral)
+            {
+                if (currentProjectOrImport.HasUnsavedChanges)
+                {
+                    _inputRecorder.MarkNonCacheable(NonCacheableReason.InMemoryProject, currentProjectOrImport.FullPath);
+                }
+                else
+                {
+                    _inputRecorder.RecordProjectSource(currentProjectOrImport.FullPath, currentProjectOrImport.LastWriteTimeWhenReadUtc);
+                }
+            }
+
             using (_evaluationProfiler.TrackFile(currentProjectOrImport.FullPath))
             {
                 // We accumulate InitialTargets from the project and each import
@@ -1827,7 +1874,9 @@ namespace Microsoft.Build.Evaluation
 
                 // If the whole fallback folder doesn't exist, short-circuit and don't
                 // bother constructing an exact file path.
-                if (!_fallbackSearchPathsCache.DirectoryExists(extensionPathExpanded))
+                bool fallbackRootExists = _fallbackSearchPathsCache.DirectoryExists(extensionPathExpanded);
+                _inputRecorder?.RecordProbe(extensionPathExpanded, ProbeKind.Directory, fallbackRootExists);
+                if (!fallbackRootExists)
                 {
                     // Set to log an error only if the change wave is enabled.
                     missingDirectoryDespiteTrueCondition = !containsWildcards;
@@ -2115,7 +2164,9 @@ namespace Microsoft.Build.Evaluation
                     // "S:\sdk\.dotnet\sdk\10.0.100-preview.6.25315.102\Sdks\Microsoft.NET.Sdk\Sdk"
                     //                  ^5              ^4               ^3          ^2        ^1
                     string dotnetExe = Path.Combine(FileUtilities.GetFolderAbove(sdkResult.Path, 5), Constants.DotnetProcessName);
-                    if (FileSystems.Default.FileExists(dotnetExe))
+                    bool dotnetExeExists = FileSystems.Default.FileExists(dotnetExe);
+                    _inputRecorder?.RecordProbe(dotnetExe, ProbeKind.File, dotnetExeExists);
+                    if (dotnetExeExists)
                     {
                         _data.AddSdkResolvedEnvironmentVariable(Constants.DotnetHostPathEnvVarName, dotnetExe);
                     }
@@ -2470,7 +2521,9 @@ namespace Microsoft.Build.Evaluation
                         // Perhaps the import tag has a typo in, for example.
 
                         // There's a specific message for file not existing
-                        if (!FileSystems.Default.FileExists(importFileUnescaped))
+                        bool importExists = FileSystems.Default.FileExists(importFileUnescaped);
+                        _inputRecorder?.RecordProbe(importFileUnescaped, ProbeKind.File, importExists);
+                        if (!importExists)
                         {
                             if ((_loadSettings & ProjectLoadSettings.IgnoreMissingImports) != 0)
                             {

--- a/src/Build/Evaluation/Expander.Function.cs
+++ b/src/Build/Evaluation/Expander.Function.cs
@@ -556,6 +556,8 @@ internal partial class Expander<P, I>
                     }
                 }
 
+                _propertiesUseTracker.InputRecorder?.RecordPropertyFunction(_receiverType, _methodMethodName, objectInstance is not null, args, functionResult);
+
                 // If the result of the function call is a string, then we need to escape the result
                 // so that we maintain the "engine contains escaped data" state.
                 // The exception is that the user is explicitly calling MSBuild::Unescape, MSBuild::Escape, or ConvertFromBase64

--- a/src/Build/Evaluation/Expander.Function.cs
+++ b/src/Build/Evaluation/Expander.Function.cs
@@ -368,6 +368,7 @@ internal partial class Expander<P, I>
         {
             object functionResult = String.Empty;
             object[] args = null;
+            object[] invocationArguments = null;
 
             try
             {
@@ -495,7 +496,7 @@ internal partial class Expander<P, I>
                 {
                     if (!WellKnownFunctions.TryExecuteWellKnownConstructorNoThrow(_receiverType, out functionResult, args))
                     {
-                        functionResult = LateBindExecute(null /* no previous exception */, BindingFlags.Public | BindingFlags.Instance, null /* no instance for a constructor */, args, true /* is constructor */);
+                        functionResult = LateBindExecute(null /* no previous exception */, BindingFlags.Public | BindingFlags.Instance, null /* no instance for a constructor */, args, true /* is constructor */, out invocationArguments);
                     }
                 }
                 else
@@ -551,12 +552,12 @@ internal partial class Expander<P, I>
                         {
                             // The standard binder failed, so do our best to coerce types into the arguments for the function
                             // This may happen if the types need coercion, but it may also happen if the object represents a type that contains open type parameters, that is, ContainsGenericParameters returns true.
-                            functionResult = LateBindExecute(ex, _bindingFlags, objectInstance, args, false /* is not constructor */);
+                            functionResult = LateBindExecute(ex, _bindingFlags, objectInstance, args, false /* is not constructor */, out invocationArguments);
                         }
                     }
                 }
 
-                _propertiesUseTracker.InputRecorder?.RecordPropertyFunction(_receiverType, _methodMethodName, objectInstance is not null, args, functionResult);
+                _propertiesUseTracker.InputRecorder?.RecordPropertyFunction(_receiverType, _methodMethodName, objectInstance is not null, args, functionResult, invocationArguments);
 
                 // If the result of the function call is a string, then we need to escape the result
                 // so that we maintain the "engine contains escaped data" state.
@@ -1243,7 +1244,7 @@ internal partial class Expander<P, I>
             Justification = "The only RDC method reachable here is Enum.GetValues(Type), which is unreachable via property functions; see comment above.")]
         [UnconditionalSuppressMessage("Trimming", "IL2080:UnrecognizedReflectionPattern",
             Justification = "_bindingFlags is masked to AllowedBindingFlags at construction, so it never carries BindingFlags.NonPublic; GetMethods(_bindingFlags) therefore binds only public methods of the property-function allowlist receiver, whose public members are preserved for trimming.")]
-        private object LateBindExecute(Exception ex, BindingFlags bindingFlags, object objectInstance /* null unless instance method */, object[] args, bool isConstructor)
+        private object LateBindExecute(Exception ex, BindingFlags bindingFlags, object objectInstance /* null unless instance method */, object[] args, bool isConstructor, out object[] invocationArguments)
         {
             // First let's try for a method where all arguments are strings..
             Type[] types = new Type[_arguments.Length];
@@ -1342,6 +1343,7 @@ internal partial class Expander<P, I>
                 throw new TargetInvocationException(new MissingMethodException());
             }
 
+            invocationArguments = args;
             return functionResult;
         }
     }

--- a/src/Build/Evaluation/Expander.ItemExpander.Transforms.cs
+++ b/src/Build/Evaluation/Expander.ItemExpander.Transforms.cs
@@ -152,9 +152,11 @@ internal partial class Expander<P, I>
                 List<TransformEntry> output,
                 string[] arguments,
                 string functionName,
-                IElementLocation elementLocation)
+                IElementLocation elementLocation,
+                IFileSystem fileSystem)
             {
                 ProjectErrorUtilities.VerifyThrowInvalidProject(arguments == null || arguments.Length == 0, elementLocation, "InvalidItemFunctionSyntax", functionName, arguments == null ? 0 : arguments.Length);
+                fileSystem ??= FileSystems.Default;
 
                 foreach (TransformEntry item in input)
                 {
@@ -191,7 +193,7 @@ internal partial class Expander<P, I>
                         ProjectErrorUtilities.ThrowInvalidProject(elementLocation, "InvalidItemFunctionExpression", functionName, item.Value, e.Message);
                     }
 
-                    if (FileSystems.Default.FileOrDirectoryExists(rootedPath))
+                    if (fileSystem.FileOrDirectoryExists(rootedPath))
                     {
                         output.Add(item);
                     }

--- a/src/Build/Evaluation/Expander.ItemExpander.cs
+++ b/src/Build/Evaluation/Expander.ItemExpander.cs
@@ -155,6 +155,30 @@ internal partial class Expander<P, I>
                     }
                 }
 
+                if (expander._propertiesUseTracker.InputRecorder is { } inputRecorder)
+                {
+                    switch (kind)
+                    {
+                        case TransformKind.ItemSpecModifierFunction:
+                            inputRecorder.RecordMetadataName(functionName);
+                            break;
+                        case TransformKind.ExpandQuotedExpressionFunction:
+                            inputRecorder.RecordMetadataExpression(function);
+                            break;
+                        case TransformKind.Metadata:
+                        case TransformKind.HasMetadata:
+                        case TransformKind.WithMetadataValue:
+                        case TransformKind.WithoutMetadataValue:
+                        case TransformKind.AnyHaveMetadataValue:
+                            if (arguments is { Length: > 0 })
+                            {
+                                inputRecorder.RecordMetadataName(arguments[0]);
+                            }
+
+                            break;
+                    }
+                }
+
                 switch (kind)
                 {
                     case TransformKind.ItemSpecModifierFunction:
@@ -164,7 +188,7 @@ internal partial class Expander<P, I>
                         Transforms.Count(input, output);
                         break;
                     case TransformKind.Exists:
-                        Transforms.Exists(input, output, arguments, functionName, elementLocation);
+                        Transforms.Exists(input, output, arguments, functionName, elementLocation, expander._fileSystem);
                         break;
                     case TransformKind.Combine:
                         Transforms.Combine(input, output, arguments, functionName, elementLocation);

--- a/src/Build/Evaluation/Expander.PropertyExpander.cs
+++ b/src/Build/Evaluation/Expander.PropertyExpander.cs
@@ -732,6 +732,7 @@ internal partial class Expander<P, I>
                     }
 
                     object valueFromRegistry = Registry.GetValue(registryKeyName, valueName, null /* default if key or value name is not found */);
+                    _propertiesUseTracker.InputRecorder?.RecordRegistryRead(registryKeyName, valueName, valueFromRegistry);
 
                     if (valueFromRegistry != null)
                     {

--- a/src/Build/Evaluation/Expander.cs
+++ b/src/Build/Evaluation/Expander.cs
@@ -118,6 +118,7 @@ internal partial class Expander<P, I>
     {
         _fileSystem = evaluationContext.FileSystem;
         EvaluationContext = evaluationContext;
+        _propertiesUseTracker.InputRecorder = evaluationContext.InputRecorder;
     }
 
     /// <summary>
@@ -176,6 +177,7 @@ internal partial class Expander<P, I>
         : this(properties, items, metadata, fileSystem, loggingContext)
     {
         EvaluationContext = evaluationContext;
+        _propertiesUseTracker.InputRecorder = evaluationContext?.InputRecorder;
     }
 
     /// <summary>
@@ -206,6 +208,14 @@ internal partial class Expander<P, I>
     {
         get { return _propertiesUseTracker; }
         set { _propertiesUseTracker = value; }
+    }
+
+    private void RecordMetadataInputs(string expression, ExpanderOptions options)
+    {
+        if (_propertiesUseTracker.InputRecorder is { } inputRecorder && (options & ExpanderOptions.ExpandMetadata) != 0)
+        {
+            inputRecorder.RecordMetadataExpression(expression);
+        }
     }
 
     /// <summary>
@@ -253,6 +263,7 @@ internal partial class Expander<P, I>
 
         Assumed.NotNull(elementLocation);
 
+        RecordMetadataInputs(expression, options);
         string result = MetadataExpander.ExpandMetadataLeaveEscaped(expression, _metadata, options, elementLocation, _loggingContext);
         result = PropertyExpander.ExpandPropertiesLeaveEscaped(result, _properties, options, elementLocation, _propertiesUseTracker, _fileSystem);
         result = ItemExpander.ExpandItemVectorsIntoString(this, result, _items, options, elementLocation);
@@ -274,6 +285,7 @@ internal partial class Expander<P, I>
 
         Assumed.NotNull(elementLocation);
 
+        RecordMetadataInputs(expression, options);
         string metaExpanded = MetadataExpander.ExpandMetadataLeaveEscaped(expression, _metadata, options, elementLocation);
         return PropertyExpander.ExpandPropertiesLeaveTypedAndEscaped(metaExpanded, _properties, options, elementLocation, _propertiesUseTracker, _fileSystem);
     }
@@ -322,6 +334,7 @@ internal partial class Expander<P, I>
 
         Assumed.NotNull(elementLocation);
 
+        RecordMetadataInputs(expression, options);
         expression = MetadataExpander.ExpandMetadataLeaveEscaped(expression, _metadata, options, elementLocation);
         expression = PropertyExpander.ExpandPropertiesLeaveEscaped(expression, _properties, options, elementLocation, _propertiesUseTracker, _fileSystem);
         expression = FileUtilities.MaybeAdjustFilePath(expression);

--- a/src/Build/Evaluation/LazyItemEvaluator.cs
+++ b/src/Build/Evaluation/LazyItemEvaluator.cs
@@ -599,6 +599,13 @@ namespace Microsoft.Build.Evaluation
                         string metadataExpanded = _expander.ExpandIntoStringLeaveEscaped(matchOnMetadataSplit, ExpanderOptions.ExpandPropertiesAndItems, itemElement.MatchOnMetadataLocation);
                         var metadataSplits = ExpressionShredder.SplitSemiColonSeparatedList(metadataExpanded);
                         operationBuilder.MatchOnMetadata.AddRange(metadataSplits);
+                        if (_expander.PropertiesUseTracker.InputRecorder is { } inputRecorder)
+                        {
+                            foreach (string metadataName in metadataSplits)
+                            {
+                                inputRecorder.RecordMetadataName(metadataName);
+                            }
+                        }
                     }
                 }
             }

--- a/src/Build/Evaluation/ParserIgnoreConfiguration.cs
+++ b/src/Build/Evaluation/ParserIgnoreConfiguration.cs
@@ -10,6 +10,7 @@ using Microsoft.Build.BackEnd;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Shared.FileSystem;
+using Microsoft.NET.StringTools;
 
 namespace Microsoft.Build.Evaluation
 {
@@ -67,6 +68,36 @@ namespace Microsoft.Build.Evaluation
         }
 
         internal IReadOnlyCollection<string> LoadedConfigFiles => _loadedConfigFiles;
+
+        /// <summary>
+        /// Hash of the loaded files and every allowed name, independent of enumeration order. Two configurations that
+        /// skip the same elements and attributes have the same fingerprint, so an evaluation cache can key on it.
+        /// </summary>
+        internal long ComputeFingerprint()
+        {
+            long fingerprint = _loadedConfigFiles.Count;
+            foreach (string file in _loadedConfigFiles)
+            {
+                fingerprint ^= FowlerNollVo1aHash.ComputeHash64Fast(file);
+            }
+
+            return fingerprint ^ HashEntries(_allowedAttributes, 1) ^ HashEntries(_allowedChildren, 2);
+
+            static long HashEntries(Dictionary<string, HashSet<string>> entries, long salt)
+            {
+                long hash = 0;
+                foreach (KeyValuePair<string, HashSet<string>> entry in entries)
+                {
+                    long element = FowlerNollVo1aHash.ComputeHash64Fast(entry.Key);
+                    foreach (string name in entry.Value)
+                    {
+                        hash ^= FowlerNollVo1aHash.Combine64(salt, FowlerNollVo1aHash.Combine64(element, FowlerNollVo1aHash.ComputeHash64Fast(name)));
+                    }
+                }
+
+                return hash;
+            }
+        }
 
         internal static ParserIgnoreConfiguration Empty { get; } = new ParserIgnoreConfiguration();
 

--- a/src/Build/Evaluation/PropertiesUseTracker.cs
+++ b/src/Build/Evaluation/PropertiesUseTracker.cs
@@ -6,6 +6,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Build.BackEnd.Logging;
 using Microsoft.Build.Collections;
+using Microsoft.Build.Evaluation.Context;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Experimental.BuildCheck.Infrastructure;
 using Microsoft.Build.Framework;
@@ -22,6 +23,12 @@ namespace Microsoft.Build.Evaluation;
 internal sealed class PropertiesUseTracker
 {
     internal LoggingContext? LoggingContext { get; init; }
+
+    /// <summary>
+    /// Records the inputs property functions consume; null unless the owning evaluation records its inputs.
+    /// Travels with the tracker because the tracker already reaches every property expansion seam.
+    /// </summary>
+    internal EvaluationInputRecorder? InputRecorder { get; set; }
 
     public PropertiesUseTracker(LoggingContext? loggingContext) => LoggingContext = loggingContext;
 

--- a/src/Build/Instance/ProjectInstance.cs
+++ b/src/Build/Instance/ProjectInstance.cs
@@ -1295,6 +1295,11 @@ namespace Microsoft.Build.Execution
         public IReadOnlyList<string> ImportPaths { get; private set; }
 
         /// <summary>
+        /// Inputs recorded during evaluation when <see cref="Traits.RecordEvaluationInputs"/> is set; otherwise null.
+        /// </summary>
+        internal EvaluationInputs EvaluationInputs { get; private set; }
+
+        /// <summary>
         /// This list will contain duplicate imports if an import is imported multiple times. However, only the first import was used in evaluation.
         /// </summary>
         public IReadOnlyList<string> ImportPathsIncludingDuplicates { get; private set; }
@@ -3342,7 +3347,7 @@ namespace Microsoft.Build.Execution
 
             evaluationContext = evaluationContext?.ContextForNewProject() ?? EvaluationContext.Create(EvaluationContext.SharingPolicy.Isolated);
 
-            Evaluator<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.Evaluate(
+            EvaluationInputs = Evaluator<ProjectPropertyInstance, ProjectItemInstance, ProjectMetadataInstance, ProjectItemDefinitionInstance>.Evaluate(
                 data: this,
                 project: null,
                 xml,

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -322,6 +322,7 @@
     <Compile Include="Evaluation\Context\EvaluationContext.cs" />
     <Compile Include="Evaluation\Context\EvaluationInputRecorder.cs" />
     <Compile Include="Evaluation\Context\EvaluationInputs.cs" />
+    <Compile Include="Evaluation\Context\EvaluationInputValidator.cs" />
     <Compile Include="Evaluation\Context\PropertyFunctionEffects.cs" />
     <Compile Include="Evaluation\Context\RecordingFileSystem.cs" />
     <Compile Include="Evaluation\Profiler\EvaluationLocationMarkdownPrettyPrinter.cs" />

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -320,6 +320,8 @@
     <Compile Include="Definition\ProjectEvaluationStage.cs" />
     <Compile Include="Definition\ToolsetLocalReader.cs" />
     <Compile Include="Evaluation\Context\EvaluationContext.cs" />
+    <Compile Include="Evaluation\Context\EvaluationInputRecorder.cs" />
+    <Compile Include="Evaluation\Context\EvaluationInputs.cs" />
     <Compile Include="Evaluation\Profiler\EvaluationLocationMarkdownPrettyPrinter.cs" />
     <Compile Include="Evaluation\Profiler\EvaluationLocationPrettyPrinterBase.cs" />
     <Compile Include="Evaluation\Profiler\EvaluationLocationTabSeparatedPrettyPrinter.cs" />

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -322,6 +322,8 @@
     <Compile Include="Evaluation\Context\EvaluationContext.cs" />
     <Compile Include="Evaluation\Context\EvaluationInputRecorder.cs" />
     <Compile Include="Evaluation\Context\EvaluationInputs.cs" />
+    <Compile Include="Evaluation\Context\PropertyFunctionEffects.cs" />
+    <Compile Include="Evaluation\Context\RecordingFileSystem.cs" />
     <Compile Include="Evaluation\Profiler\EvaluationLocationMarkdownPrettyPrinter.cs" />
     <Compile Include="Evaluation\Profiler\EvaluationLocationPrettyPrinterBase.cs" />
     <Compile Include="Evaluation\Profiler\EvaluationLocationTabSeparatedPrettyPrinter.cs" />

--- a/src/Framework.UnitTests/FileMatcher_Tests.cs
+++ b/src/Framework.UnitTests/FileMatcher_Tests.cs
@@ -2681,6 +2681,90 @@ namespace Microsoft.Build.UnitTests
 
         #endregion
 
+        [Fact]
+        public void SharedCacheHitReportsTraversedDirectoriesWithoutEnumerating()
+        {
+            TransientTestFolder root = _env.CreateFolder(createFolder: true);
+            _env.CreateFile(root, "a.cs", string.Empty);
+            TransientTestFolder sub = _env.CreateFolder(Path.Combine(root.Path, "sub"), createFolder: true);
+            _env.CreateFile(sub, "b.cs", string.Empty);
+            TransientTestFolder empty = _env.CreateFolder(Path.Combine(root.Path, "empty"), createFolder: true);
+            var cache = new ConcurrentDictionary<string, IReadOnlyList<string>>();
+            new FileMatcher(FileSystems.Default, cache, cacheTraversedDirectories: true).GetFiles(root.Path, "**/*.cs").FileList.Length.ShouldBe(2);
+
+            List<string> traversed = [];
+            var reusing = new FileMatcher(new ThrowingFileSystem(), cache, directoryTraversed: traversed.Add, cacheTraversedDirectories: true);
+
+            reusing.GetFiles(root.Path, "**/*.cs").FileList.Length.ShouldBe(2);
+
+            traversed.Select(path => path.TrimEnd(Path.DirectorySeparatorChar)).ShouldBe([root.Path, sub.Path, empty.Path], ignoreOrder: true);
+        }
+
+        [Fact]
+        public void CacheHitWithoutStoredDirectoriesReportsThemByEnumeratingAgain()
+        {
+            // A cache that does not outlive the evaluation stores no directories; a hit then enumerates again through the
+            // entry cache so the recorder still sees every directory.
+            TransientTestFolder root = _env.CreateFolder(createFolder: true);
+            _env.CreateFile(root, "a.cs", string.Empty);
+            var cache = new ConcurrentDictionary<string, IReadOnlyList<string>>();
+            List<string> traversed = [];
+            var matcher = new FileMatcher(FileSystems.Default, cache, directoryTraversed: traversed.Add);
+
+            matcher.GetFiles(root.Path, "*.cs").FileList.Length.ShouldBe(1);
+            traversed.Clear();
+            matcher.GetFiles(root.Path, "*.cs").FileList.Length.ShouldBe(1);
+
+            traversed.Select(path => path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)).ShouldContain(root.Path);
+            cache.Keys.ShouldAllBe(key => !key.EndsWith("\0traversed", StringComparison.Ordinal));
+        }
+
+        [Fact]
+        public void SharedCacheHitReportsTheMissingRootDirectory()
+        {
+            // An expansion rooted in a directory that does not exist is empty; creating the directory changes it, so the
+            // reuse must report the probed root even though nothing was enumerated.
+            TransientTestFolder root = _env.CreateFolder(createFolder: true);
+            string missing = Path.Combine(root.Path, "missing");
+            var cache = new ConcurrentDictionary<string, IReadOnlyList<string>>();
+            new FileMatcher(FileSystems.Default, cache, cacheTraversedDirectories: true).GetFiles(root.Path, "missing/**/*.cs").FileList.ShouldBeEmpty();
+
+            List<string> traversed = [];
+            var reusing = new FileMatcher(new ThrowingFileSystem(), cache, directoryTraversed: traversed.Add, cacheTraversedDirectories: true);
+
+            reusing.GetFiles(root.Path, "missing/**/*.cs").FileList.ShouldBeEmpty();
+
+            traversed.Select(path => path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)).ShouldBe([missing]);
+        }
+
+        /// <summary>Fails every operation, proving a cached expansion is reused without touching the file system.</summary>
+        private sealed class ThrowingFileSystem : IFileSystem
+        {
+            public TextReader ReadFile(string path) => throw new InvalidOperationException(path);
+
+            public Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share) => throw new InvalidOperationException(path);
+
+            public string ReadFileAllText(string path) => throw new InvalidOperationException(path);
+
+            public byte[] ReadFileAllBytes(string path) => throw new InvalidOperationException(path);
+
+            public IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly) => throw new InvalidOperationException(path);
+
+            public IEnumerable<string> EnumerateDirectories(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly) => throw new InvalidOperationException(path);
+
+            public IEnumerable<string> EnumerateFileSystemEntries(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly) => throw new InvalidOperationException(path);
+
+            public FileAttributes GetAttributes(string path) => throw new InvalidOperationException(path);
+
+            public DateTime GetLastWriteTimeUtc(string path) => throw new InvalidOperationException(path);
+
+            public bool DirectoryExists(string path) => throw new InvalidOperationException(path);
+
+            public bool FileExists(string path) => throw new InvalidOperationException(path);
+
+            public bool FileOrDirectoryExists(string path) => throw new InvalidOperationException(path);
+        }
+
         private sealed class FileSystemAdapter : IFileSystem
         {
             private readonly MockFileSystem _mockFileSystem;

--- a/src/Framework/NativeMethods.cs
+++ b/src/Framework/NativeMethods.cs
@@ -16,6 +16,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using Microsoft.Build.Utilities;
 using Microsoft.Build.Shared;
+using Microsoft.Build.Shared.FileSystem;
 using Microsoft.Win32.SafeHandles;
 using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 using Windows.Win32;
@@ -689,6 +690,78 @@ internal static class NativeMethods
     /// Native architecture getter
     /// </summary>
     internal static ProcessorArchitectures ProcessorArchitectureNative => SystemInformation.ProcessorArchitectureTypeNative;
+
+    /// <summary>
+    /// Reads whether a path is a file or a directory, its last write time, and its size with one system call on Windows.
+    /// Returns false when the path does not exist.
+    /// </summary>
+    /// <param name="fullPath">Full path to the file or directory in the filesystem</param>
+    /// <param name="isDirectory">True when the path is a directory</param>
+    /// <param name="isReparsePoint">True when the entry is a reparse point, such as a symbolic link or a junction</param>
+    /// <param name="lastWriteTimeUtc">The UTC last write time</param>
+    /// <param name="length">The file size in bytes, or zero for a directory</param>
+    internal static bool TryGetFileSystemEntry(string fullPath, out bool isDirectory, out bool isReparsePoint, out DateTime lastWriteTimeUtc, out long length)
+    {
+#if FEATURE_WINDOWSINTEROP
+        if (IsWindows)
+        {
+            if (PInvoke.GetFileAttributesEx(fullPath, out WIN32_FILE_ATTRIBUTE_DATA data))
+            {
+                var attributes = (FILE_FLAGS_AND_ATTRIBUTES)data.dwFileAttributes;
+                isDirectory = (attributes & FILE_FLAGS_AND_ATTRIBUTES.FILE_ATTRIBUTE_DIRECTORY) != 0;
+                isReparsePoint = (attributes & FILE_FLAGS_AND_ATTRIBUTES.FILE_ATTRIBUTE_REPARSE_POINT) != 0;
+                lastWriteTimeUtc = DateTime.FromFileTimeUtc(data.ftLastWriteTime.ToLong());
+                length = isDirectory ? 0 : ((long)data.nFileSizeHigh << 32) | data.nFileSizeLow;
+                return true;
+            }
+
+            isDirectory = false;
+            isReparsePoint = false;
+            lastWriteTimeUtc = DateTime.MinValue;
+            length = 0;
+            return false;
+        }
+#endif
+
+        // One stat: FileInfo reports the attributes and timestamp of a directory as well, only Exists and Length are file-specific.
+        var entry = new FileInfo(fullPath);
+        FileAttributes entryAttributes = entry.Attributes;
+        if ((int)entryAttributes == -1)
+        {
+            isDirectory = false;
+            isReparsePoint = false;
+            lastWriteTimeUtc = DateTime.MinValue;
+            length = 0;
+            return false;
+        }
+
+        isDirectory = (entryAttributes & FileAttributes.Directory) != 0;
+        isReparsePoint = (entryAttributes & FileAttributes.ReparsePoint) != 0;
+        lastWriteTimeUtc = entry.LastWriteTimeUtc;
+        length = isDirectory ? 0 : entry.Length;
+        return true;
+    }
+
+    /// <summary>
+    /// True when a Windows entry is a symbolic link or a junction. Other reparse points, such as cloud file placeholders
+    /// and deduplicated files, do not redirect to another path. Always false on other platforms.
+    /// </summary>
+    internal static bool IsSymbolicLinkOrJunction(string fullPath)
+    {
+#if FEATURE_WINDOWSINTEROP
+        if (IsWindows)
+        {
+            const uint MountPointTag = 0xA0000003;
+            const uint SymbolicLinkTag = 0xA000000C;
+            using SafeFindFileHandle handle = WindowsNative.FindFirstFileW(fullPath, out WindowsNative.Win32FindData data);
+            return !handle.IsInvalid
+                && (data.DwFileAttributes & FileAttributes.ReparsePoint) != 0
+                && data.DwReserved0 is MountPointTag or SymbolicLinkTag;
+        }
+#endif
+
+        return false;
+    }
 
     /// <summary>
     /// Get the last write time of the fullpath to a directory. If the pointed path is not a directory, or

--- a/src/Framework/Traits.cs
+++ b/src/Framework/Traits.cs
@@ -60,6 +60,11 @@ namespace Microsoft.Build.Framework
         public readonly bool UseLegacyCultureSensitiveFileGlobs = Environment.GetEnvironmentVariable("MSBUILDUSELEGACYCULTURESENSITIVEFILEGLOBS") == "1";
 
         /// <summary>
+        /// Record the inputs each project evaluation consumes so an evaluation cache can validate them.
+        /// </summary>
+        public readonly bool RecordEvaluationInputs = Environment.GetEnvironmentVariable("MSBUILDRECORDEVALUATIONINPUTS") == "1";
+
+        /// <summary>
         /// Cache file existence for the entire process
         /// </summary>
         public readonly bool CacheFileExistence = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("MsBuildCacheFileExistence"));

--- a/src/Framework/Utilities/FileMatcher.cs
+++ b/src/Framework/Utilities/FileMatcher.cs
@@ -22,6 +22,7 @@ using DirectFileSystemEntry = System.IO.Enumeration.FileSystemEntry;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared.FileSystem;
@@ -157,6 +158,24 @@ namespace Microsoft.Build.Shared
 
         private readonly GetFileSystemEntries _getFileSystemEntries;
 
+        /// <summary>
+        /// Called with every directory a glob enumerates or probes for existence, and with the same directories when a
+        /// cached expansion is reused, so an evaluation input recorder sees the same dependencies either way.
+        /// </summary>
+        private readonly Action<string> _directoryTraversed;
+
+        /// <summary>
+        /// Whether to store the directories an expansion depends on next to its cached file list, for a cache that
+        /// outlives the evaluation and may serve a recorder later.
+        /// </summary>
+        private readonly bool _cacheTraversedDirectories;
+
+        /// <summary>
+        /// Collects the directories the expansion running on the current call chain depends on, so they can be cached
+        /// next to its file list. Flows into the tasks the expansion starts.
+        /// </summary>
+        private static readonly AsyncLocal<ConcurrentBag<string>> s_traversedDirectories = new();
+
         private static class FileSpecRegexParts
         {
             internal const string BeginningOfLine = "^";
@@ -190,7 +209,9 @@ namespace Microsoft.Build.Shared
             IFileSystem fileSystem,
             ConcurrentDictionary<string, IReadOnlyList<string>> fileEntryExpansionCache = null,
             FileMatcherImplementation implementation = FileMatcherImplementation.Auto,
-            FileMatcherCaseFolding caseFolding = FileMatcherCaseFolding.Auto) : this(
+            FileMatcherCaseFolding caseFolding = FileMatcherCaseFolding.Auto,
+            Action<string> directoryTraversed = null,
+            bool cacheTraversedDirectories = false) : this(
             fileSystem,
             (entityType, path, pattern, projectDirectory, stripProjectDirectory) => GetAccessibleFileSystemEntries(
                 fileSystem,
@@ -202,7 +223,9 @@ namespace Microsoft.Build.Shared
             fileEntryExpansionCache,
             implementation,
             allowDirectEnumeration: true,
-            caseFolding)
+            caseFolding,
+            directoryTraversed,
+            cacheTraversedDirectories)
         {
         }
 
@@ -212,8 +235,12 @@ namespace Microsoft.Build.Shared
             ConcurrentDictionary<string, IReadOnlyList<string>> getFileSystemDirectoryEntriesCache = null,
             FileMatcherImplementation implementation = FileMatcherImplementation.Auto,
             bool allowDirectEnumeration = false,
-            FileMatcherCaseFolding caseFolding = FileMatcherCaseFolding.Auto)
+            FileMatcherCaseFolding caseFolding = FileMatcherCaseFolding.Auto,
+            Action<string> directoryTraversed = null,
+            bool cacheTraversedDirectories = false)
         {
+            _directoryTraversed = directoryTraversed;
+            _cacheTraversedDirectories = cacheTraversedDirectories;
             if (Traits.Instance.MSBuildCacheFileEnumerations)
             {
                 _cachedGlobExpansions = s_cachedGlobExpansions.Value;
@@ -230,7 +257,7 @@ namespace Microsoft.Build.Shared
             _allowDirectEnumeration = allowDirectEnumeration;
             _usesFileSystemEntryCache = getFileSystemDirectoryEntriesCache is not null;
 
-            _getFileSystemEntries = getFileSystemDirectoryEntriesCache == null
+            GetFileSystemEntries entries = getFileSystemDirectoryEntriesCache == null
                 ? getFileSystemEntries
                 : (type, path, pattern, directory, stripProjectDirectory) =>
                 {
@@ -257,6 +284,31 @@ namespace Microsoft.Build.Shared
                         ? RemoveProjectDirectory(filteredEntriesForPath, directory).ToList()
                         : filteredEntriesForPath.ToList();
                 };
+
+            // Only a matcher that reports or stores the directories it depends on pays for a call per directory.
+            _getFileSystemEntries = directoryTraversed == null && !cacheTraversedDirectories
+                ? entries
+                : (type, path, pattern, directory, stripProjectDirectory) =>
+                {
+                    NoteTraversal(path);
+                    return entries(type, path, pattern, directory, stripProjectDirectory);
+                };
+        }
+
+        /// <summary>
+        /// Reports a directory an expansion depends on: one it enumerates, whether the entries come from the file system
+        /// or the entry cache, or the root whose existence it probes. Nothing to do, and no async-local read, unless
+        /// this matcher reports or stores them.
+        /// </summary>
+        private void NoteTraversal(string path)
+        {
+            if (_directoryTraversed is null && !_cacheTraversedDirectories)
+            {
+                return;
+            }
+
+            _directoryTraversed?.Invoke(path);
+            s_traversedDirectories.Value?.Add(path);
         }
 
         /// <summary>
@@ -2100,6 +2152,10 @@ namespace Microsoft.Build.Shared
                 selection,
                 ResolvedCaseFolding);
 
+            // An evaluation input recorder needs the directories an expansion depends on even when the expansion comes from
+            // the cache, so a cache that outlives the evaluation stores them next to the file list.
+            string? traversalKey = _cacheTraversedDirectories ? enumerationKey + "\0traversed" : null;
+
             IReadOnlyList<string>? files;
             string[] fileList;
             SearchAction action = SearchAction.None;
@@ -2117,22 +2173,84 @@ namespace Microsoft.Build.Shared
                                 enumerationKey,
                                 (_) =>
                                 {
-                                    (fileList, action, excludeFileSpec, globFailure) = GetFilesForImplementation(
-                                        projectDirectoryUnescaped,
-                                        filespecUnescaped,
-                                        excludeSpecsUnescaped,
-                                        selection);
+                                    (fileList, action, excludeFileSpec, globFailure) = Expand();
 
                                     return fileList;
                                 });
                     }
+                    else if (_directoryTraversed != null && !ReplayTraversal(traversalKey))
+                    {
+                        (fileList, action, excludeFileSpec, globFailure) = Expand();
+                        files = fileList;
+                    }
                 }
+            }
+            else if (_directoryTraversed != null && !ReplayTraversal(traversalKey))
+            {
+                // The expansion was cached without its directories, so enumerate again for the recorder's benefit; the
+                // directory entries themselves come from the entry cache.
+                (fileList, action, excludeFileSpec, globFailure) = Expand();
+                files = fileList;
             }
 
             // Copy the file enumerations to prevent outside modifications of the cache (e.g. sorting, escaping) and to maintain the original method contract that a new array is created on each call.
             var filesToReturn = files.ToArray();
 
             return (filesToReturn, action, excludeFileSpec, globFailure);
+
+            (string[] FileList, SearchAction Action, string ExcludeFileSpec, string? GlobFailure) Expand()
+            {
+                if (traversalKey is null)
+                {
+                    return GetFilesForImplementation(projectDirectoryUnescaped, filespecUnescaped, excludeSpecsUnescaped, selection);
+                }
+
+                ConcurrentBag<string>? outer = s_traversedDirectories.Value;
+                var traversed = new ConcurrentBag<string>();
+                s_traversedDirectories.Value = traversed;
+                try
+                {
+                    var result = GetFilesForImplementation(projectDirectoryUnescaped, filespecUnescaped, excludeSpecsUnescaped, selection);
+                    _cachedGlobExpansions[traversalKey] = Distinct(traversed);
+                    return result;
+                }
+                finally
+                {
+                    s_traversedDirectories.Value = outer;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Hands the directories a cached expansion depends on to the recorder. False when the expansion was cached
+        /// without them.
+        /// </summary>
+        private bool ReplayTraversal(string? traversalKey)
+        {
+            if (traversalKey is null || !_cachedGlobExpansions.TryGetValue(traversalKey, out IReadOnlyList<string>? traversed))
+            {
+                return false;
+            }
+
+            foreach (string directory in traversed)
+            {
+                _directoryTraversed(directory);
+            }
+
+            return true;
+        }
+
+        private static string[] Distinct(ConcurrentBag<string> paths)
+        {
+            var distinct = new HashSet<string>(FileUtilities.PathComparer);
+            foreach (string path in paths)
+            {
+                distinct.Add(path);
+            }
+
+            string[] result = new string[distinct.Count];
+            distinct.CopyTo(result);
+            return result;
         }
 #nullable disable
 
@@ -2259,11 +2377,15 @@ namespace Microsoft.Build.Shared
 
             /*
              * If the fixed directory part doesn't exist, then this means no files should be
-             * returned.
+             * returned. The probe is a dependency of the expansion: creating the directory changes the result.
              */
-            if (fixedDirectoryPart.Length > 0 && !_fileSystem.DirectoryExists(fixedDirectoryPart))
+            if (fixedDirectoryPart.Length > 0)
             {
-                return SearchAction.ReturnEmptyList;
+                NoteTraversal(fixedDirectoryPart);
+                if (!_fileSystem.DirectoryExists(fixedDirectoryPart))
+                {
+                    return SearchAction.ReturnEmptyList;
+                }
             }
 
             /*

--- a/src/MSBuild.Benchmarks/EvaluationInputDetoursComparison.cs
+++ b/src/MSBuild.Benchmarks/EvaluationInputDetoursComparison.cs
@@ -1,0 +1,344 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if EVALUATION_INPUT_DETOURS
+using System.Collections;
+using System.Runtime.InteropServices;
+using BuildXL.Processes;
+using BuildXL.Utilities.Core;
+using static BuildXL.Processes.FileAccessManifest;
+
+namespace MSBuild.Benchmarks;
+
+/// <summary>
+/// Runs <see cref="EvaluationInputRecordHost"/> under BuildXL Detours and compares every file system path the process
+/// touched during evaluation with the paths the recorder wrote down. A touched path is explained when it was recorded, or
+/// when it was only probed or enumerated and its parent directory was recorded, since a recorded directory's timestamp covers
+/// its membership but not the content of its files. Everything else is printed for attribution, reads separately. Opt-in: build with <c>-p:EnableEvaluationInputDetours=true</c> on Windows x64.
+/// </summary>
+internal static class EvaluationInputDetoursComparison
+{
+    internal const string Switch = "--evaluation-input-detours";
+    private const string RecordingVariable = "MSBUILDRECORDEVALUATIONINPUTS";
+
+    internal static bool TryRun(List<string> args, out int exitCode)
+    {
+        if (!args.Remove(Switch))
+        {
+            exitCode = 0;
+            return false;
+        }
+
+        string project = Path.GetFullPath(HarnessArguments.Take(args, "--project"));
+        Dictionary<string, string> globalProperties = HarnessArguments.TakeGlobalProperties(args);
+        HarnessArguments.ExpectEmpty(args);
+
+        if (RuntimeInformation.ProcessArchitecture != Architecture.X64)
+        {
+            throw new PlatformNotSupportedException($"Detours requires x64, but this process is {RuntimeInformation.ProcessArchitecture}.");
+        }
+
+        string resultFile = Path.GetTempFileName();
+        try
+        {
+            var listener = new AccessListener(Path.GetDirectoryName(project)!);
+            listener.SetMessageHandlingFlags(
+                MessageHandlingFlags.DebugMessageNotify |
+                MessageHandlingFlags.FileAccessNotify |
+                MessageHandlingFlags.ProcessDataNotify |
+                MessageHandlingFlags.ProcessDetoursStatusNotify);
+
+            SandboxedProcessInfo info = CreateProcessInfo(ChildArguments(project, globalProperties, resultFile), listener);
+            using ISandboxedProcess process = SandboxedProcessFactory.StartAsync(info, forceSandboxing: false).GetAwaiter().GetResult();
+            SandboxedProcessResult processResult = process.GetResultAsync().GetAwaiter().GetResult();
+            Validate(processResult, listener);
+
+            Dictionary<string, string> recorded = ReadRecorded(resultFile, out string summary);
+            Dictionary<string, bool> touched = listener.Paths;
+            int overlap = 0;
+            int owned = 0;
+            List<string> unexplainedProbes = [];
+            List<string> unexplainedReads = [];
+            foreach (KeyValuePair<string, bool> access in touched)
+            {
+                string path = access.Key;
+                bool readContent = access.Value;
+                if (recorded.ContainsKey(path))
+                {
+                    overlap++;
+                }
+                else if (!readContent && recorded.TryGetValue(Path.GetDirectoryName(path) ?? string.Empty, out string? parentKind) && parentKind == "Directory")
+                {
+                    // A probe or enumeration under a recorded directory is covered by that directory's timestamp; a read is not.
+                    owned++;
+                }
+                else
+                {
+                    (readContent ? unexplainedReads : unexplainedProbes).Add(path);
+                }
+            }
+
+            unexplainedProbes.Sort(StringComparer.OrdinalIgnoreCase);
+            unexplainedReads.Sort(StringComparer.OrdinalIgnoreCase);
+            Console.WriteLine(
+                $"EVALUATION_INPUT_DETOURS|Accesses={listener.AccessCount}|TouchedPaths={touched.Count}|RecordedPaths={recorded.Count}" +
+                $"|Overlap={overlap}|OwnedByRecordedDirectory={owned}|RecordedOnly={recorded.Count - overlap}" +
+                $"|DetoursOnly={unexplainedProbes.Count + unexplainedReads.Count}|DetoursOnlyReads={unexplainedReads.Count}|{summary}");
+            foreach (string path in unexplainedProbes)
+            {
+                Console.WriteLine("DETOURS_ONLY|" + path);
+            }
+
+            foreach (string path in unexplainedReads)
+            {
+                Console.WriteLine("DETOURS_ONLY_READ|" + path);
+            }
+
+            foreach (KeyValuePair<string, string> entry in recorded)
+            {
+                if (!touched.ContainsKey(entry.Key))
+                {
+                    Console.WriteLine($"RECORDED_ONLY|{entry.Value}|{entry.Key}");
+                }
+            }
+
+            exitCode = 0;
+            return true;
+        }
+        finally
+        {
+            File.Delete(resultFile);
+        }
+    }
+
+    private static string ChildArguments(string project, Dictionary<string, string> globalProperties, string resultFile)
+    {
+        var arguments = new System.Text.StringBuilder();
+        arguments.Append(HarnessArguments.Quote(typeof(EvaluationInputDetoursComparison).Assembly.Location))
+            .Append(' ').Append(EvaluationInputRecordHost.Switch)
+            .Append(" --project ").Append(HarnessArguments.Quote(project))
+            .Append(" --result-file ").Append(HarnessArguments.Quote(resultFile));
+        foreach (KeyValuePair<string, string> property in globalProperties)
+        {
+            arguments.Append(" --global-property ").Append(HarnessArguments.Quote($"{property.Key}={property.Value}"));
+        }
+
+        return arguments.ToString();
+    }
+
+    private static SandboxedProcessInfo CreateProcessInfo(string arguments, AccessListener listener)
+    {
+        var info = new SandboxedProcessInfo(
+            fileStorage: null,
+            fileName: Environment.ProcessPath ?? throw new InvalidOperationException("The host executable path is unknown."),
+            disableConHostSharing: false,
+            detoursEventListener: listener,
+            createJobObjectForCurrentProcess: false)
+        {
+            SandboxKind = SandboxKind.Default,
+            PipDescription = "MSBuild evaluation input recording",
+            PipSemiStableHash = 0,
+            Arguments = arguments,
+            EnvironmentVariables = ChildEnvironment(),
+            MaxLengthInMemory = 0,
+        };
+
+        info.FileAccessManifest.AddScope(AbsolutePath.Invalid, FileAccessPolicy.MaskNothing, FileAccessPolicy.AllowAll | FileAccessPolicy.ReportAccess);
+        info.FileAccessManifest.MonitorChildProcesses = true;
+        info.FileAccessManifest.IgnoreReparsePoints = true;
+        info.FileAccessManifest.UseExtraThreadToDrainNtClose = false;
+        info.FileAccessManifest.UseLargeNtClosePreallocatedList = true;
+        info.FileAccessManifest.LogProcessData = true;
+        info.FileAccessManifest.ReportProcessArgs = true;
+        info.FileAccessManifest.NormalizeReadTimestamps = false;
+        info.NestedProcessTerminationTimeout = TimeSpan.Zero;
+        return info;
+    }
+
+    private static BuildParameters.IBuildParameters ChildEnvironment()
+    {
+        Dictionary<string, string> variables = new(StringComparer.OrdinalIgnoreCase);
+        foreach (DictionaryEntry variable in Environment.GetEnvironmentVariables())
+        {
+            variables[(string)variable.Key] = (string)variable.Value!;
+        }
+
+        variables[RecordingVariable] = "1";
+        return BuildParameters.GetFactory().PopulateFromDictionary(variables);
+    }
+
+    private static void Validate(SandboxedProcessResult result, AccessListener listener)
+    {
+        if (result.ExitCode != 0 || result.Killed || result.TimedOut || result.HasDetoursInjectionFailures ||
+            result.MessageProcessingFailure is not null || !listener.StartObserved || !listener.StopObserved || listener.AccessCount == 0)
+        {
+            string standardError = result.StandardError?.ReadValueAsync().GetAwaiter().GetResult() ?? string.Empty;
+            string standardOutput = result.StandardOutput?.ReadValueAsync().GetAwaiter().GetResult() ?? string.Empty;
+            throw new InvalidOperationException(
+                $"Detours run failed. ExitCode={result.ExitCode} Killed={result.Killed} TimedOut={result.TimedOut} " +
+                $"InjectionFailures={result.HasDetoursInjectionFailures} MessageFailure={result.MessageProcessingFailure is not null} " +
+                $"Start={listener.StartObserved} Stop={listener.StopObserved} Accesses={listener.AccessCount}" +
+                $"{Environment.NewLine}{standardOutput}{Environment.NewLine}{standardError}");
+        }
+    }
+
+    private static Dictionary<string, string> ReadRecorded(string resultFile, out string summary)
+    {
+        Dictionary<string, string> recorded = new(StringComparer.OrdinalIgnoreCase);
+        summary = string.Empty;
+        foreach (string line in File.ReadLines(resultFile))
+        {
+            if (line.StartsWith(EvaluationInputRecordHost.RecordedPrefix, StringComparison.Ordinal))
+            {
+                string[] parts = line.Substring(EvaluationInputRecordHost.RecordedPrefix.Length).Split('|');
+                recorded[EvaluationInputRecordHost.Decode(parts[1])] = parts[0];
+            }
+            else if (line.StartsWith(EvaluationInputRecordHost.SummaryPrefix, StringComparison.Ordinal))
+            {
+                summary = line.Substring(EvaluationInputRecordHost.SummaryPrefix.Length);
+            }
+        }
+
+        if (summary.Length == 0)
+        {
+            throw new InvalidOperationException("The record host did not write a summary.");
+        }
+
+        return recorded;
+    }
+
+    /// <summary>
+    /// Collects every normalized path the sandboxed process touched between the start and stop marker probes.
+    /// </summary>
+    private sealed class AccessListener : IDetoursEventListener
+    {
+        private readonly string _startMarker;
+        private readonly string _stopMarker;
+        // Path to whether any access read or wrote its content rather than probing or enumerating it.
+        private readonly Dictionary<string, bool> _paths = new(StringComparer.OrdinalIgnoreCase);
+        private int _accessCount;
+        private volatile bool _counting;
+        private volatile bool _startObserved;
+        private volatile bool _stopObserved;
+
+        internal AccessListener(string measurementRoot)
+        {
+            _startMarker = Path.Combine(measurementRoot, EvaluationInputRecordHost.StartMarker);
+            _stopMarker = Path.Combine(measurementRoot, EvaluationInputRecordHost.StopMarker);
+        }
+
+        internal int AccessCount => Volatile.Read(ref _accessCount);
+
+        internal bool StartObserved => _startObserved;
+
+        internal bool StopObserved => _stopObserved;
+
+        internal Dictionary<string, bool> Paths
+        {
+            get
+            {
+                lock (_paths)
+                {
+                    return new Dictionary<string, bool>(_paths, StringComparer.OrdinalIgnoreCase);
+                }
+            }
+        }
+
+        public override void HandleFileAccess(IDetoursEventListener.FileAccessData fileAccessData)
+        {
+            string? path = Normalize(fileAccessData.Path);
+            if (path is null)
+            {
+                return;
+            }
+
+            if (string.Equals(path, _startMarker, StringComparison.OrdinalIgnoreCase))
+            {
+                _startObserved = true;
+                _counting = true;
+                return;
+            }
+
+            if (string.Equals(path, _stopMarker, StringComparison.OrdinalIgnoreCase))
+            {
+                _stopObserved = true;
+                _counting = false;
+                return;
+            }
+
+            if (!_counting)
+            {
+                return;
+            }
+
+            bool readContent = (fileAccessData.RequestedAccess & (RequestedAccess.Read | RequestedAccess.Write)) != 0;
+            Interlocked.Increment(ref _accessCount);
+            lock (_paths)
+            {
+                _paths[path] = readContent || (_paths.TryGetValue(path, out bool earlier) && earlier);
+            }
+        }
+
+        public override void HandleDebugMessage(DebugData debugData)
+        {
+        }
+
+        public override void HandleProcessData(IDetoursEventListener.ProcessData processData)
+        {
+        }
+
+        public override void HandleProcessDetouringStatus(ProcessDetouringStatusData data)
+        {
+        }
+
+        /// <summary>
+        /// Turns a Detours path into a full DOS path; pipes, devices, and other non-file paths return null.
+        /// </summary>
+        private static string? Normalize(string path)
+        {
+            if (path.StartsWith(@"\??\UNC\", StringComparison.OrdinalIgnoreCase) || path.StartsWith(@"\\?\UNC\", StringComparison.OrdinalIgnoreCase))
+            {
+                path = @"\\" + path.Substring(8);
+            }
+            else if (path.StartsWith(@"\??\", StringComparison.Ordinal) || path.StartsWith(@"\\?\", StringComparison.Ordinal) || path.StartsWith(@"\\.\", StringComparison.Ordinal))
+            {
+                path = path.Substring(4);
+            }
+
+            bool dosPath = path.Length >= 3 && char.IsLetter(path[0]) && path[1] == ':' && (path[2] == '\\' || path[2] == '/');
+            if (!dosPath && !path.StartsWith(@"\\", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            try
+            {
+                path = Path.GetFullPath(path.Replace('/', '\\'));
+                return string.Equals(path, Path.GetPathRoot(path), StringComparison.OrdinalIgnoreCase) ? path : path.TrimEnd('\\');
+            }
+            catch (Exception exception) when (exception is ArgumentException or NotSupportedException or PathTooLongException)
+            {
+                return null;
+            }
+        }
+    }
+}
+#else
+namespace MSBuild.Benchmarks;
+
+internal static class EvaluationInputDetoursComparison
+{
+    internal const string Switch = "--evaluation-input-detours";
+
+    internal static bool TryRun(List<string> args, out int exitCode)
+    {
+        if (args.Contains(Switch))
+        {
+            throw new PlatformNotSupportedException("Build with -p:EnableEvaluationInputDetours=true on Windows x64 to use the Detours comparison.");
+        }
+
+        exitCode = 0;
+        return false;
+    }
+}
+#endif

--- a/src/MSBuild.Benchmarks/EvaluationInputRecordHost.cs
+++ b/src/MSBuild.Benchmarks/EvaluationInputRecordHost.cs
@@ -1,0 +1,70 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using Microsoft.Build.Definition;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Evaluation.Context;
+using Microsoft.Build.Execution;
+
+namespace MSBuild.Benchmarks;
+
+/// <summary>
+/// Child process of <see cref="EvaluationInputDetoursComparison"/>. Evaluates one project with input recording on and
+/// writes the recorded paths to a result file. The parent runs it inside the Detours sandbox and observes its file accesses
+/// between the two marker probes.
+/// </summary>
+internal static class EvaluationInputRecordHost
+{
+    internal const string Switch = "--evaluation-input-record-host";
+    internal const string StartMarker = ".evaluation-input-measure-start";
+    internal const string StopMarker = ".evaluation-input-measure-stop";
+    internal const string RecordedPrefix = "RECORDED|";
+    internal const string SummaryPrefix = "SUMMARY|";
+
+    internal static bool TryRun(List<string> args, out int exitCode)
+    {
+        if (!args.Remove(Switch))
+        {
+            exitCode = 0;
+            return false;
+        }
+
+        string project = Path.GetFullPath(HarnessArguments.Take(args, "--project"));
+        string resultFile = HarnessArguments.Take(args, "--result-file");
+        Dictionary<string, string> globalProperties = HarnessArguments.TakeGlobalProperties(args);
+        HarnessArguments.ExpectEmpty(args);
+
+        string measurementRoot = Path.GetDirectoryName(project)!;
+        using var collection = new ProjectCollection(globalProperties);
+        var options = new ProjectOptions { ProjectCollection = collection, GlobalProperties = globalProperties };
+
+        _ = File.Exists(Path.Combine(measurementRoot, StartMarker));
+        ProjectInstance instance = ProjectInstance.FromFile(project, options);
+        _ = File.Exists(Path.Combine(measurementRoot, StopMarker));
+
+        EvaluationInputs inputs = instance.EvaluationInputs
+            ?? throw new InvalidOperationException("Recording is off; the parent must set MSBUILDRECORDEVALUATIONINPUTS=1.");
+
+        var result = new StringBuilder();
+        foreach (KeyValuePair<string, FileDependency> file in inputs.Files)
+        {
+            result.Append(RecordedPrefix).Append(file.Value.Kind).Append('|').AppendLine(Encode(file.Key));
+        }
+
+        result.Append(SummaryPrefix)
+            .Append("NonCacheable=").Append(inputs.NonCacheable)
+            .Append("|EnvironmentReads=").Append(inputs.EnvironmentReads.Count)
+            .Append("|SdkResolutions=").Append(inputs.SdkResolutions.Length)
+            .Append("|RegistryReads=").Append(inputs.RegistryReads.Length)
+            .Append("|Detail=").AppendLine(Encode(inputs.NonCacheableDetail ?? string.Empty));
+        File.WriteAllText(resultFile, result.ToString());
+
+        exitCode = 0;
+        return true;
+    }
+
+    internal static string Encode(string value) => Convert.ToBase64String(Encoding.UTF8.GetBytes(value));
+
+    internal static string Decode(string value) => Encoding.UTF8.GetString(Convert.FromBase64String(value));
+}

--- a/src/MSBuild.Benchmarks/EvaluationInputRecordingBenchmark.cs
+++ b/src/MSBuild.Benchmarks/EvaluationInputRecordingBenchmark.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.Build.Evaluation.Context;
+
+namespace MSBuild.Benchmarks;
+
+/// <summary>
+/// Measures observation-layer overhead in isolated and shared evaluation contexts.
+/// Filesystem validation is measured separately by <see cref="EvaluationInputValidationBenchmark"/>.
+/// </summary>
+[MemoryDiagnoser]
+public class EvaluationInputRecordingBenchmark
+{
+    private EvaluationInputBenchmarkFixture _fixture = null!;
+    private EvaluationContext _sharedContext = null!;
+
+    [ParamsSource(nameof(ProjectPaths))]
+    public string ProjectPath { get; set; } = EvaluationInputBenchmarkFixture.SyntheticProject;
+
+    public static IEnumerable<string> ProjectPaths => EvaluationInputBenchmarkFixture.ProjectPaths;
+
+    [GlobalSetup(Targets = [nameof(Evaluate), nameof(EvaluateSharedContext)])]
+    public void SetupWithoutRecording() => Setup(record: false);
+
+    [GlobalSetup(Targets = [nameof(EvaluateRecording), nameof(EvaluateRecordingSharedContext)])]
+    public void SetupWithRecording() => Setup(record: true);
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        EvaluationInputBenchmarkFixture.SetRecording(enabled: false);
+        _fixture?.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public int Evaluate() => _fixture.EvaluateProject().GetItems("Compile").Count;
+
+    [Benchmark]
+    public int EvaluateRecording() => _fixture.EvaluateProject().GetItems("Compile").Count;
+
+    /// <summary>Evaluation through one shared <see cref="EvaluationContext"/>, whose glob and SDK caches stay warm across evaluations as in a graph build.</summary>
+    [Benchmark]
+    public int EvaluateSharedContext() => _fixture.EvaluateProject(_sharedContext).GetItems("Compile").Count;
+
+    /// <summary>The shared-context evaluation with recording: cached glob expansions are reused and the directories they depend on are replayed to the recorder.</summary>
+    [Benchmark]
+    public int EvaluateRecordingSharedContext() => _fixture.EvaluateProject(_sharedContext).GetItems("Compile").Count;
+
+    private void Setup(bool record)
+    {
+        _fixture = new EvaluationInputBenchmarkFixture(ProjectPath);
+        _sharedContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
+        _fixture.RecordInputs();
+        EvaluationInputBenchmarkFixture.SetRecording(record);
+    }
+}

--- a/src/MSBuild.Benchmarks/EvaluationInputValidationBenchmark.cs
+++ b/src/MSBuild.Benchmarks/EvaluationInputValidationBenchmark.cs
@@ -1,0 +1,173 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+using Microsoft.Build.Evaluation.Context;
+
+namespace MSBuild.Benchmarks;
+
+/// <summary>
+/// Measures filesystem validation of unchanged and stale evaluation inputs.
+/// Evaluation and input capture happen only during setup.
+/// </summary>
+[MemoryDiagnoser]
+public class EvaluationInputValidationBenchmark
+{
+    private EvaluationInputBenchmarkFixture _fixture = null!;
+    private string? _importPath;
+    private string? _globDirectory;
+    private string? _globMemberPath;
+    private DateTime _projectWriteTime;
+    private DateTime _importWriteTime;
+    private bool _globMemberCreated;
+
+    [ParamsSource(nameof(ProjectPaths))]
+    public string ProjectPath { get; set; } = EvaluationInputBenchmarkFixture.SyntheticProject;
+
+    public static IEnumerable<string> ProjectPaths => EvaluationInputBenchmarkFixture.ProjectPaths;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _fixture = new EvaluationInputBenchmarkFixture(ProjectPath);
+        _fixture.RecordInputs();
+        _importPath = FindNearestImport();
+        _globDirectory = FindShallowestDirectoryUnderProject();
+        if (_globDirectory is not null)
+        {
+            _globMemberPath = Path.Combine(_globDirectory, $"evaluation-inputs-benchmark-{Guid.NewGuid():N}.tmp");
+        }
+        Console.WriteLine($"// stale import {_importPath}, glob directory {_globDirectory}");
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
+    {
+        try
+        {
+            RemoveGlobMember();
+        }
+        finally
+        {
+            EvaluationInputBenchmarkFixture.SetRecording(enabled: false);
+            _fixture?.Dispose();
+        }
+    }
+
+    [IterationSetup(Target = nameof(ValidateStaleProjectFile))]
+    public void TouchProjectFile() => _projectWriteTime = Touch(_fixture.ProjectPath);
+
+    [IterationCleanup(Target = nameof(ValidateStaleProjectFile))]
+    public void RestoreProjectFile() => File.SetLastWriteTimeUtc(_fixture.ProjectPath, _projectWriteTime);
+
+    [IterationSetup(Target = nameof(ValidateStaleImportedFile))]
+    public void TouchImportedFile() => _importWriteTime = Touch(ImportPath);
+
+    [IterationCleanup(Target = nameof(ValidateStaleImportedFile))]
+    public void RestoreImportedFile() => File.SetLastWriteTimeUtc(ImportPath, _importWriteTime);
+
+    [IterationSetup(Target = nameof(ValidateStaleGlobMembership))]
+    public void AddGlobMember()
+    {
+        using FileStream stream = new(GlobMemberPath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+        _globMemberCreated = true;
+    }
+
+    [IterationCleanup(Target = nameof(ValidateStaleGlobMembership))]
+    public void RemoveGlobMember()
+    {
+        if (_globMemberCreated)
+        {
+            File.Delete(GlobMemberPath);
+            _globMemberCreated = false;
+        }
+    }
+
+    /// <summary>Unchanged file/directory validation only; environment reads, SDK results, registry reads, and request identity are not checked.</summary>
+    [Benchmark]
+    public bool ValidateUnchanged() => Validate();
+
+    /// <summary>Validation after the project file's timestamp moved; the result is false.</summary>
+    [Benchmark]
+    public bool ValidateStaleProjectFile() => Validate();
+
+    /// <summary>Validation after the timestamp of the recorded import nearest the project moved; the result is false.</summary>
+    [Benchmark]
+    public bool ValidateStaleImportedFile() => Validate();
+
+    /// <summary>Validation after a file appeared in a directory a glob traversed, which moves the directory's timestamp; the result is false.</summary>
+    [Benchmark]
+    public bool ValidateStaleGlobMembership() => Validate();
+
+    private bool Validate() => EvaluationInputValidator.IsFileSystemCurrent(_fixture.Inputs, out _);
+
+    private string ImportPath =>
+        _importPath ?? throw new NotSupportedException($"{_fixture.ProjectPath} records no imported .props or .targets file.");
+
+    private string GlobMemberPath =>
+        _globMemberPath ?? throw new NotSupportedException($"{_fixture.ProjectPath} records no directory under the project.");
+
+    /// <summary>
+    /// Moves a file's timestamp forward by two seconds and returns the original, so file systems with coarse timestamps see a change.
+    /// </summary>
+    private static DateTime Touch(string path)
+    {
+        DateTime original = File.GetLastWriteTimeUtc(path);
+        File.SetLastWriteTimeUtc(path, original.AddSeconds(2));
+        return original;
+    }
+
+    /// <summary>
+    /// The recorded .props or .targets file sharing the longest path prefix with the project: the import a developer edits,
+    /// not one inside the SDK.
+    /// </summary>
+    private string? FindNearestImport()
+    {
+        string? nearest = null;
+        int longestShared = -1;
+        foreach (KeyValuePair<string, FileDependency> file in _fixture.Inputs.Files)
+        {
+            string extension = Path.GetExtension(file.Key);
+            if (file.Value.Kind != PathKind.File
+                || string.Equals(file.Key, _fixture.ProjectPath, StringComparison.OrdinalIgnoreCase)
+                || !(extension.Equals(".props", StringComparison.OrdinalIgnoreCase) || extension.Equals(".targets", StringComparison.OrdinalIgnoreCase)))
+            {
+                continue;
+            }
+
+            int shared = 0;
+            while (shared < file.Key.Length && shared < _fixture.ProjectPath.Length && char.ToUpperInvariant(file.Key[shared]) == char.ToUpperInvariant(_fixture.ProjectPath[shared]))
+            {
+                shared++;
+            }
+
+            if (shared > longestShared)
+            {
+                longestShared = shared;
+                nearest = file.Key;
+            }
+        }
+
+        return nearest;
+    }
+
+    /// <summary>
+    /// The shallowest recorded directory at or below the project directory, which a glob traversed.
+    /// </summary>
+    private string? FindShallowestDirectoryUnderProject()
+    {
+        string projectDirectory = Path.GetDirectoryName(_fixture.ProjectPath)!;
+        string? shallowest = null;
+        foreach (KeyValuePair<string, FileDependency> file in _fixture.Inputs.Files)
+        {
+            bool underProject = string.Equals(file.Key, projectDirectory, StringComparison.OrdinalIgnoreCase)
+                || file.Key.StartsWith(projectDirectory + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase);
+            if (file.Value.Kind == PathKind.Directory && underProject && (shallowest is null || file.Key.Length < shallowest.Length))
+            {
+                shallowest = file.Key;
+            }
+        }
+
+        return shallowest;
+    }
+}

--- a/src/MSBuild.Benchmarks/HarnessArguments.cs
+++ b/src/MSBuild.Benchmarks/HarnessArguments.cs
@@ -1,0 +1,58 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace MSBuild.Benchmarks;
+
+/// <summary>
+/// Argument parsing shared by the evaluation input harness entry points.
+/// </summary>
+internal static class HarnessArguments
+{
+    internal static string Take(List<string> args, string name)
+    {
+        int index = args.IndexOf(name);
+        if (index < 0 || index + 1 >= args.Count)
+        {
+            throw new ArgumentException($"Missing required argument '{name}'.");
+        }
+
+        string value = args[index + 1];
+        args.RemoveRange(index, 2);
+        return value;
+    }
+
+    internal static Dictionary<string, string> TakeGlobalProperties(List<string> args)
+    {
+        Dictionary<string, string> properties = new(StringComparer.OrdinalIgnoreCase);
+        int index;
+        while ((index = args.IndexOf("--global-property")) >= 0)
+        {
+            if (index + 1 >= args.Count)
+            {
+                throw new ArgumentException("Missing value for '--global-property'.");
+            }
+
+            string assignment = args[index + 1];
+            args.RemoveRange(index, 2);
+            int separator = assignment.IndexOf('=');
+            if (separator <= 0)
+            {
+                throw new ArgumentException($"Global property '{assignment}' must use the form Name=Value.");
+            }
+
+            properties[assignment.Substring(0, separator)] = assignment.Substring(separator + 1);
+        }
+
+        return properties;
+    }
+
+    internal static void ExpectEmpty(List<string> args)
+    {
+        if (args.Count != 0)
+        {
+            throw new ArgumentException($"Unexpected arguments: {string.Join(" ", args)}");
+        }
+    }
+
+    internal static string Quote(string value) => string.Concat("\"", value.Replace("\"", "\\\""), "\"");
+}

--- a/src/MSBuild.Benchmarks/Infrastructure/EvaluationInputBenchmarkFixture.cs
+++ b/src/MSBuild.Benchmarks/Infrastructure/EvaluationInputBenchmarkFixture.cs
@@ -1,0 +1,173 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Text;
+using Microsoft.Build.Definition;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Evaluation.Context;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+
+namespace MSBuild.Benchmarks;
+
+/// <summary>
+/// Shared project setup and input capture for the recording and filesystem-validation benchmarks.
+/// </summary>
+/// <remarks>
+/// <para>
+/// By default the benchmark evaluates a synthetic project that mirrors an SDK-style project without the SDK:
+/// a <c>Directory.Build.props</c> found by upward search, wildcard imports, chained properties, file,
+/// environment, and path property functions, and recursive item globs over a source tree with excluded
+/// <c>obj</c> directories.
+/// </para>
+/// <para>
+/// To measure real projects, set <c>MSBUILD_EVALUATION_INPUTS_BENCHMARK_PROJECTS</c> to a
+/// <see cref="Path.PathSeparator"/>-separated list of restored project files. SDK-style projects also need
+/// <c>MSBUILD_EXE_PATH</c> pointing at the bootstrap <c>MSBuild.dll</c>, <c>MSBuildSDKsPath</c> at its
+/// <c>Sdks</c> directory (<c>artifacts\bin\bootstrap\core\sdk\&lt;version&gt;</c>), and
+/// <c>DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR</c> at <c>artifacts\bin\bootstrap\core</c>. Pass those three to
+/// the benchmark process through BenchmarkDotNet, for example
+/// <c>Run-Benchmarks.ps1 -BenchmarkDotNetArguments '--envVars', 'MSBUILD_EXE_PATH:...', ...</c>; setting
+/// them in the host environment redirects the build of the generated benchmark project instead.
+/// A real project that is not cacheable fails setup with the reason, which makes the run double as an
+/// admissibility check.
+/// </para>
+/// </remarks>
+internal sealed class EvaluationInputBenchmarkFixture : IDisposable
+{
+    private const string RecordingVariable = "MSBUILDRECORDEVALUATIONINPUTS";
+    private const string ProjectsVariable = "MSBUILD_EVALUATION_INPUTS_BENCHMARK_PROJECTS";
+    internal const string SyntheticProject = "synthetic";
+    private const int DirectoryCount = 32;
+    private const int SourceFilesPerDirectory = 4;
+    private const int ImportCount = 8;
+    private const int ChainedPropertyCount = 100;
+
+    private readonly TemporaryDirectory? _directory;
+
+    internal string ProjectPath { get; }
+    internal EvaluationInputs Inputs { get; private set; } = null!;
+
+    internal static IEnumerable<string> ProjectPaths
+    {
+        get
+        {
+            yield return SyntheticProject;
+
+            string? projects = Environment.GetEnvironmentVariable(ProjectsVariable);
+            if (!string.IsNullOrEmpty(projects))
+            {
+                foreach (string project in projects.Split([Path.PathSeparator], StringSplitOptions.RemoveEmptyEntries))
+                {
+                    yield return Path.GetFullPath(project);
+                }
+            }
+        }
+    }
+
+    internal EvaluationInputBenchmarkFixture(string projectPath)
+    {
+        if (projectPath == SyntheticProject)
+        {
+            _directory = new TemporaryDirectory(nameof(EvaluationInputBenchmarkFixture));
+            CreateTree();
+            ProjectPath = _directory.WriteFile("evaluation.proj", CreateProjectXml());
+        }
+        else
+        {
+            ProjectPath = projectPath;
+        }
+    }
+
+    internal void RecordInputs()
+    {
+        SetRecording(enabled: true);
+        Inputs = EvaluateProject().EvaluationInputs
+            ?? throw new InvalidOperationException("Recording did not produce inputs.");
+        if (!Inputs.IsCacheable)
+        {
+            throw new InvalidOperationException($"{ProjectPath} is not cacheable: {Inputs.NonCacheable} {Inputs.NonCacheableDetail}");
+        }
+
+        Console.WriteLine($"// {ProjectPath}: {Inputs.Files.Count} paths, {Inputs.EnvironmentReads.Count} environment reads, {Inputs.SdkResolutions.Length} SDK resolutions, {Inputs.RegistryReads.Length} registry reads");
+    }
+
+    /// <summary>
+    /// A cold evaluation: the fresh collection keeps the project XML cache empty so every evaluation reads its files again.
+    /// The collection costs the same with and without recording.
+    /// </summary>
+    internal ProjectInstance EvaluateProject(EvaluationContext? context = null)
+    {
+        using ProjectCollection collection = new();
+        return ProjectInstance.FromFile(ProjectPath, new ProjectOptions { ProjectCollection = collection, EvaluationContext = context });
+    }
+
+    internal static void SetRecording(bool enabled)
+    {
+        Environment.SetEnvironmentVariable(RecordingVariable, enabled ? "1" : null);
+        Traits.UpdateFromEnvironment();
+    }
+
+    public void Dispose() => _directory?.Dispose();
+
+    private void CreateTree()
+    {
+        _directory!.WriteFile("Directory.Build.props", "<Project><PropertyGroup><FromDirectoryBuildProps>true</FromDirectoryBuildProps></PropertyGroup></Project>");
+        _directory.WriteFile("version.txt", "1.2.3");
+
+        for (int importIndex = 0; importIndex < ImportCount; importIndex++)
+        {
+            StringBuilder import = new("<Project><PropertyGroup>");
+            for (int propertyIndex = 0; propertyIndex < 10; propertyIndex++)
+            {
+                import.Append($"<Import{importIndex}Property{propertyIndex}>{propertyIndex}</Import{importIndex}Property{propertyIndex}>");
+            }
+
+            import.Append("</PropertyGroup></Project>");
+            _directory.WriteFile(Path.Combine("imports", $"import{importIndex:D2}.props"), import.ToString());
+        }
+
+        for (int directoryIndex = 0; directoryIndex < DirectoryCount; directoryIndex++)
+        {
+            string directory = Path.Combine("src", $"group{directoryIndex:D3}");
+            for (int fileIndex = 0; fileIndex < SourceFilesPerDirectory; fileIndex++)
+            {
+                _directory.WriteFile(Path.Combine(directory, $"file{fileIndex}.cs"), "class C {}");
+            }
+
+            _directory.WriteFile(Path.Combine(directory, "readme.txt"), "readme");
+            _directory.WriteFile(Path.Combine(directory, "obj", "generated.cs"), "class G {}");
+        }
+    }
+
+    private static string CreateProjectXml()
+    {
+        StringBuilder xml = new();
+        xml.AppendLine("<Project>");
+        xml.AppendLine("  <PropertyGroup>");
+        xml.AppendLine("    <DirectoryBuildPropsPath>$([MSBuild]::GetPathOfFileAbove('Directory.Build.props'))</DirectoryBuildPropsPath>");
+        xml.AppendLine("  </PropertyGroup>");
+        xml.AppendLine("  <Import Project=\"$(DirectoryBuildPropsPath)\" Condition=\"'$(DirectoryBuildPropsPath)' != ''\" />");
+        xml.AppendLine("  <PropertyGroup>");
+        xml.AppendLine("    <Configuration Condition=\"'$(Configuration)' == ''\">Debug</Configuration>");
+        xml.AppendLine("    <OutputPath>bin/$(Configuration)/</OutputPath>");
+        xml.AppendLine("    <Version>$([System.IO.File]::ReadAllText('$(MSBuildThisFileDirectory)version.txt').Trim())</Version>");
+        xml.AppendLine("    <SourceRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'src'))</SourceRoot>");
+        xml.AppendLine("    <Stamp>$([System.Environment]::GetEnvironmentVariable('MSBUILD_BENCHMARK_STAMP'))</Stamp>");
+        xml.AppendLine("    <HasGenerated>$([System.IO.Directory]::Exists('$(SourceRoot)generated'))</HasGenerated>");
+        xml.AppendLine("    <Chain0>value</Chain0>");
+        for (int i = 1; i < ChainedPropertyCount; i++)
+        {
+            xml.AppendLine($"    <Chain{i}>$(Chain{i - 1}).{i}</Chain{i}>");
+        }
+
+        xml.AppendLine("  </PropertyGroup>");
+        xml.AppendLine("  <Import Project=\"imports/*.props\" />");
+        xml.AppendLine("  <ItemGroup>");
+        xml.AppendLine("    <Compile Include=\"src/**/*.cs\" Exclude=\"src/**/obj/**\" />");
+        xml.AppendLine("    <None Include=\"**/*.txt\" />");
+        xml.AppendLine("  </ItemGroup>");
+        xml.AppendLine("</Project>");
+        return xml.ToString();
+    }
+}

--- a/src/MSBuild.Benchmarks/MSBuild.Benchmarks.csproj
+++ b/src/MSBuild.Benchmarks/MSBuild.Benchmarks.csproj
@@ -11,6 +11,18 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <!-- Opt-in BuildXL Detours comparison for evaluation input recording; Windows x64 only. -->
+  <PropertyGroup Condition="'$(EnableEvaluationInputDetours)' == 'true'">
+    <DefineConstants>$(DefineConstants);EVALUATION_INPUT_DETOURS</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(EnableEvaluationInputDetours)' == 'true'">
+    <!-- Keep aligned with eng\dependabot\Directory.Packages.props; CPM is disabled for this project. -->
+    <PackageReference Include="Microsoft.BuildXL.Processes" Version="0.1.0-20260612.4" PrivateAssets="all" />
+    <!-- Cuts the netstandard1.x dependency chain Microsoft.BuildXL.Processes brings in, as Microsoft.Build does. -->
+    <PackageReference Include="NETStandard.Library" Version="2.0.3" PrivateAssets="all" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" VersionOverride="0.16.0-preview.1" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" VersionOverride="0.16.0-preview.1" />

--- a/src/MSBuild.Benchmarks/MSBuild.Benchmarks.csproj
+++ b/src/MSBuild.Benchmarks/MSBuild.Benchmarks.csproj
@@ -14,6 +14,8 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" VersionOverride="0.16.0-preview.1" />
     <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" VersionOverride="0.16.0-preview.1" />
+    <!-- Microsoft.Build references NuGet.Frameworks privately; evaluating real SDK projects needs it beside Microsoft.Build.dll. -->
+    <PackageReference Include="NuGet.Frameworks" Version="$(NuGetBuildTasksVersion)" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">

--- a/src/MSBuild.Benchmarks/Program.cs
+++ b/src/MSBuild.Benchmarks/Program.cs
@@ -6,9 +6,15 @@ using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnostics.Windows;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
+using MSBuild.Benchmarks;
 using static MSBuild.Benchmarks.Extensions;
 
 var argList = new List<string>(args);
+
+if (EvaluationInputDetoursComparison.TryRun(argList, out int harnessExitCode) || EvaluationInputRecordHost.TryRun(argList, out harnessExitCode))
+{
+    return harnessExitCode;
+}
 
 ParseAndRemoveBooleanParameter(argList, "--collect-etw", out bool collectEtw);
 ParseAndRemoveBooleanParameter(argList, "--disable-ngen", out bool disableNGen);

--- a/src/MSBuild.Benchmarks/readme.md
+++ b/src/MSBuild.Benchmarks/readme.md
@@ -149,6 +149,17 @@ Scalar string, primitive, enum, decimal, date/time, timespan, and GUID fallbacks
 Other fallback objects mark recording non-cacheable instead of retaining a mutable reference.
 Registry access alone no longer stops recording. These are logical requests/results, not a
 trace of each internal view probe or of resolver/toolset-internal registry accesses.
+The comparison summary prints only the registry-read count, not potentially sensitive values.
+
+To compare the recorded inputs with every path the process touched, build with
+`-p:EnableEvaluationInputDetours=true` on Windows x64 and run the comparison instead of a benchmark.
+It prints a summary line, then every touched path the recording does not explain: `DETOURS_ONLY|` for
+probes and enumerations, `DETOURS_ONLY_READ|` for content reads, and `RECORDED_ONLY|` for recorded
+paths the sandbox never saw.
+
+```
+dotnet run -c Release -f net11.0 -p:EnableEvaluationInputDetours=true -- --evaluation-input-detours --project <path> [--global-property Name=Value]
+```
 
 ## Command-Line Options
 

--- a/src/MSBuild.Benchmarks/readme.md
+++ b/src/MSBuild.Benchmarks/readme.md
@@ -103,6 +103,53 @@ dotnet run -c Release -f net11.0 -- --filter "*ItemSpecModifiersBenchmark*"
 ```
 dotnet run -c Release -f net11.0 -- --filter "*ItemSpecModifiersBenchmark.IncludeOnly"
 ```
+
+## Evaluation Input Recording
+
+`EvaluationInputRecordingBenchmark` measures what recording evaluation inputs
+(`MSBUILDRECORDEVALUATIONINPUTS=1`) adds to an evaluation, in an isolated and in a shared evaluation
+context. `EvaluationInputValidationBenchmark` separately measures checks of recorded files and
+directories: unchanged, and after a project file, an import, or a glob directory changed.
+Its evaluation and input capture happen outside the timed operations.
+
+Both use the same synthetic project and any restored projects listed in
+`MSBUILD_EVALUATION_INPUTS_BENCHMARK_PROJECTS` (path-separator
+delimited). SDK-style projects also need `MSBUILD_EXE_PATH`, `MSBuildSDKsPath`, and
+`DOTNET_MSBUILD_SDK_RESOLVER_CLI_DIR` pointing at the bootstrap SDK, passed to the benchmark process
+with `--envVars` as the shared fixture remarks describe. A project that is not cacheable fails setup with the
+reason.
+
+Run the observation cases or unchanged validation independently:
+
+```powershell
+.\src\MSBuild.Benchmarks\Run-Benchmarks.ps1 -Framework net11.0 -Filter '*EvaluationInputRecordingBenchmark.*'
+.\src\MSBuild.Benchmarks\Run-Benchmarks.ps1 -Framework net11.0 -Filter '*EvaluationInputValidationBenchmark.ValidateUnchanged'
+```
+
+The two classes produce separate reports. To express validation cost relative to fresh evaluation,
+compare `EvaluationInputValidationBenchmark.ValidateUnchanged` with
+`EvaluationInputRecordingBenchmark.Evaluate` for the same project and run settings.
+The stale-validation cases mutate files or directory membership; use synthetic or disposable workloads.
+
+Validation compares path existence, file/directory kind, last-write timestamp, and length.
+Glob membership is checked through the timestamps of the directories traversed.
+Environment reads, SDK results, and registry reads remain recorded but are not revalidated, and the request key
+is not compared. A successful filesystem check alone does not establish that an evaluation result
+can be reused. Incomplete/non-cacheable recording and failed filesystem checks still reject validation.
+
+Registry reads through `$(Registry:...)`, `[MSBuild]::GetRegistryValue`, and
+`[MSBuild]::GetRegistryValueFromView` are retained in `EvaluationInputs.RegistryReads`.
+Each observation contains the decoded key, value name (empty for the default value),
+returned value, and the string view tokens the intrinsic considers (not ignored non-string arguments).
+The key may be null for an accepted no-view request. Values are captured from the
+existing call, not by rereading the registry; missing values remain `null`, while an intrinsic
+that returns a supplied fallback records that fallback. Repeated reads are kept in order.
+Binary, multi-string, and character arrays are copied into immutable arrays before further expansion.
+Scalar string, primitive, enum, decimal, date/time, timespan, and GUID fallbacks are also supported.
+Other fallback objects mark recording non-cacheable instead of retaining a mutable reference.
+Registry access alone no longer stops recording. These are logical requests/results, not a
+trace of each internal view probe or of resolver/toolset-internal registry accesses.
+
 ## Command-Line Options
 
 ### Custom Options


### PR DESCRIPTION
Fixes https://github.com/dotnet/msbuild/issues/14688
Prototype for future evaluation reuse: **record inputs and check files, not cache evaluations**. Part of #14234

### What we record

- **Files and folders:** projects, imports, `Directory.Parse.config`, reads, `Exists(...)` including missing paths, parent-folder searches and folders searched by wildcards such as `**\*.cs`. Record path type, last-write time and file size.
- **Environment variables:** a fingerprint of the environment imported as properties, plus variable names and values read through property functions such as `Environment.GetEnvironmentVariable(...)`.
- **Registry values:** key paths, value names, requested registry views, and returned values.
- **SDK resolution:** requested SDK references and their resolution results.

**As part of the key:**

- **Project and global properties:** the project path and global properties such as `Configuration` and `TargetFramework`.
- **Toolset:** versions, paths, and a fingerprint of toolset configuration.
- **Evaluation and engine settings:** engine version, change waves, evaluation/load modes, interactive mode, and node count.
- **Evaluation directories:** startup and working directories.
- **Language and region:** current culture and UI culture.
- **XML-parser settings:** a fingerprint of parser configuration.

### Out of scope of observation layer

| Category | What happens today | Reason |
|---|---|---|
| SDK resolver dependencies | Internal file, setting, and network dependencies are not observed. | Not implemented. MSBuild and resolvers need a contract for reporting inputs and checking changes. |
| Additional file metadata | `ModifiedTime`, `CreatedTime`, `AccessedTime`, and calls such as `File.GetAttributes(...)` are not observed and block reuse. | Not implemented yet; these inputs should be supported. |
| Unsaved project XML | API-created projects without a file path and unsaved edits block reuse. | Disk timestamps cannot describe unsaved contents. Content/version tracking is not implemented. |
| Host-provided filesystem answers | Caller-supplied filesystems and directory caches block reuse. | Their answers may not reflect disk state. Recording host-provided inputs is not implemented. |
| File and folder links (symlinks/junctions) | Direct symbolic links and junctions block reuse; changed links in parent folders can be missed. | Tracking link targets and parent-path changes is not implemented. |
| Permissions and accessibility | Permissions and per-operation access results are not recorded as dependencies; access changes can be missed. | Path kind, timestamps, and size do not establish read/list access. Permission-aware observation and validation are not implemented. |
| Time and random values | Calls such as `DateTime.Now` and `Guid.NewGuid()` block reuse. | They require fresh answers. Reusing an old timestamp or GUID changes the requested behavior. |
| File content fingerprints | No content hashes are recorded; edits preserving timestamps and sizes can be missed. | This prototype uses metadata-only checks. Stronger content checks are future work. |
| Files changing during evaluation | Changes between reading a file and recording its state can be missed. | Reads and observations do not form a single filesystem snapshot; stronger coordination is needed. |
| Installed tool state | Installed SDK/framework lookups are assumed stable rather than fully observed. | Tracking and validating installation changes is not implemented. |
| Other machine/runtime state | Some process settings and OS data, such as time-zone data, are assumed stable. | Reuse across processes or machines needs additional state checks; these are future work. |

### Testing and measurement results

- [Observation overhead](https://github.com/dotnet/msbuild/pull/14940#issuecomment-5560253413): recording added about 9% to evaluation time for OrchardCore Core and CMS.
- [Filesystem validation](https://github.com/dotnet/msbuild/pull/14940#issuecomment-5560255488): checking unchanged filesystem inputs took 5.8-7.5% of reevaluation time on OrchardCore and Roslyn, excluding cached-project reuse.
- [BuildXL comparison](https://github.com/dotnet/msbuild/pull/14940#issuecomment-5560255365): across 463 evaluations of 232 OrchardCore projects, all 893 unmatched paths were explained, with no missing project/import/glob input confirmed.

### Next steps

Integrating with projectInstance prototype:
- Merge this prototype with the ProjectInstance reuse prototype; compare reused results with fresh evaluations.
- Complete and compare request keys before reuse: project, global properties, tools, folders, language/region, engine, and parser settings.

Complete observation layer:
- Add invalidation for environment variables, registry values, SDK results, and resolver dependencies.
- Observe additional file metadata (`ModifiedTime`, `CreatedTime`, `AccessedTime`, file attributes) and invalidate when it changes.
- Add an MSBuild/resolver contract for reporting dependencies and deciding when SDK results can be reused.

Future work for observation layer:
- Track unsaved project XML by content or version.
- Support caller-supplied filesystems and directory caches, including their change information.
- Track file/folder link targets and changes to links in parent folders.
- Track installed tool and machine/runtime state, and invalidate when it changes.
- Add stronger file-content checks and detect changes while evaluation inputs are being recorded.
