### PR TITLE
Make in-process ResolveAssemblyReference cancellable

### DIFF
--- a/documentation/wiki/ResolveAssemblyReference.md
+++ b/documentation/wiki/ResolveAssemblyReference.md
@@ -90,6 +90,12 @@ Referenced assemblies are added to the closure iteratively until no more new ref
 
 Direct references that we started with are called Primary references. Indirect assemblies that were added to closure because of a transitive reference are called Dependency. Each indirect assembly remembers all the primary ("root") items that led to its inclusion and their corresponding metadata.
 
+### Cancellation
+
+In-process RAR implements `ICancelableTask`, allowing MSBuild to stop assembly resolution when a build is canceled. Cancellation is cooperative: RAR checks for cancellation while resolving references, traversing dependencies, and producing results. An in-progress synchronous file operation must finish before cancellation can be observed.
+
+A canceled invocation returns `false` without reporting cancellation as an assembly resolution error. This does not cancel an invocation already running in an out-of-process RAR node.
+
 ## Results
 
 RAR is just as rich at logging results as it is for inputs:

--- a/documentation/wiki/ResolveAssemblyReference.md
+++ b/documentation/wiki/ResolveAssemblyReference.md
@@ -96,6 +96,8 @@ In-process RAR implements `ICancelableTask`, allowing MSBuild to stop assembly r
 
 A canceled invocation returns `false` without reporting cancellation as an assembly resolution error. This does not cancel an invocation already running in an out-of-process RAR node.
 
+Cancellation is checked before writing the state file, not during serialization. Successfully read assembly metadata remains reusable by later tasks; dependency remapping is kept task-local rather than modifying the shared raw metadata.
+
 ## Results
 
 RAR is just as rich at logging results as it is for inputs:

--- a/src/Tasks.UnitTests/AssemblyDependency/CancellationTests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/CancellationTests.cs
@@ -1,0 +1,276 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Versioning;
+using System.Threading;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Shared;
+using Microsoft.Build.Tasks;
+using Microsoft.Build.Tasks.AssemblyDependency;
+using Microsoft.Build.Tasks.AssemblyFoldersFromConfig;
+using Microsoft.Build.Utilities;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.UnitTests.ResolveAssemblyReference_Tests;
+
+public sealed class CancellationTests(ITestOutputHelper output)
+{
+    private readonly ITestOutputHelper _output = output;
+
+    [Fact]
+    public void CancelBeforeExecute()
+    {
+        MockEngine engine = new(_output);
+        ResolveAssemblyReference task = new() { BuildEngine = engine };
+        ICancelableTask cancelable = task;
+
+        cancelable.Cancel();
+        cancelable.Cancel();
+
+        task.Execute().ShouldBeFalse();
+        task.ResolvedFiles.ShouldBeEmpty();
+        task.FilesWritten.ShouldBeEmpty();
+        engine.Errors.ShouldBe(0);
+        engine.Warnings.ShouldBe(0);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void CancelDuringPrimaryResolution(bool useAssemblyFiles)
+    {
+        using TestEnvironment env = TestEnvironment.Create(_output);
+        string directory = env.CreateFolder().Path;
+        ResolveAssemblyReference task = CreateTask(directory);
+        if (useAssemblyFiles)
+        {
+            task.Assemblies = [];
+            task.AssemblyFiles = [new TaskItem(Path.Combine(directory, "A.dll")), new TaskItem(Path.Combine(directory, "B.dll"))];
+        }
+
+        List<string> assemblyReads = [];
+        Execute(task, getAssemblyName: path =>
+        {
+            assemblyReads.Add(Path.GetFileNameWithoutExtension(path));
+            task.Cancel();
+            return GetAssemblyName(path);
+        }).ShouldBeFalse();
+
+        assemblyReads.ShouldBe(["A"]);
+        task.ResolvedFiles.ShouldBeEmpty();
+        AssertCanceledWithoutWritingState(task);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    [InlineData(false, false)]
+    public void CancelDuringDependencyDiscovery(bool findDependencies, bool autoUnify)
+    {
+        using TestEnvironment env = TestEnvironment.Create(_output);
+        ResolveAssemblyReference task = CreateTask(env.CreateFolder().Path);
+        task.Assemblies = [new TaskItem("A")];
+        task.FindDependencies = findDependencies;
+        task.AutoUnify = autoUnify;
+        int metadataReads = 0;
+
+        Execute(task, getAssemblyMetadata: (
+            string path,
+            ConcurrentDictionary<string, AssemblyMetadata> cache,
+            out AssemblyNameExtension[] dependencies,
+            out string[] scatterFiles,
+            out FrameworkName? frameworkName) =>
+        {
+            metadataReads++;
+            dependencies = [new AssemblyNameExtension("B, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null")];
+            scatterFiles = [];
+            frameworkName = null;
+            task.Cancel();
+        }).ShouldBeFalse();
+
+        metadataReads.ShouldBe(1);
+        AssertCanceledWithoutWritingState(task);
+    }
+
+    [Fact]
+    public async System.Threading.Tasks.Task CancelFromAnotherThreadPreservesExistingState()
+    {
+        using TestEnvironment env = TestEnvironment.Create(_output);
+        string directory = env.CreateFolder().Path;
+        ResolveAssemblyReference initialTask = CreateTask(directory);
+        Execute(initialTask).ShouldBeTrue();
+        initialTask.ResolvedFiles.Length.ShouldBe(2);
+        byte[] originalState = File.ReadAllBytes(initialTask.StateFile);
+
+        ResolveAssemblyReference task = CreateTask(directory);
+        using ManualResetEventSlim readingFile = new();
+        using ManualResetEventSlim cancellationRequested = new();
+        System.Threading.Tasks.Task cancel = System.Threading.Tasks.Task.Run(() =>
+        {
+            try
+            {
+                readingFile.Wait(TimeSpan.FromSeconds(30)).ShouldBeTrue();
+                task.Cancel();
+            }
+            finally
+            {
+                cancellationRequested.Set();
+            }
+        });
+
+        int fileReads = 0;
+        bool result = Execute(task, getLastWriteTime: path =>
+        {
+            fileReads++;
+            readingFile.Set();
+            cancellationRequested.Wait(TimeSpan.FromSeconds(30)).ShouldBeTrue();
+            return GetLastWriteTime(path);
+        });
+        await cancel;
+
+        result.ShouldBeFalse();
+        fileReads.ShouldBe(1);
+        File.ReadAllBytes(task.StateFile).ShouldBe(originalState);
+        task.FilesWritten.ShouldBeEmpty();
+        ((MockEngine)task.BuildEngine).Errors.ShouldBe(0);
+        ((MockEngine)task.BuildEngine).Warnings.ShouldBe(0);
+    }
+
+    [Fact]
+    public void UnrelatedCancellationExceptionIsNotHandled()
+    {
+        using TestEnvironment env = TestEnvironment.Create(_output);
+        ResolveAssemblyReference task = CreateTask(env.CreateFolder().Path);
+        using CancellationTokenSource unrelatedCancellation = new();
+        OperationCanceledException exception = new(unrelatedCancellation.Token);
+
+        Should.Throw<OperationCanceledException>(() =>
+            Execute(task, getAssemblyName: _ => throw exception)).ShouldBeSameAs(exception);
+    }
+
+    [Fact]
+    public void CancelDuringCachedAssemblyFolderSearch()
+    {
+        using TestEnvironment env = TestEnvironment.Create(_output);
+        env.SetEnvironmentVariable("MSBUILDDISABLEASSEMBLYFOLDERSEXCACHE", null);
+        TransientTestFolder firstFolder = env.CreateFolder();
+        string firstDirectory = firstFolder.Path;
+        string secondDirectory = env.CreateFolder().Path;
+        env.CreateFile(firstFolder, "A.dll", string.Empty);
+        string config = env.CreateFile(fileName: "folders.config", contents: $$"""
+            <AssemblyFoldersConfig>
+              <AssemblyFolders>
+                <AssemblyFolder>
+                  <FrameworkVersion>v4.0</FrameworkVersion>
+                  <Path>{{firstDirectory}}</Path>
+                </AssemblyFolder>
+                <AssemblyFolder>
+                  <FrameworkVersion>v3.5</FrameworkVersion>
+                  <Path>{{secondDirectory}}</Path>
+                </AssemblyFolder>
+              </AssemblyFolders>
+            </AssemblyFoldersConfig>
+            """).Path;
+        ResolveAssemblyReference task = CreateTask(firstDirectory);
+        using CancellationTokenSource cancellation = new();
+        int assemblyReads = 0;
+        AssemblyFoldersFromConfigResolver resolver = new(
+            $"{{AssemblyFoldersFromConfig:{config},v4.0}}",
+            _ =>
+            {
+                assemblyReads++;
+                cancellation.Cancel();
+                // Keep searching for an MSIL assembly after finding this architecture-specific one.
+                return new AssemblyNameExtension("A, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null, ProcessorArchitecture=x86");
+            },
+            _ => throw new InvalidOperationException("The cached file lookup should be used."),
+            _ => "v4.0.30319",
+            new Version(4, 0),
+            System.Reflection.ProcessorArchitecture.MSIL,
+            true,
+            task.BuildEngine,
+            task.Log,
+            task.TaskEnvironment)
+        {
+            CancellationToken = cancellation.Token
+        };
+
+        OperationCanceledException exception = Should.Throw<OperationCanceledException>(() =>
+            resolver.Resolve(new AssemblyNameExtension("A"), string.Empty, string.Empty, true, false, false,
+                [".dll"], string.Empty, string.Empty, [], out _, out _));
+
+        exception.CancellationToken.ShouldBe(cancellation.Token);
+        assemblyReads.ShouldBeGreaterThan(0);
+    }
+
+    private ResolveAssemblyReference CreateTask(string directory) => new()
+    {
+        BuildEngine = new MockEngine(_output),
+        Assemblies = [new TaskItem("A"), new TaskItem("B")],
+        SearchPaths = [directory],
+        AllowedAssemblyExtensions = [".dll"],
+        IgnoreDefaultInstalledAssemblyTables = true,
+        FindRelatedFiles = false,
+        FindSatellites = false,
+        FindSerializationAssemblies = false,
+        StateFile = Path.Combine(directory, "references.cache")
+    };
+
+    private static void AssertCanceledWithoutWritingState(ResolveAssemblyReference task)
+    {
+        File.Exists(task.StateFile).ShouldBeFalse();
+        task.FilesWritten.ShouldBeEmpty();
+        ((MockEngine)task.BuildEngine).Errors.ShouldBe(0);
+        ((MockEngine)task.BuildEngine).Warnings.ShouldBe(0);
+    }
+
+    private static AssemblyNameExtension GetAssemblyName(string path) =>
+        new($"{Path.GetFileNameWithoutExtension(path)}, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
+
+    private static DateTime GetLastWriteTime(string path) =>
+        DateTime.FromFileTimeUtc(path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ? 1 : 0);
+
+    private static bool Execute(
+        ResolveAssemblyReference task,
+        GetAssemblyName? getAssemblyName = null,
+        GetAssemblyMetadata? getAssemblyMetadata = null,
+        GetLastWriteTime? getLastWriteTime = null) =>
+        task.Execute(
+            path => path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase),
+            _ => true,
+            (_, _) => [],
+            getAssemblyName ?? GetAssemblyName,
+            getAssemblyMetadata ?? ((
+                string path,
+                ConcurrentDictionary<string, AssemblyMetadata> cache,
+                out AssemblyNameExtension[] dependencies,
+                out string[] scatterFiles,
+                out FrameworkName? frameworkName) =>
+            {
+                dependencies = [];
+                scatterFiles = [];
+                frameworkName = null;
+            }),
+#if FEATURE_WIN32_REGISTRY
+            (_, _) => [],
+            (_, _) => string.Empty,
+#endif
+            getLastWriteTime ?? GetLastWriteTime,
+            _ => "v4.0.30319",
+#if FEATURE_WIN32_REGISTRY
+            (_, _) => throw new InvalidOperationException("Registry access is not expected."),
+#endif
+            (_, _, _, _, _, _, _) => string.Empty,
+            (string path, GetAssemblyRuntimeVersion getRuntimeVersion, FileExists fileExists, out string imageRuntimeVersion, out bool isManagedWinmd) =>
+            {
+                imageRuntimeVersion = "v4.0.30319";
+                isManagedWinmd = false;
+                return false;
+            },
+            _ => 0);
+}

--- a/src/Tasks.UnitTests/AssemblyDependency/CancellationTests.cs
+++ b/src/Tasks.UnitTests/AssemblyDependency/CancellationTests.cs
@@ -2,9 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Runtime.Versioning;
 using System.Threading;
 using Microsoft.Build.Framework;
@@ -102,12 +104,14 @@ public sealed class CancellationTests(ITestOutputHelper output)
     {
         using TestEnvironment env = TestEnvironment.Create(_output);
         string directory = env.CreateFolder().Path;
-        ResolveAssemblyReference initialTask = CreateTask(directory);
+        MockEngine engine = new(_output);
+        ResolveAssemblyReference initialTask = CreateTask(directory, engine);
         Execute(initialTask).ShouldBeTrue();
         initialTask.ResolvedFiles.Length.ShouldBe(2);
+        initialTask.FilesWritten.ShouldHaveSingleItem().ItemSpec.ShouldBe(initialTask.StateFile);
         byte[] originalState = File.ReadAllBytes(initialTask.StateFile);
 
-        ResolveAssemblyReference task = CreateTask(directory);
+        ResolveAssemblyReference task = CreateTask(directory, engine);
         using ManualResetEventSlim readingFile = new();
         using ManualResetEventSlim cancellationRequested = new();
         System.Threading.Tasks.Task cancel = System.Threading.Tasks.Task.Run(() =>
@@ -139,10 +143,245 @@ public sealed class CancellationTests(ITestOutputHelper output)
         task.FilesWritten.ShouldBeEmpty();
         ((MockEngine)task.BuildEngine).Errors.ShouldBe(0);
         ((MockEngine)task.BuildEngine).Warnings.ShouldBe(0);
+
+        ResolveAssemblyReference recovered = CreateTask(directory, engine);
+        Execute(recovered).ShouldBeTrue();
+        AssertSameOutputs(initialTask, recovered);
+        File.ReadAllBytes(recovered.StateFile).ShouldBe(originalState);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, false)]
+    [InlineData(false, true)]
+    [InlineData(true, true)]
+    public void RemappingDoesNotPolluteSharedMetadata(bool cancelAfterRemapping, bool targetAlreadyReferenced)
+    {
+        using TestEnvironment env = TestEnvironment.Create(_output);
+        string directory = env.CreateFolder().Path;
+        MockEngine engine = new(_output);
+        string redist = env.CreateFile(fileName: "remapping.xml", contents: """
+            <FileList Redist="TestFramework">
+              <File AssemblyName="UnusedFrameworkAssembly" Version="1.0.0.0" Culture="neutral" PublicKeyToken="null" InGAC="false" />
+              <Remap>
+                <From AssemblyName="B">
+                  <To AssemblyName="C" Version="1.0.0.0" Culture="neutral" PublicKeyToken="null" />
+                </From>
+              </Remap>
+            </FileList>
+            """).Path;
+        AssemblyNameExtension originalDependency = GetAssemblyName("B.dll");
+        AssemblyNameExtension existingTarget = GetAssemblyName("C.dll");
+        AssemblyNameExtension[] rawDependencies = targetAlreadyReferenced
+            ? [existingTarget, originalDependency]
+            : [originalDependency];
+        int primaryMetadataReads = 0;
+        GetAssemblyMetadata metadata = (
+            string path,
+            ConcurrentDictionary<string, AssemblyMetadata> cache,
+            out AssemblyNameExtension[] dependencies,
+            out string[] scatterFiles,
+            out FrameworkName? frameworkName) =>
+        {
+            if (Path.GetFileNameWithoutExtension(path) == "A")
+            {
+                primaryMetadataReads++;
+                dependencies = rawDependencies;
+            }
+            else
+            {
+                dependencies = [];
+            }
+            scatterFiles = [];
+            frameworkName = null;
+        };
+
+        ResolveAssemblyReference control = CreateTask(directory, engine);
+        control.Assemblies = [new TaskItem("A")];
+        Execute(control, getAssemblyMetadata: metadata).ShouldBeTrue();
+        control.ResolvedDependencyFiles.Select(item => Path.GetFileNameWithoutExtension(item.ItemSpec))
+            .ShouldBe(targetAlreadyReferenced ? ["B", "C"] : ["B"], ignoreOrder: true);
+
+        ResolveAssemblyReference remapped = CreateTask(directory, engine);
+        remapped.Assemblies = [new TaskItem("A")];
+        remapped.InstalledAssemblyTables = [new TaskItem(redist)];
+        remapped.StateFile = Path.Combine(directory, "remapped.cache");
+        bool cancellationRequested = false;
+        bool result = Execute(remapped, getAssemblyMetadata: metadata, getLastWriteTime: path =>
+        {
+            if (cancelAfterRemapping && Path.GetFileNameWithoutExtension(path) == "C")
+            {
+                cancellationRequested = true;
+                remapped.Cancel();
+            }
+            return GetLastWriteTime(path);
+        });
+        result.ShouldBe(!cancelAfterRemapping);
+        cancellationRequested.ShouldBe(cancelAfterRemapping);
+        if (cancelAfterRemapping)
+        {
+            AssertCanceledWithoutWritingState(remapped);
+        }
+        else
+        {
+            remapped.ResolvedDependencyFiles.ShouldHaveSingleItem().GetMetadata("FusionName").ShouldBe(existingTarget.FullName);
+        }
+
+        ResolveAssemblyReference recovered = CreateTask(directory, engine);
+        recovered.Assemblies = [new TaskItem("A")];
+        recovered.StateFile = Path.Combine(directory, "recovered.cache");
+        Execute(recovered, getAssemblyMetadata: metadata).ShouldBeTrue();
+        AssertSameOutputs(control, recovered);
+        primaryMetadataReads.ShouldBe(1, "the recovery must reuse the process-wide metadata, not reread it");
+        rawDependencies.Last().ShouldBeSameAs(originalDependency);
+        originalDependency.RemappedFromEnumerator.ShouldBeEmpty();
+        existingTarget.RemappedFromEnumerator.ShouldBeEmpty();
+        engine.Errors.ShouldBe(0);
+        engine.Warnings.ShouldBe(0);
+    }
+
+    [Theory]
+    [InlineData("timestamp")]
+    [InlineData("name")]
+    [InlineData("metadata")]
+    public void ColdCacheRecoversAfterCancellation(string cancellationPoint)
+    {
+        using TestEnvironment env = TestEnvironment.Create(_output);
+        string directory = env.CreateFolder().Path;
+        MockEngine engine = new(_output);
+        ResolveAssemblyReference canceled = CreateTask(directory, engine);
+        canceled.Assemblies = [new TaskItem("A")];
+        int primaryNameReads = 0;
+        int primaryMetadataReads = 0;
+        bool requestedCancellation = false;
+
+        void CancelAt(string point, string path)
+        {
+            if (!requestedCancellation && point == cancellationPoint && Path.GetFileNameWithoutExtension(path) == "A")
+            {
+                requestedCancellation = true;
+                canceled.Cancel();
+            }
+        }
+
+        GetAssemblyName name = path =>
+        {
+            if (Path.GetFileNameWithoutExtension(path) == "A")
+            {
+                primaryNameReads++;
+            }
+            CancelAt("name", path);
+            return GetAssemblyName(path);
+        };
+        GetAssemblyMetadata metadata = (
+            string path,
+            ConcurrentDictionary<string, AssemblyMetadata> cache,
+            out AssemblyNameExtension[] dependencies,
+            out string[] scatterFiles,
+            out FrameworkName? frameworkName) =>
+        {
+            if (Path.GetFileNameWithoutExtension(path) == "A")
+            {
+                primaryMetadataReads++;
+                dependencies = [GetAssemblyName("B.dll")];
+            }
+            else
+            {
+                dependencies = [];
+            }
+            scatterFiles = [];
+            frameworkName = null;
+            CancelAt("metadata", path);
+        };
+        GetLastWriteTime timestamp = path =>
+        {
+            CancelAt("timestamp", path);
+            return GetLastWriteTime(path);
+        };
+
+        Execute(canceled, name, metadata, timestamp).ShouldBeFalse();
+        requestedCancellation.ShouldBeTrue();
+        AssertCanceledWithoutWritingState(canceled);
+
+        ResolveAssemblyReference recovered = CreateTask(directory, engine);
+        recovered.Assemblies = [new TaskItem("A")];
+        Execute(recovered, name, metadata, timestamp).ShouldBeTrue();
+        recovered.ResolvedFiles.ShouldHaveSingleItem().GetMetadata("FusionName").ShouldBe(GetAssemblyName("A.dll").FullName);
+        recovered.ResolvedDependencyFiles.ShouldHaveSingleItem().GetMetadata("FusionName").ShouldBe(GetAssemblyName("B.dll").FullName);
+        recovered.CopyLocalFiles.Length.ShouldBe(2);
+        recovered.CopyLocalFiles.ShouldAllBe(item => item.GetMetadata("CopyLocal") == "true");
+        recovered.FilesWritten.ShouldHaveSingleItem().ItemSpec.ShouldBe(recovered.StateFile);
+
+        ResolveAssemblyReference cached = CreateTask(directory, engine);
+        cached.Assemblies = [new TaskItem("A")];
+        Execute(cached, name, metadata, timestamp).ShouldBeTrue();
+        AssertSameOutputs(recovered, cached);
+        primaryNameReads.ShouldBe(1);
+        primaryMetadataReads.ShouldBe(1);
+        engine.Errors.ShouldBe(0);
+        engine.Warnings.ShouldBe(0);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AssemblyFolderCacheRecoversAfterCancellation(bool useCache)
+    {
+        using TestEnvironment env = TestEnvironment.Create(_output);
+        env.SetEnvironmentVariable("MSBUILDDISABLEASSEMBLYFOLDERSEXCACHE", useCache ? null : "1");
+        TransientTestFolder folder = env.CreateFolder();
+        env.CreateFile(folder, "A.dll", string.Empty);
+        env.CreateFile(folder, "B.dll", string.Empty);
+        string config = env.CreateFile(fileName: "folders.config", contents: $$"""
+            <AssemblyFoldersConfig>
+              <AssemblyFolders>
+                <AssemblyFolder>
+                  <FrameworkVersion>v4.0</FrameworkVersion>
+                  <Path>{{folder.Path}}</Path>
+                </AssemblyFolder>
+              </AssemblyFolders>
+            </AssemblyFoldersConfig>
+            """).Path;
+        string searchPath = $"{{AssemblyFoldersFromConfig:{config},v4.0}}";
+        string cacheKey = "6f7de854-47fe-4ae2-9cfe-9b33682abd91" + searchPath;
+        MockEngine engine = new(_output);
+        ResolveAssemblyReference canceled = CreateTask(folder.Path, engine);
+        canceled.SearchPaths = [searchPath];
+        bool requestedCancellation = false;
+        Execute(canceled, getAssemblyName: path =>
+        {
+            requestedCancellation = true;
+            canceled.Cancel();
+            return GetAssemblyName(path);
+        }).ShouldBeFalse();
+        requestedCancellation.ShouldBeTrue();
+        AssertCanceledWithoutWritingState(canceled);
+        object? originalCache = engine.GetRegisteredTaskObject(cacheKey, RegisteredTaskObjectLifetime.Build);
+        if (useCache)
+        {
+            originalCache.ShouldBeOfType<AssemblyFoldersFromConfigCache>();
+        }
+        else
+        {
+            originalCache.ShouldBeNull();
+        }
+
+        ResolveAssemblyReference recovered = CreateTask(folder.Path, engine);
+        recovered.SearchPaths = [searchPath];
+        Execute(recovered).ShouldBeTrue();
+        recovered.ResolvedFiles.Length.ShouldBe(2);
+        engine.GetRegisteredTaskObject(cacheKey, RegisteredTaskObjectLifetime.Build).ShouldBeSameAs(originalCache);
+
+        ResolveAssemblyReference control = CreateTask(folder.Path);
+        control.SearchPaths = [searchPath];
+        Execute(control).ShouldBeTrue();
+        AssertSameOutputs(control, recovered);
+        engine.Errors.ShouldBe(0);
+        engine.Warnings.ShouldBe(0);
     }
 
     [Fact]
-    public void UnrelatedCancellationExceptionIsNotHandled()
+    public void UnrelatedCancellationExceptionFromAssemblyNameIsNotHandled()
     {
         using TestEnvironment env = TestEnvironment.Create(_output);
         ResolveAssemblyReference task = CreateTask(env.CreateFolder().Path);
@@ -208,9 +447,9 @@ public sealed class CancellationTests(ITestOutputHelper output)
         assemblyReads.ShouldBeGreaterThan(0);
     }
 
-    private ResolveAssemblyReference CreateTask(string directory) => new()
+    private ResolveAssemblyReference CreateTask(string directory, MockEngine? engine = null) => new()
     {
-        BuildEngine = new MockEngine(_output),
+        BuildEngine = engine ?? new MockEngine(_output),
         Assemblies = [new TaskItem("A"), new TaskItem("B")],
         SearchPaths = [directory],
         AllowedAssemblyExtensions = [".dll"],
@@ -220,6 +459,32 @@ public sealed class CancellationTests(ITestOutputHelper output)
         FindSerializationAssemblies = false,
         StateFile = Path.Combine(directory, "references.cache")
     };
+
+    private static void AssertSameOutputs(ResolveAssemblyReference expected, ResolveAssemblyReference actual)
+    {
+        Snapshot(actual.ResolvedFiles).ShouldBe(Snapshot(expected.ResolvedFiles));
+        Snapshot(actual.ResolvedDependencyFiles).ShouldBe(Snapshot(expected.ResolvedDependencyFiles));
+        Snapshot(actual.CopyLocalFiles).ShouldBe(Snapshot(expected.CopyLocalFiles));
+        Snapshot(actual.RelatedFiles).ShouldBe(Snapshot(expected.RelatedFiles));
+        Snapshot(actual.SatelliteFiles).ShouldBe(Snapshot(expected.SatelliteFiles));
+        Snapshot(actual.SerializationAssemblyFiles).ShouldBe(Snapshot(expected.SerializationAssemblyFiles));
+        Snapshot(actual.ScatterFiles).ShouldBe(Snapshot(expected.ScatterFiles));
+        Snapshot(actual.SuggestedRedirects).ShouldBe(Snapshot(expected.SuggestedRedirects));
+        actual.DependsOnSystemRuntime.ShouldBe(expected.DependsOnSystemRuntime);
+        actual.DependsOnNETStandard.ShouldBe(expected.DependsOnNETStandard);
+    }
+
+    private static string[] Snapshot(ITaskItem[] items) =>
+        items.Select(item =>
+        {
+            IDictionary metadata = item.CloneCustomMetadata();
+            return item.ItemSpec + " | " + string.Join(" | ",
+                metadata.Keys.Cast<string>()
+                    .OrderBy(name => name, StringComparer.Ordinal)
+                    .Select(name => $"{name}={metadata[name]}"));
+        })
+            .OrderBy(value => value, StringComparer.Ordinal)
+            .ToArray();
 
     private static void AssertCanceledWithoutWritingState(ResolveAssemblyReference task)
     {
@@ -233,7 +498,9 @@ public sealed class CancellationTests(ITestOutputHelper output)
         new($"{Path.GetFileNameWithoutExtension(path)}, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null");
 
     private static DateTime GetLastWriteTime(string path) =>
-        DateTime.FromFileTimeUtc(path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) ? 1 : 0);
+        path.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+            ? DateTime.FromFileTimeUtc(1)
+            : File.GetLastWriteTimeUtc(path);
 
     private static bool Execute(
         ResolveAssemblyReference task,

--- a/src/Tasks/AssemblyDependency/AssemblyResolution.cs
+++ b/src/Tasks/AssemblyDependency/AssemblyResolution.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using Microsoft.Build.Tasks.AssemblyFoldersFromConfig;
@@ -76,6 +77,7 @@ namespace Microsoft.Build.Tasks
                 // Search each searchpath.
                 foreach (Resolver resolver in resolvers)
                 {
+                    resolver.CancellationToken.ThrowIfCancellationRequested();
                     if
                     (
                         resolver.Resolve(
@@ -121,6 +123,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="getAssemblyPathInGac"></param>
         /// <param name="log"></param>
         /// <param name="taskEnvironment">TaskEnvironment for thread-safe environment variable access.</param>
+        /// <param name="cancellationToken">Token used to stop assembly resolution.</param>
         /// <returns></returns>
 #else
         /// <summary>
@@ -139,6 +142,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="getAssemblyPathInGac"></param>
         /// <param name="log"></param>
         /// <param name="taskEnvironment">TaskEnvironment for thread-safe environment variable access.</param>
+        /// <param name="cancellationToken">Token used to stop assembly resolution.</param>
         /// <returns></returns>
 #endif
         public static Resolver[] CompileSearchPaths(
@@ -159,12 +163,14 @@ namespace Microsoft.Build.Tasks
             Version targetedRuntimeVersion,
             GetAssemblyPathInGac getAssemblyPathInGac,
             TaskLoggingHelper log,
-            TaskEnvironment taskEnvironment)
+            TaskEnvironment taskEnvironment,
+            CancellationToken cancellationToken = default)
         {
             var resolvers = new Resolver[searchPaths.Length];
 
             for (int p = 0; p < searchPaths.Length; ++p)
             {
+                cancellationToken.ThrowIfCancellationRequested();
                 string basePath = searchPaths[p];
 
                 // Was {HintPathFromItem} specified? If so, take the Item's
@@ -210,6 +216,8 @@ namespace Microsoft.Build.Tasks
                 {
                     resolvers[p] = new DirectoryResolver(searchPaths[p], getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion, null, taskEnvironment);
                 }
+
+                resolvers[p].CancellationToken = cancellationToken;
             }
             return resolvers;
         }
@@ -223,12 +231,17 @@ namespace Microsoft.Build.Tasks
             GetAssemblyName getAssemblyName,
             GetAssemblyRuntimeVersion getRuntimeVersion,
             Version targetedRuntimeVersion,
-            TaskEnvironment taskEnvironment)
+            TaskEnvironment taskEnvironment,
+            CancellationToken cancellationToken = default)
         {
             var resolvers = new Resolver[parentReferenceDirectories.Count];
             for (int i = 0; i < parentReferenceDirectories.Count; i++)
             {
-                resolvers[i] = new DirectoryResolver(parentReferenceDirectories[i].Directory, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion, parentReferenceDirectories[i].ParentAssembly, taskEnvironment);
+                cancellationToken.ThrowIfCancellationRequested();
+                resolvers[i] = new DirectoryResolver(parentReferenceDirectories[i].Directory, getAssemblyName, fileExists, getRuntimeVersion, targetedRuntimeVersion, parentReferenceDirectories[i].ParentAssembly, taskEnvironment)
+                {
+                    CancellationToken = cancellationToken
+                };
             }
 
             return resolvers;

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -1080,35 +1080,42 @@ namespace Microsoft.Build.Tasks
 
             if (dependentAssemblies?.Length > 0)
             {
-                // Re-map immediately so that to the sytem we actually got the remapped version when reading the manifest.
+                // The cached dependency array and its names can be shared by other RAR tasks.
+                // Keep remapping changes in this task's result list.
                 for (int i = 0; i < dependentAssemblies.Length; i++)
                 {
                     _cancellationToken.ThrowIfCancellationRequested();
-                    // This will return a clone of the remapped assemblyNameExtension so its ok to party on it.
-                    AssemblyNameExtension remappedExtension = _installedAssemblies?.RemapAssemblyExtension(dependentAssemblies[i]);
+                    AssemblyNameExtension dependency = dependentAssemblies[i];
+                    AssemblyNameExtension remappedExtension = _installedAssemblies?.RemapAssemblyExtension(dependency);
                     if (remappedExtension != null)
                     {
-                        AssemblyNameExtension originalExtension = dependentAssemblies[i];
-                        AssemblyNameExtension existingExtension = dependencies.Find(x => x.Equals(remappedExtension));
-                        if (existingExtension != null)
+                        int existingIndex = dependencies.FindIndex(x => x.Equals(remappedExtension));
+                        if (existingIndex >= 0)
                         {
-                            existingExtension.AddRemappedAssemblyName(originalExtension.CloneImmutable());
+                            AssemblyNameExtension existingExtension = dependencies[existingIndex];
+                            // Clone() shares the remapping set, so make a private name and set before merging.
+                            AssemblyNameExtension mergedExtension = new(existingExtension.AssemblyName.CloneIfPossible());
+                            foreach (AssemblyNameExtension priorRemapping in existingExtension.RemappedFromEnumerator)
+                            {
+                                mergedExtension.AddRemappedAssemblyName(priorRemapping);
+                            }
+
+                            mergedExtension.AddRemappedAssemblyName(dependency.CloneImmutable());
+                            dependencies[existingIndex] = mergedExtension;
                             continue;
                         }
-                        else
-                        {
-                            dependentAssemblies[i] = remappedExtension;
-                            dependentAssemblies[i].AddRemappedAssemblyName(originalExtension.CloneImmutable());
-                        }
+
+                        remappedExtension.AddRemappedAssemblyName(dependency.CloneImmutable());
+                        dependency = remappedExtension;
                     }
 
                     // Assemblies which reference WinMD files sometimes will have references to mscorlib version 255.255.255 which is invalid. For this reason
                     // We will remove the dependency to mscorlib from the list of dependencies so it is not used for resolution or unification.
-                    bool isMscorlib = IsPseudoAssembly(dependentAssemblies[i].Name);
+                    bool isMscorlib = IsPseudoAssembly(dependency.Name);
 
-                    if (!isMscorlib || dependentAssemblies[i].Version.Major != 255)
+                    if (!isMscorlib || dependency.Version.Major != 255)
                     {
-                        dependencies.Add(dependentAssemblies[i]);
+                        dependencies.Add(dependency);
                     }
                 }
 

--- a/src/Tasks/AssemblyDependency/ReferenceTable.cs
+++ b/src/Tasks/AssemblyDependency/ReferenceTable.cs
@@ -9,6 +9,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Versioning;
+using System.Threading;
 using Microsoft.Build.Eventing;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
@@ -172,6 +173,7 @@ namespace Microsoft.Build.Tasks
         private readonly WarnOrErrorOnTargetArchitectureMismatchBehavior _warnOrErrorOnTargetArchitectureMismatch = WarnOrErrorOnTargetArchitectureMismatchBehavior.Warning;
 
         private readonly ConcurrentDictionary<string, AssemblyMetadata> _assemblyMetadataCache;
+        private readonly CancellationToken _cancellationToken;
 
         /// <summary>
         /// When we exclude an assembly from resolution because it is part of out exclusion list we need to let the user know why this is.
@@ -231,6 +233,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="ignoreFrameworkAttributeVersionMismatch"></param>
         /// <param name="nonCultureResourceDirectories"></param>
         /// <param name="taskEnvironment">TaskEnvironment for thread-safe environment variable access and path resolution.</param>
+        /// <param name="cancellationToken">Token used to stop assembly resolution.</param>
 #else
         /// <summary>
         /// Construct.
@@ -272,6 +275,7 @@ namespace Microsoft.Build.Tasks
         /// <param name="ignoreFrameworkAttributeVersionMismatch"></param>
         /// <param name="nonCultureResourceDirectories"></param>
         /// <param name="taskEnvironment">TaskEnvironment for thread-safe environment variable access and path resolution.</param>
+        /// <param name="cancellationToken">Token used to stop assembly resolution.</param>
 #endif
         internal ReferenceTable(
             IBuildEngine buildEngine,
@@ -315,7 +319,8 @@ namespace Microsoft.Build.Tasks
             bool unresolveFrameworkAssembliesFromHigherFrameworks,
             ConcurrentDictionary<string, AssemblyMetadata> assemblyMetadataCache,
             string[] nonCultureResourceDirectories,
-            TaskEnvironment taskEnvironment)
+            TaskEnvironment taskEnvironment,
+            CancellationToken cancellationToken = default)
         {
             _log = log;
             _findDependencies = findDependencies;
@@ -348,6 +353,7 @@ namespace Microsoft.Build.Tasks
             _nonCultureResourceDirectories = nonCultureResourceDirectories;
             _enableCustomCulture = enableCustomCulture;
             _taskEnvironment = taskEnvironment;
+            _cancellationToken = cancellationToken;
 
             // Set condition for when to check assembly version against the target framework version
             _checkAssemblyVersionAgainstTargetFrameworkVersion = unresolveFrameworkAssembliesFromHigherFrameworks || ((_projectTargetFramework ?? ReferenceTable.s_targetFrameworkVersion_40) <= ReferenceTable.s_targetFrameworkVersion_40);
@@ -360,6 +366,7 @@ namespace Microsoft.Build.Tasks
             {
                 foreach (ITaskItem resolvedSDK in resolvedSDKItems)
                 {
+                    _cancellationToken.ThrowIfCancellationRequested();
                     string sdkName = resolvedSDK.GetMetadata("SDKName");
 
                     if (sdkName.Length > 0)
@@ -388,7 +395,8 @@ namespace Microsoft.Build.Tasks
                     targetedRuntimeVersion,
                     getAssemblyPathInGac,
                     log,
-                    taskEnvironment);
+                    taskEnvironment,
+                    cancellationToken);
         }
 
         /// <summary>
@@ -550,6 +558,7 @@ namespace Microsoft.Build.Tasks
             {
                 foreach (ITaskItem i in referenceAssemblyFiles)
                 {
+                    _cancellationToken.ThrowIfCancellationRequested();
                     SetPrimaryFileItem(i);
                 }
             }
@@ -560,6 +569,7 @@ namespace Microsoft.Build.Tasks
             {
                 foreach (ITaskItem n in referenceAssemblyNames)
                 {
+                    _cancellationToken.ThrowIfCancellationRequested();
                     Exception e = SetPrimaryAssemblyReferenceItem(n);
 
                     if (e != null)
@@ -999,6 +1009,7 @@ namespace Microsoft.Build.Tasks
 
                 foreach (string subDirectory in subDirectories)
                 {
+                    _cancellationToken.ThrowIfCancellationRequested();
                     // Is there a candidate satellite in that folder?
                     string cultureName = Path.GetFileName(subDirectory);
 
@@ -1062,6 +1073,7 @@ namespace Microsoft.Build.Tasks
                 out scatterFiles,
                 out FrameworkName frameworkName);
 
+            _cancellationToken.ThrowIfCancellationRequested();
             reference.FrameworkNameAttribute = frameworkName;
 
             var dependencies = new List<AssemblyNameExtension>(dependentAssemblies?.Length ?? 0);
@@ -1071,6 +1083,7 @@ namespace Microsoft.Build.Tasks
                 // Re-map immediately so that to the sytem we actually got the remapped version when reading the manifest.
                 for (int i = 0; i < dependentAssemblies.Length; i++)
                 {
+                    _cancellationToken.ThrowIfCancellationRequested();
                     // This will return a clone of the remapped assemblyNameExtension so its ok to party on it.
                     AssemblyNameExtension remappedExtension = _installedAssemblies?.RemapAssemblyExtension(dependentAssemblies[i]);
                     if (remappedExtension != null)
@@ -1114,6 +1127,7 @@ namespace Microsoft.Build.Tasks
         {
             foreach (AssemblyNameExtension preUnificationAssemblyName in preUnificationAssemblyNames)
             {
+                _cancellationToken.ThrowIfCancellationRequested();
                 // First, unify the assembly name so that we're dealing with the right version.
                 // Not AssemblyNameExtension because we're going to write to it.
                 var dependentAssembly = new AssemblyNameExtension(preUnificationAssemblyName.AssemblyName.CloneIfPossible());
@@ -1323,14 +1337,17 @@ namespace Microsoft.Build.Tasks
             // If a reference has the SDKName metadata on it then we will only search using a single resolver, that is the InstalledSDKResolver.
             if (reference.SDKName.Length > 0)
             {
-                jaggedResolvers.Add([new InstalledSDKResolver(_resolvedSDKReferences, "SDKResolver", _getAssemblyName, _fileExists, _getRuntimeVersion, _targetedRuntimeVersion, _taskEnvironment)]);
+                jaggedResolvers.Add([new InstalledSDKResolver(_resolvedSDKReferences, "SDKResolver", _getAssemblyName, _fileExists, _getRuntimeVersion, _targetedRuntimeVersion, _taskEnvironment)
+                {
+                    CancellationToken = _cancellationToken
+                }]);
             }
             else
             {
                 // Do not probe near dependees if the reference is primary and resolved externally. If resolved externally, the search paths should have been specified in such a way to point to the assembly file.
                 if (parentReferenceFolders.Count > 0 && (assemblyName == null || !_externallyResolvedPrimaryReferences.Contains(assemblyName.Name)))
                 {
-                    jaggedResolvers.Add(AssemblyResolution.CompileDirectories(parentReferenceFolders, _fileExists, _getAssemblyName, _getRuntimeVersion, _targetedRuntimeVersion, _taskEnvironment));
+                    jaggedResolvers.Add(AssemblyResolution.CompileDirectories(parentReferenceFolders, _fileExists, _getAssemblyName, _getRuntimeVersion, _targetedRuntimeVersion, _taskEnvironment, _cancellationToken));
                 }
 
                 jaggedResolvers.Add(Resolvers);
@@ -1402,6 +1419,7 @@ namespace Microsoft.Build.Tasks
         internal void RemoveReferencesMarkedForExclusion(bool removeOnlyNoWarning, string subsetName)
         {
             MSBuildEventSource.Log.RarRemoveReferencesMarkedForExclusionStart();
+            try
             {
                 // Create a table which will contain the references which are not in the deny list
                 var goodReferences = new Dictionary<AssemblyNameExtension, Reference>(AssemblyNameComparer.GenericComparer);
@@ -1420,6 +1438,7 @@ namespace Microsoft.Build.Tasks
                 // Go through each of the references, we go through this table because in general it will be considerably smaller than the denylist. (10's of references vs 100's of deny list items)
                 foreach (KeyValuePair<AssemblyNameExtension, Reference> assembly in References)
                 {
+                    _cancellationToken.ThrowIfCancellationRequested();
                     AssemblyNameExtension assemblyName = assembly.Key;
                     Reference assemblyReference = assembly.Value;
 
@@ -1484,11 +1503,15 @@ namespace Microsoft.Build.Tasks
                 // dependencies of them.
                 foreach (Reference reference in removedReferences)
                 {
+                    _cancellationToken.ThrowIfCancellationRequested();
                     RemoveDependencies(reference, goodReferences, dependencyGraph);
                 }
 
                 // Replace the references table with the list only containing good references.
                 References = goodReferences;
+            }
+            finally
+            {
                 MSBuildEventSource.Log.RarRemoveReferencesMarkedForExclusionStop();
             }
         }
@@ -1655,7 +1678,9 @@ namespace Microsoft.Build.Tasks
             List<Exception> exceptions)
         {
             MSBuildEventSource.Log.RarComputeClosureStart();
+            try
             {
+                _cancellationToken.ThrowIfCancellationRequested();
                 References.Clear();
                 _externallyResolvedPrimaryReferences.Clear();
                 SkippedFindingExternallyResolvedDependencies = false;
@@ -1665,7 +1690,10 @@ namespace Microsoft.Build.Tasks
 
                 ComputeClosure();
             }
-            MSBuildEventSource.Log.RarComputeClosureStop();
+            finally
+            {
+                MSBuildEventSource.Log.RarComputeClosureStop();
+            }
         }
 
         /// <summary>
@@ -1684,6 +1712,7 @@ namespace Microsoft.Build.Tasks
                 int dependencyIterations = 0;
                 do
                 {
+                    _cancellationToken.ThrowIfCancellationRequested();
                     // Resolve all references.
                     ResolveAssemblyFilenames();
 
@@ -1726,6 +1755,7 @@ namespace Microsoft.Build.Tasks
 
             foreach (Reference reference in References.Values)
             {
+                _cancellationToken.ThrowIfCancellationRequested();
                 // If the reference is resolved, but dependencies haven't been found,
                 // then find dependencies.
                 if (reference.IsResolved && !reference.DependenciesFound)
@@ -1807,6 +1837,7 @@ namespace Microsoft.Build.Tasks
             // Add each new dependency found.
             foreach (KeyValuePair<AssemblyNameExtension, Reference> newEntry in newEntries)
             {
+                _cancellationToken.ThrowIfCancellationRequested();
                 newDependencies = true;
                 AddReference(newEntry.Key, newEntry.Value);
             }
@@ -1821,6 +1852,7 @@ namespace Microsoft.Build.Tasks
         {
             foreach (KeyValuePair<AssemblyNameExtension, Reference> assembly in References)
             {
+                _cancellationToken.ThrowIfCancellationRequested();
                 Reference reference = assembly.Value;
 
                 // Has this reference been resolved to a file name?
@@ -1840,6 +1872,7 @@ namespace Microsoft.Build.Tasks
             // Now we have references organized into groups that would conflict.
             foreach (List<AssemblyNameReference> assemblyReferences in baseNameToReferences.Values)
             {
+                _cancellationToken.ThrowIfCancellationRequested();
                 ResolveConflictsBetweenReferences(assemblyReferences);
             }
         }
@@ -1855,6 +1888,7 @@ namespace Microsoft.Build.Tasks
 
             while (comparisonIndex < assemblyReferences.Count)
             {
+                _cancellationToken.ThrowIfCancellationRequested();
                 bool isLeftVictim = ResolveAssemblyNameConflict(
                     assemblyReferences[currentWinnerIndex],
                     assemblyReferences[comparisonIndex]) == 0;
@@ -1902,6 +1936,7 @@ namespace Microsoft.Build.Tasks
             {
                 foreach (AssemblyNameReference assemblyNameReference in references)
                 {
+                    _cancellationToken.ThrowIfCancellationRequested();
                     AssemblyNameExtension assemblyName = assemblyNameReference.assemblyName;
                     Reference reference = assemblyNameReference.reference;
 
@@ -1958,6 +1993,7 @@ namespace Microsoft.Build.Tasks
 
             foreach (AssemblyNameReference assemblyNameReference in assemblyNamesList)
             {
+                _cancellationToken.ThrowIfCancellationRequested();
                 var remapping = new DependentAssembly
                 {
                     PartialAssemblyName = assemblyNameReference.assemblyName.AssemblyName
@@ -2217,6 +2253,7 @@ namespace Microsoft.Build.Tasks
 
             foreach (KeyValuePair<AssemblyNameExtension, Reference> assemblyNameWithReference in References)
             {
+                _cancellationToken.ThrowIfCancellationRequested();
                 AssemblyNameExtension assemblyName = assemblyNameWithReference.Key;
                 Reference reference = assemblyNameWithReference.Value;
                 AssemblyNameReference assemblyReference = AssemblyNameReference.Create(assemblyName, reference);
@@ -2627,6 +2664,7 @@ namespace Microsoft.Build.Tasks
 
             foreach (KeyValuePair<AssemblyNameExtension, Reference> kvp in References)
             {
+                _cancellationToken.ThrowIfCancellationRequested();
                 AssemblyNameExtension assemblyName = kvp.Key;
                 Reference reference = kvp.Value;
 
@@ -3106,6 +3144,7 @@ namespace Microsoft.Build.Tasks
 
             foreach (KeyValuePair<AssemblyNameExtension, Reference> assembly in References)
             {
+                _cancellationToken.ThrowIfCancellationRequested();
                 AssemblyNameExtension assemblyName = assembly.Key;
                 Reference reference = assembly.Value;
                 string assemblyFullName = assemblyName.FullName;

--- a/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
+++ b/src/Tasks/AssemblyDependency/ResolveAssemblyReference.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
+using System.Threading;
 using System.Xml.Linq;
 
 using Microsoft.Build.Eventing;
@@ -34,7 +35,7 @@ namespace Microsoft.Build.Tasks
     /// depend on those assemblyFiles including second and nth-order dependencies too.
     /// </summary>
     [MSBuildMultiThreadableTask]
-    public class ResolveAssemblyReference : TaskExtension, IIncrementalTask, IMultiThreadableTask
+    public class ResolveAssemblyReference : TaskExtension, ICancelableTask, IIncrementalTask, IMultiThreadableTask
     {
         /// <summary>
         /// key assembly used to trigger inclusion of facade references.
@@ -62,6 +63,8 @@ namespace Microsoft.Build.Tasks
         /// Cache of system state information, used to optimize performance.
         /// </summary>
         internal SystemState _cache = null;
+
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
 
         /// <summary>
         /// Construct
@@ -1236,6 +1239,7 @@ namespace Microsoft.Build.Tasks
         {
             bool success = true;
             MSBuildEventSource.Log.RarLogResultsStart();
+            try
             {
                 /*
                 PERF NOTE: The Silent flag turns off logging completely from the task side. This means
@@ -1247,6 +1251,7 @@ namespace Microsoft.Build.Tasks
                     // First, loop over primaries and display information.
                     foreach (KeyValuePair<AssemblyNameExtension, Reference> assembly in dependencyTable.References)
                     {
+                        _cancellationTokenSource.Token.ThrowIfCancellationRequested();
                         AssemblyNameExtension assemblyName = assembly.Key;
                         string fusionName = assemblyName.FullName;
                         Reference primaryCandidate = assembly.Value;
@@ -1260,6 +1265,7 @@ namespace Microsoft.Build.Tasks
                     // Second, loop over dependencies and display information.
                     foreach (KeyValuePair<AssemblyNameExtension, Reference> assembly in dependencyTable.References)
                     {
+                        _cancellationTokenSource.Token.ThrowIfCancellationRequested();
                         AssemblyNameExtension assemblyName = assembly.Key;
                         string fusionName = assemblyName.FullName;
                         Reference dependencyCandidate = assembly.Value;
@@ -1273,6 +1279,7 @@ namespace Microsoft.Build.Tasks
                     // Third, show conflicts and their resolution.
                     foreach (KeyValuePair<AssemblyNameExtension, Reference> assembly in dependencyTable.References)
                     {
+                        _cancellationTokenSource.Token.ThrowIfCancellationRequested();
                         AssemblyNameExtension assemblyName = assembly.Key;
                         string fusionName = assemblyName.FullName;
                         Reference conflictCandidate = assembly.Value;
@@ -1335,6 +1342,7 @@ namespace Microsoft.Build.Tasks
                         // A high-priority message for each individual redirect.
                         for (int i = 0; i < idealAssemblyRemappings.Count; i++)
                         {
+                            _cancellationTokenSource.Token.ThrowIfCancellationRequested();
                             DependentAssembly idealRemapping = idealAssemblyRemappings[i];
                             AssemblyName idealRemappingPartialAssemblyName = idealRemapping.PartialAssemblyName;
                             Reference reference = idealAssemblyRemappingsIdentities[i].reference;
@@ -1439,32 +1447,35 @@ namespace Microsoft.Build.Tasks
                         }
                     }
                 }
-            }
-
 #if FEATURE_WIN32_REGISTRY
-            MessageImportance messageImportance = MessageImportance.Low;
-            if (dependencyTable.Resolvers != null && Log.LogsMessagesOfImportance(messageImportance))
-            {
-                foreach (Resolver r in dependencyTable.Resolvers)
+                MessageImportance messageImportance = MessageImportance.Low;
+                if (dependencyTable.Resolvers != null && Log.LogsMessagesOfImportance(messageImportance))
                 {
-                    if (r is AssemblyFoldersExResolver assemblyFoldersExResolver)
+                    foreach (Resolver r in dependencyTable.Resolvers)
                     {
-                        AssemblyFoldersEx assemblyFoldersEx = assemblyFoldersExResolver.AssemblyFoldersExLocations;
-
-                        if (assemblyFoldersEx != null && _showAssemblyFoldersExLocations.TryGetValue(r.SearchPath, out messageImportance))
+                        _cancellationTokenSource.Token.ThrowIfCancellationRequested();
+                        if (r is AssemblyFoldersExResolver assemblyFoldersExResolver)
                         {
-                            Log.LogMessageFromResources(messageImportance, "ResolveAssemblyReference.AssemblyFoldersExSearchLocations", r.SearchPath);
-                            foreach (var path in assemblyFoldersEx.UniqueDirectoryPaths)
+                            AssemblyFoldersEx assemblyFoldersEx = assemblyFoldersExResolver.AssemblyFoldersExLocations;
+
+                            if (assemblyFoldersEx != null && _showAssemblyFoldersExLocations.TryGetValue(r.SearchPath, out messageImportance))
                             {
-                                Log.LogMessageFromResources(messageImportance, "ResolveAssemblyReference.EightSpaceIndent", path);
+                                Log.LogMessageFromResources(messageImportance, "ResolveAssemblyReference.AssemblyFoldersExSearchLocations", r.SearchPath);
+                                foreach (var path in assemblyFoldersEx.UniqueDirectoryPaths)
+                                {
+                                    _cancellationTokenSource.Token.ThrowIfCancellationRequested();
+                                    Log.LogMessageFromResources(messageImportance, "ResolveAssemblyReference.EightSpaceIndent", path);
+                                }
                             }
                         }
                     }
                 }
-            }
 #endif
-
-            MSBuildEventSource.Log.RarLogResultsStop();
+            }
+            finally
+            {
+                MSBuildEventSource.Log.RarLogResultsStop();
+            }
 
             return success;
         }
@@ -1643,6 +1654,7 @@ namespace Microsoft.Build.Tasks
             Log.LogMessage(importance, property, "Assemblies");
             foreach (ITaskItem item in Assemblies)
             {
+                _cancellationTokenSource.Token.ThrowIfCancellationRequested();
                 Log.LogMessage(importance, indent + item.ItemSpec);
                 LogAttribute(item, ItemMetadataNames.privateMetadata);
                 LogAttribute(item, ItemMetadataNames.hintPath);
@@ -1655,6 +1667,7 @@ namespace Microsoft.Build.Tasks
             Log.LogMessage(importance, property, "AssemblyFiles");
             foreach (ITaskItem item in AssemblyFiles)
             {
+                _cancellationTokenSource.Token.ThrowIfCancellationRequested();
                 Log.LogMessage(importance, indent + item.ItemSpec);
                 LogAttribute(item, ItemMetadataNames.privateMetadata);
                 LogAttribute(item, ItemMetadataNames.fusionName);
@@ -1663,6 +1676,7 @@ namespace Microsoft.Build.Tasks
             Log.LogMessage(importance, property, "CandidateAssemblyFiles");
             foreach (AbsolutePath file in _candidateAssemblyFiles)
             {
+                _cancellationTokenSource.Token.ThrowIfCancellationRequested();
                 try
                 {
                     if (FileUtilities.HasExtension(file.OriginalValue, _allowedAssemblyExtensions))
@@ -1695,6 +1709,7 @@ namespace Microsoft.Build.Tasks
             Log.LogMessage(importance, property, "SearchPaths");
             foreach (string path in SearchPaths)
             {
+                _cancellationTokenSource.Token.ThrowIfCancellationRequested();
                 Log.LogMessage(importance, indent + path);
             }
 
@@ -2282,6 +2297,11 @@ namespace Microsoft.Build.Tasks
         #endregion
         #region ITask Members
 
+        /// <summary>
+        /// Stop assembly resolution as soon as possible.
+        /// </summary>
+        public void Cancel() => _cancellationTokenSource.Cancel();
+
 #if FEATURE_WIN32_REGISTRY
         /// <summary>
         /// Execute the task.
@@ -2336,10 +2356,12 @@ namespace Microsoft.Build.Tasks
             ReadMachineTypeFromPEHeader readMachineTypeFromPEHeader)
         {
             bool success = true;
+            CancellationToken cancellationToken = _cancellationTokenSource.Token;
             MSBuildEventSource.Log.RarOverallStart();
             {
                 try
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     FrameworkNameVersioning frameworkMoniker = null;
                     if (!String.IsNullOrEmpty(_targetedFrameworkMoniker))
                     {
@@ -2359,6 +2381,7 @@ namespace Microsoft.Build.Tasks
 
                     // Log task inputs.
                     LogInputs();
+                    cancellationToken.ThrowIfCancellationRequested();
 
                     if (!VerifyInputConditions())
                     {
@@ -2485,12 +2508,19 @@ namespace Microsoft.Build.Tasks
                     }
 
                     // Load any prior saved state.
+                    cancellationToken.ThrowIfCancellationRequested();
                     ReadStateFile(fileExists);
+                    cancellationToken.ThrowIfCancellationRequested();
                     _cache.SetInstalledAssemblyInformation(installedAssemblyTableInfo);
 
                     // Cache delegates.
                     getAssemblyMetadata = _cache.CacheDelegate(getAssemblyMetadata);
-                    fileExists = _cache.CacheDelegate();
+                    FileExists cachedFileExists = _cache.CacheDelegate();
+                    fileExists = path =>
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        return cachedFileExists(path);
+                    };
                     directoryExists = _cache.CacheDelegate(directoryExists);
                     getDirectories = _cache.CacheDelegate(getDirectories);
 
@@ -2499,6 +2529,7 @@ namespace Microsoft.Build.Tasks
                     // Wrap the GetLastWriteTime callback with a check for SDK/immutable files.
                     _cache.SetGetLastWriteTime(path =>
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
                         if (dependencyTable?.IsImmutableFile(path) == true)
                         {
                             // We don't want to perform I/O to see what the actual timestamp on disk is so we return a fixed made up value.
@@ -2512,6 +2543,7 @@ namespace Microsoft.Build.Tasks
                     GetAssemblyName originalGetAssemblyName = getAssemblyName;
                     getAssemblyName = _cache.CacheDelegate(path =>
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
                         AssemblyNameExtension assemblyName = dependencyTable?.GetImmutableFileAssemblyName(path);
                         return assemblyName ?? originalGetAssemblyName(path);
                     });
@@ -2519,6 +2551,7 @@ namespace Microsoft.Build.Tasks
                     GetAssemblyRuntimeVersion originalGetRuntimeVersion = getRuntimeVersion;
                     getRuntimeVersion = _cache.CacheDelegate(path =>
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
                         if (dependencyTable?.IsImmutableFile(path) == true)
                         {
                             // There are no WinRT assemblies in the SDK, everything has the .NET metadata version.
@@ -2613,7 +2646,8 @@ namespace Microsoft.Build.Tasks
                         _unresolveFrameworkAssembliesFromHigherFrameworks,
                         assemblyMetadataCache,
                         _nonCultureResourceDirectories,
-                        TaskEnvironment);
+                        TaskEnvironment,
+                        cancellationToken);
 
                     dependencyTable.FindDependenciesOfExternallyResolvedReferences = FindDependenciesOfExternallyResolvedReferences;
 
@@ -2698,6 +2732,7 @@ namespace Microsoft.Build.Tasks
                     }
 
                     // Build the output tables.
+                    cancellationToken.ThrowIfCancellationRequested();
                     dependencyTable.GetReferenceItems(
                         out _resolvedFiles,
                         out _resolvedDependencyFiles,
@@ -2722,6 +2757,7 @@ namespace Microsoft.Build.Tasks
                     bool useNetStandard = false;
                     foreach (var reference in dependencyTable.References.Keys)
                     {
+                        cancellationToken.ThrowIfCancellationRequested();
                         if (string.Equals(SystemRuntimeAssemblyName, reference.Name, StringComparison.OrdinalIgnoreCase))
                         {
                             useSystemRuntime = true;
@@ -2741,6 +2777,7 @@ namespace Microsoft.Build.Tasks
                         // when we are not producing the (full) dependency graph look for direct dependencies of primary references
                         foreach (var resolvedReference in dependencyTable.References.Values)
                         {
+                            cancellationToken.ThrowIfCancellationRequested();
                             if (FindDependencies && !resolvedReference.ExternallyResolved)
                             {
                                 // if we're finding dependencies and a given reference was not marked as ExternallyResolved
@@ -2776,6 +2813,7 @@ namespace Microsoft.Build.Tasks
                     this.DependsOnSystemRuntime = useSystemRuntime.ToString();
                     this.DependsOnNETStandard = useNetStandard.ToString();
 
+                    cancellationToken.ThrowIfCancellationRequested();
                     WriteStateFile();
 
                     // Save the new state out and put into the file exists if it is actually on disk.
@@ -2785,6 +2823,7 @@ namespace Microsoft.Build.Tasks
                     }
 
                     // Log the results.
+                    cancellationToken.ThrowIfCancellationRequested();
                     success = LogResults(dependencyTable, idealAssemblyRemappings, idealAssemblyRemappingsIdentities, generalResolutionExceptions);
 
                     DumpTargetProfileLists(installedAssemblyTableInfo, inclusionListSubsetTableInfo, dependencyTable);
@@ -2793,6 +2832,7 @@ namespace Microsoft.Build.Tasks
                     {
                         foreach (ITaskItem item in _resolvedFiles)
                         {
+                            cancellationToken.ThrowIfCancellationRequested();
                             AssemblyNameExtension assemblyName = null;
 
                             if (fileExists(item.ItemSpec) && !Reference.IsFrameworkFile(item.ItemSpec, _targetFrameworkDirectories))
@@ -2846,7 +2886,11 @@ namespace Microsoft.Build.Tasks
                         }
                     }
                     MSBuildEventSource.Log.RarOverallStop(_assemblyNames?.Length ?? -1, _assemblyFiles?.Length ?? -1, _resolvedFiles?.Length ?? -1, _resolvedDependencyFiles?.Length ?? -1, _copyLocalFiles?.Length ?? -1, _findDependencies);
-                    return success && !Log.HasLoggedErrors;
+                    return success && !Log.HasLoggedErrors && !cancellationToken.IsCancellationRequested;
+                }
+                catch (OperationCanceledException e) when (e.CancellationToken == cancellationToken)
+                {
+                    success = false;
                 }
                 catch (ArgumentException e)
                 {
@@ -2864,7 +2908,7 @@ namespace Microsoft.Build.Tasks
 
             MSBuildEventSource.Log.RarOverallStop(_assemblyNames?.Length ?? -1, _assemblyFiles?.Length ?? -1, _resolvedFiles?.Length ?? -1, _resolvedDependencyFiles?.Length ?? -1, _copyLocalFiles?.Length ?? -1, _findDependencies);
 
-            return success && !Log.HasLoggedErrors;
+            return success && !Log.HasLoggedErrors && !cancellationToken.IsCancellationRequested;
         }
 
         /// <summary>
@@ -2890,7 +2934,8 @@ namespace Microsoft.Build.Tasks
                         getAssemblyMetadata(resolvedReference.FullPath, assemblyMetadataCache, out result, out scatterFiles, out frameworkName);
                     }
                 }
-                catch (Exception e) when (!ExceptionHandling.IsCriticalException(e))
+                catch (Exception e) when (!ExceptionHandling.IsCriticalException(e)
+                    && !(e is OperationCanceledException canceled && canceled.CancellationToken == _cancellationTokenSource.Token))
                 {
                 }
             }

--- a/src/Tasks/AssemblyDependency/Resolver.cs
+++ b/src/Tasks/AssemblyDependency/Resolver.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using System.Threading;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 
@@ -107,6 +108,8 @@ namespace Microsoft.Build.Tasks
         /// </summary>
         public string SearchPath => searchPathElement;
 
+        internal CancellationToken CancellationToken { get; set; }
+
         /// <summary>
         /// Resolve a single file.
         /// </summary>
@@ -157,6 +160,7 @@ namespace Microsoft.Build.Tasks
             string fullPathToCandidateAssembly,
             ResolutionSearchLocation searchLocation)
         {
+            CancellationToken.ThrowIfCancellationRequested();
             if (searchLocation != null)
             {
                 searchLocation.FileNameAttempted = fullPathToCandidateAssembly;
@@ -310,6 +314,7 @@ namespace Microsoft.Build.Tasks
             string fullPathToDirectory,
             List<ResolutionSearchLocation> assembliesConsideredAndRejected)
         {
+            CancellationToken.ThrowIfCancellationRequested();
             if (assemblyName == null)
             {
                 // This can happen if the assembly name is actually a file name.


### PR DESCRIPTION
Fixes #12268

### Context

Canceling a build currently waits for ResolveAssemblyReference to finish its work. This is particularly noticeable with large reference sets and dependency graphs. Add cooperative cancellation for in-process RAR without changing normal resolution behavior.

### Changes Made

- Implement `ICancelableTask` and propagate a cancellation token through reference resolution, dependency traversal, conflict handling, and output/logging loops. Handle this task's cancellation by returning `false` without introducing cancellation diagnostics.
- Keep cache serialization uninterrupted once it starts, and balance the affected tracing events when execution unwinds.
- Fix a pre-existing cache-isolation problem found while reviewing cancellation safety: dependency remapping modified arrays and nested remapping sets owned by the process-wide metadata cache. Remapping now uses task-local results so later tasks do not inherit another invocation's remappings.
- Add deterministic cancellation and recovery tests, including shared folder-cache reuse, cold cache initialization, complete output metadata comparisons, and positive cache-write controls. Document cancellation semantics.

### Testing

- Full repository build and bootstrap sample build succeeded.
- Scoped RAR suites passed: 52 tests on `net11.0` and 433 on `net472`, including 18 cancellation cases on each runtime. Four cache-isolation regressions failed before the isolation fix and passed afterward.
- Local end-to-end `BuildManager` stress probe: 20,000 references across 64 search paths. Eight cancellation runs, triggered after RAR entered closure computation, returned from `EndBuild()` in 57-73 ms. The non-cancellable SDK RAR baseline on the same engine took 33 seconds after cancellation.
- Local same-process recovery probe: 512 generated signed primary assemblies, transitive dependencies, a real version conflict, and related/satellite/serializer outputs. Cold and warm cancellation, subsequent recovery, and timestamp invalidation preserved the expected output paths and metadata. Cancellation preserved the existing state file; timestamp invalidation updated it. CWD, PATH, and cultures remained unchanged.

The end-to-end probes are local validation artifacts, not committed integration tests.

### Notes

- In-process only; out-of-process RAR behavior and communication are unchanged.
- Cancellation is cooperative, not a guarantee of bounded latency during synchronous I/O or cache initialization. A cache write already in progress may finish before the task returns `false`.
- No new warnings/errors or ChangeWave. Uncancelled resolution semantics are preserved apart from preventing shared-cache contamination.