### PR TITLE
[1/8] Restore repository orientation and clarify local build context

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,1 +1,1 @@
-../AGENTS.md
+Follow [AGENTS.md](../AGENTS.md) at the repository root. It is the canonical repository-wide guidance; load only the path instructions and task references relevant to the work.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,80 +1,30 @@
 ---
-applyTo: "src/*.UnitTests/**/*.cs"
+applyTo: "src/*.UnitTests/**/*.cs,src/UnitTests.Shared/**/*.cs,src/Shared/UnitTests/**/*.cs"
 ---
 
-# Testing Instructions
+# Test authoring
 
-Use xUnit with Shouldly assertions. Use Shouldly assertions for all assertions in modified code, even if the file is predominantly using xUnit assertions.
+## State, output, and assertions
 
-## Capturing Output
+- Use xUnit and Shouldly; use Shouldly for assertions in modified code.
+- Capture diagnostics through `ITestOutputHelper`, usually `_output`, and pass it to `TestEnvironment.Create(_output)` and `MockLogger`. Avoid `Console.WriteLine` for test diagnostics.
+- Use a `using` declaration with [TestEnvironment](../../src/UnitTests.Shared/TestEnvironment.cs) for supported temporary files, environment variables, current directory, and other registered state. It reverts registered state, not arbitrary side effects; use explicit cleanup for unsupported resources.
+- Keep the repository's process-global-state isolation. Do not enable parallel collections or alter traits to speed up a test run.
+- Use [MockLogger](../../src/UnitTests.Shared/MockLogger.cs) for builds and the existing `MockEngine` for isolated task tests. Attach a logger when invoking builds so failures are diagnosable.
+- Assert relevant structured events or invariant/localized content, not an assumed English full message.
 
-Inject xUnit's `ITestOutputHelper` via the test class constructor and store it as `_output`. Pass it to `TestEnvironment.Create(_output)` so that test infrastructure output is captured. Use `_output.WriteLine(...)` instead of `Console.WriteLine` for diagnostic output in tests.
+## Projects and fixtures
 
-## Use `TestEnvironment` for Test Setup and Cleanup
+- Prefer raw string literals for project XML. Use `.Cleanup()` only when placeholders or the helper's normalization are needed; ordinary XML needs no namespace unless the scenario tests one.
+- Reuse [ObjectModelHelpers](../../src/UnitTests.Shared/ObjectModelHelpers.cs), [ProjectFromString](../../src/UnitTests.Shared/ProjectFromString.cs), and the scaffolding in [EngineTestEnvironment](../../src/UnitTests.Shared/EngineTestEnvironment.cs). Read their actual signatures before copying examples.
+- Use existing platform/conditional attributes rather than returning early and silently skipping assertions.
+- Reuse assembly fixtures and existing collections instead of duplicating global setup.
+- Use `[Theory]` with data appropriate to the runner. Follow established serialization patterns for custom theory data when serialization is required; not every custom value needs its own `IXunitSerializable` implementation.
+- Async tests return `Task` and await work. Do not use `async void`.
+- Locate copied test resources relative to the test output, commonly `AppContext.BaseDirectory`; do not depend on the shell's current directory.
 
-Use `TestEnvironment` (`Microsoft.Build.UnitTests.TestEnvironment`) to manage test state. Create with `using TestEnvironment env = TestEnvironment.Create(output);` — prefer a `using` declaration (no braces/indentation). `TestEnvironment` automatically reverts all registered state on dispose. Don't write manual `try`/`finally` blocks to restore state.
+## Evidence
 
-`TestEnvironment` can manage environment variables, temporary files and folders, the working directory, the system temp path, `ProjectCollection` lifetimes, test project scaffolding (`TransientTestProjectWithFiles`), process lifetimes, and test invariants.
+A regression assertion must distinguish the broken behavior from the fix, not merely "no crash" or "nonempty." For transport, concurrency, and build-mode changes, prove the relevant path ran.
 
-## Writing Project XML in Tests
-
-Prefer multiline raw string literals (`"""`) with natural indentation for inline MSBuild XML. Use the `.Cleanup()` extension method (from `Microsoft.Build.UnitTests.ObjectModelHelpers`) to replace `msbuildnamespace` and `msbuilddefaulttoolsversion` placeholders with real values. In raw strings, use normal double-quotes for XML attributes. Fall back to `@""` with backtick-to-quote replacement via `.Cleanup()` only when raw strings are not workable.
-```csharp
-string project = """
-    <Project>
-        <Target Name="Build"><Message Text="Hello" /></Target>
-    </Project>
-    """.Cleanup();
-```
-
-Do not specify `xmlns` in test XML snippets unless it is important to the functionality of the test.
-
-## Build and Task Testing Helpers
-
-Use `MockLogger` (`Microsoft.Build.UnitTests.MockLogger`) to capture and assert build output. It provides `AssertLogContains`, `AssertLogDoesntContain`, `AssertNoErrors`, `AssertNoWarnings`, and typed event collections (`Errors`, `Warnings`, `TargetStartedEvents`, etc.). Do not assume the test locale will be English--assert on invariant substrings or explicit localized resources, not full English strings. Tests that invoke builds via `ProjectCollection` or `BuildManager` must always attach a `MockLogger(_output)` so that build errors and warnings appear in the .trx test output for CI diagnostics.
-
-Use `MockEngine` (`Microsoft.Build.UnitTests.MockEngine`) as an `IBuildEngine` implementation for testing individual tasks in isolation without a full build.
-
-Use `ObjectModelHelpers.BuildProjectExpectSuccess`/`BuildProjectExpectFailure` (`Microsoft.Build.UnitTests.ObjectModelHelpers`) for quick in-memory builds that return a `MockLogger`. Use `ProjectFromString` (`Microsoft.Build.UnitTests.ProjectFromString`) — disposable, use with a `using` declaration — to create `Project` instances from XML for object model inspection.
-
-## Platform-Conditional Tests
-
-Use existing custom attributes for platform-specific tests instead of runtime `if` checks that silently skip assertions. Available attributes include `WindowsOnlyFact`, `WindowsFullFrameworkOnlyFact`, `UnixOnlyFact`, `RequiresSymbolicLinksFactAttribute`, `LongPathSupportDisabledFactAttribute`, and `SkipOnPlatform`. Use `ConditionalFact(nameof(ConditionMethod))` for custom conditions.
-
-## Assembly Fixtures and Collections
-
-Test assemblies use assembly fixtures (for example, `Microsoft.Build.UnitTests.MSBuildTestAssemblyFixture` and `Microsoft.Build.UnitTests.MSBuildTestEnvironmentFixture`). Avoid duplicating global setup in individual tests.
-
-## Data-Driven and Async Tests
-
-Use `[Theory]` with `[InlineData]` for simple inputs. Use `[MemberData]` or `TheoryData<T>` for complex objects (returning `IEnumerable<object[]>`). If the data type is custom, implement `IXunitSerializable`.
-
-```csharp
-[Theory]
-[InlineData("input1", "expected1")]
-public void TestLogic(string input, string expected) { ... }
-```
-
-For async tests, always return `async Task` (never `async void`) and `await` asynchronous operations.
-```csharp
-[Fact]
-public async Task AsyncOperation_Works() {
-    await service.DoWorkAsync();
-}
-```
-
-## Test Resources
-
-Resolve test data files via `AppContext.BaseDirectory` (for example, `Path.Combine(AppContext.BaseDirectory, "TestResources", "file.bin")`) so paths work across runners.
-
-## Assertion Helpers
-
-Use `Shouldly` extensions for `BuildResult`: `result.ShouldHaveSucceeded()` or `result.ShouldHaveFailed()`.
-Use `ObjectModelHelpers.AssertItemsMatch` (`Microsoft.Build.UnitTests.ObjectModelHelpers`) to validate items and metadata using a compact string format:
-```csharp
-ObjectModelHelpers.AssertItemsMatch(
-    "Item1 : Meta=Val; Item2", 
-    project.GetItems("MyItem"));
-```
-
-Use `ObjectModelHelpers.AssertSingleItem`, `AssertItems`, and `AssertItemHasMetadata` for item/property assertions, and `NormalizeSlashes` for cross-platform path comparisons.
+For runner commands, filtering, supported TFMs, and escalation, read [running-unit-tests](../skills/running-unit-tests/SKILL.md). Test authoring does not by itself require a test-generation plugin.

--- a/.github/skills/benchmarking-msbuild/SKILL.md
+++ b/.github/skills/benchmarking-msbuild/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: benchmarking-msbuild
+description: "Measure and compare MSBuild modes, SDKs, or revisions with an explicit warm/cold and clean/incremental/no-op experiment. Not speculative optimization, CI failure triage, or proof from a single elapsed-time sample."
+---
+
+# Compare MSBuild performance
+
+## Before timing
+
+Define the comparison, workload, changing variable, output artifact, and measurement budget. Read [the experiment protocol](references/experiment-protocol.md) for the required controls.
+
+Do not infer `-mt` from a discussion about migrated tasks, or a warm process from an incremental build. Confirm those settings explicitly in the experiment record before spending time on rounds.
+
+## Workflow
+
+1. Pin A/B executable and SDK identities, source revisions where applicable, and the workload.
+2. Separate clean, source-edit incremental, and no-op builds; separate process/server warmth from filesystem/compiler caches.
+3. Prove the commands succeed and actually use the intended execution modes. Diagnose setup failure before timing.
+4. Run paired interleaved rounds with the same controls, logging settings, and declared reset/warm-up procedure. Do not run unrelated heavy work concurrently with timings.
+5. Inspect spread and paired differences, not just one fastest result. Use a diagnostic run to investigate a reproducible difference without silently changing the timed configuration.
+6. Return measured results, commands/identities, artifacts, and uncertainty. Stop at the declared budget or a concrete setup blocker; do not keep sampling until a desired result appears.
+
+Use [bootstrap MSBuild](../use-bootstrap-msbuild/SKILL.md) only when local product revisions are the comparison, and [performance guidance](../optimizing-msbuild-performance/SKILL.md) after evidence identifies an implementation bottleneck.
+
+Do not alter Defender, indexing, system-wide caches, other users' processes, or machine security settings as an unrequested benchmark optimization.

--- a/.github/skills/benchmarking-msbuild/references/experiment-protocol.md
+++ b/.github/skills/benchmarking-msbuild/references/experiment-protocol.md
@@ -1,0 +1,51 @@
+# Controlled MSBuild experiment
+
+## Experiment record
+
+Fill this before running measurement rounds; discover values rather than copying a past session's machine state.
+
+| Field | Required distinction |
+|---|---|
+| Question | Full SDK comparison, MSBuild-only revision change, or one execution-mode change |
+| A/B identity | Absolute host paths, SDK/product versions, source SHA when relevant, architecture/runtime |
+| Workload | Exact project/solution/input revision; synthetic versus representative |
+| Mode | Default, `-m`, or `-mt`; relevant node reuse/server/compiler-server settings |
+| Build case | Clean outputs, controlled source-edit incremental, or no-op |
+| Warmth | MSBuild process/server, compiler process/server, filesystem cache, restore/package state |
+| Constants | Configuration, targets, properties, restore policy, logging/instrumentation, environment |
+| Plan | Warm-up, reset procedure, paired ordering, round budget, outlier policy, stopping condition |
+| Evidence | Per-round timings/results plus commands and diagnostic artifacts |
+
+A clean build means outputs were reset; it does not imply cold processes or cold filesystem caches. A source-edit incremental build is not a no-op. Warm compiler and MSBuild servers are distinct.
+
+Comparing two SDKs also changes their compilers/tasks/dependencies. Label that a full SDK comparison unless those variables are controlled; do not attribute every difference to MSBuild alone.
+
+## Preflight and provenance
+
+Resolve and record the actual executable paths. Check SDK selection from the workload directory, including `global.json` and environment overrides. Separate baseline/candidate outputs so a build cannot overwrite the other side.
+
+Run each case once for correctness before timing. Establish requested mode versus actual execution using relevant process and binlog evidence; a switch can be rejected, forwarded differently by a `dotnet` verb, or cause fallback.
+
+For local revisions, use the [bootstrap workflow](../../use-bootstrap-msbuild/SKILL.md). For installed SDKs, do not silently replace them with local bootstrap bits or modify the repository's SDK pin.
+
+## Rounds and artifacts
+
+Use paired interleaved ordering, such as A/B then B/A, to reduce time-dependent machine drift. Declare the number of rounds and how resets/warm-up work before interpreting results.
+
+Keep both sides' logging identical. If collecting a binlog materially perturbs the timing question, use separate diagnostic runs and state that distinction. Record failures instead of dropping them silently.
+
+Capture a machine-readable per-round record with case, order, identity, elapsed time, result, and relevant process state. Keep raw artifacts outside committed product source unless requested.
+
+Report the center and spread of timings plus paired differences. If noise is larger than the effect, say the experiment is inconclusive. Do not report only a favorable minimum or remove outliers after seeing which side benefits.
+
+## Investigate only the observed difference
+
+Use available binlog tools to narrow evaluation, targets/tasks, parallelism, task hosts, and critical-path changes. Profile CPU/allocations/I/O only when needed for the causal question. Read the relevant [performance guidance](../../optimizing-msbuild-performance/SKILL.md) rather than loading every performance skill.
+
+A different process count or target duration supports a mechanism but does not alone prove an end-to-end improvement. Verify that the workload still produced equivalent intended outputs.
+
+## Boundaries
+
+Do not disable security software, clear machine-wide caches, or terminate unrelated processes. Identify only task-owned processes by PID. A busy shared machine is a limitation to record, not permission to reconfigure it.
+
+Use the planned budget; extend it only for a stated reason or user request. Avoid repeated trials until a positive result or an arbitrary significance threshold appears.

--- a/.github/skills/running-unit-tests/SKILL.md
+++ b/.github/skills/running-unit-tests/SKILL.md
@@ -1,137 +1,39 @@
 ---
 name: running-unit-tests
-description: Guide for running MSBuild unit tests efficiently. Use when running, scoping, filtering, or speeding up unit tests in this repository, or when finalizing a change with a heavier validation pass. Covers xUnit v3 + Microsoft.Testing.Platform (MTP) specifics and which `dotnet test` flags do and don't apply.
-argument-hint: Run, filter, scope, or speed up MSBuild unit tests.
+description: "Run or filter existing MSBuild unit tests with the checkout's SDK and runner. Use for local test execution and scoped validation, not CI triage or generating a new test suite."
 ---
 
-# Running MSBuild Unit Tests
+# Run existing MSBuild tests
 
-This repo uses **xUnit v3** with the **Microsoft.Testing.Platform (MTP)** runner. Test projects are built as `OutputType=Exe`, so each test assembly is a self-contained host process — *not* a classic VSTest assembly.
+## Before running
 
-There are **two ways to run tests**:
+1. Read [global.json](../../../global.json) for SDK and test-runner selection, [Directory.Build.props](../../../Directory.Build.props) for runner version floors, and [src/Directory.Build.props](../../../src/Directory.Build.props) for applicable TFMs.
+2. Identify the affected test project and a filter that exercises the behavior. Use one invocation for related selectors supported by the same runner.
+3. Check that the selected SDK exists. Do not substitute an older installed SDK, alter `global.json`, or change feeds to get past a setup error.
 
-| Method | When to use |
-|--------|-------------|
-| `dotnet test <project>` | Dev loop — run a single test project, optionally filtered |
-| `build.cmd -test` / `build.sh --test` | Final validation — builds everything and runs all test projects via the repo's Arcade harness |
+## Current MTP command shape
 
-Use a **fast, scoped** `dotnet test` loop while iterating, and the **full `build.cmd -test`** pass before declaring the change done.
+With `test.runner` set to `Microsoft.Testing.Platform`, use an explicit project selector. Replace `<TFM>` and the filter below with values for the current checkout:
 
-## Repo-specific knobs to know about
+```powershell
+dotnet test --project src\Framework.UnitTests\Microsoft.Build.Framework.UnitTests.csproj `
+  --framework <TFM> -- --filter-method "*FeatureUnderTest*"
+```
 
-These are configured in `Directory.Build.props` (repo root), `src/Directory.Build.targets`, and `src/Shared/UnitTests/xunit.runner.json`. They apply to both `dotnet test` and `build.cmd -test` unless noted otherwise:
+Use the appropriate shell's path separators and continuation syntax. Run through the selected repo SDK; when using a repo-local dotnet host, keep `DOTNET_ROOT` and `PATH` consistent in the same command environment.
 
-- **Multi-targeting**: test projects target .NETFramework and .NETCoreApp on Windows (.NETCoreApp only on Linux/macOS). `dotnet test` runs the suite **once per TFM**.
-- **Single-threaded by default**: `xunit.runner.json` sets `maxParallelThreads: 1` and `parallelizeTestCollections: false`. Many tests mutate process-global state (env vars, cwd, SDK resolvers), so this is intentional.
-- **Auto trait filters**: platform/TFM-inappropriate tests are filtered out via `--filter-not-trait Category=...` (e.g., `nonwindowstests`, `failing`, `nonnetcoreapptests`). Don't try to "fix" tests that appear skipped because of these.
-- **Coverage on non-Windows**: `--coverage --coverage-settings Coverage.config` is appended unconditionally to `XunitOptions` in `src/Directory.Build.targets`. There is no MSBuild property switch to disable it from `dotnet test` — to skip coverage, run the test exe directly without `--coverage`.
-- **Test runner**: `TestRunnerName=XUnitV3`, MTP `1.9.1`, xUnit v3 `3.2.2` (set in repo-root `Directory.Build.props`).
-- **DOTNET_HOST_PATH**: `RunnerUtilities.GetMSBuildEnvironmentVariables` (in `src/UnitTests.Shared/RunnerUtilities.cs`) sets `DOTNET_HOST_PATH` to the bootstrap dotnet when tests launch MSBuild as a child process, so tasks like `RoslynCodeTaskFactory` resolve the right host. Don't override `DOTNET_HOST_PATH` from a test.
+Runner-specific flags come from the test application's registered extensions. Inspect `dotnet test --help` for the selected SDK/project or the built test executable's help if an option is uncertain. Do not mix VSTest's `--filter`, `--logger`, or `--collect` with MTP examples.
 
-## Flags — MTP vs VSTest pitfalls
+## Isolation and stopping criteria
 
-This repo uses MTP with the xUnit v3 MTP runner, **not** VSTest. Many familiar `dotnet test` flags silently do nothing. Key differences:
+- Preserve the single-threaded settings in [xunit.runner.json](../../../src/Shared/UnitTests/xunit.runner.json). Do not temporarily enable parallel collections, remove trait filters, or use quarantine mode as a speed switch.
+- Confirm that the filter selected the intended tests; zero executed tests is not success. Check failures and unexpected skips, not only process exit status.
+- Start with the affected project/TFM. Add other supported TFMs, consumers, or full-suite validation only when the changed boundary or failures justify it.
+- Documentation-only edits do not require unit tests or a product rebuild.
+- A regression proof additionally needs evidence that the assertion fails on the broken baseline and exercises the fixed implementation.
 
-- **Use** `--report-trx` (not `--logger trx`), `--coverage` (not `--collect "XPlat Code Coverage"`), `--filter-method`/`--filter-class`/`--filter-trait` for xUnit v3 native filtering.
-- **Don't use** `--filter`, `--nologo`, `--blame`, `--settings *.runsettings`, `--diag`, `--collect`, or `-- RunConfiguration.MaxCpuCount=...` — these are VSTest-only and ignored.
-- **Still works**: `-c`, `-f`, `--no-restore`, `--no-build`, `-v`, `-bl:`, `-p:Property=Value` — these are interpreted by `dotnet test` itself before MTP sees them.
+## Load only the needed reference
 
-For comprehensive MTP vs VSTest flag reference, see the `run-tests` skill from the `dotnet-test` plugin.
-
-## Dev loop: fast and scoped
-
-Aim for sub-30s iterations.
-
-> Examples below use Windows-style backslashes and PowerShell line continuations. Forward slashes work everywhere with `dotnet` (`src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj`); on Linux/macOS use `/` and shell line continuations (`\`), and the exe path becomes `artifacts/bin/<Proj>/Debug/net11.0/<Proj>` (no `.exe`).
-
-1. **Run via `dotnet test` with a single TFM and filter** (incremental build handles rebuilding automatically):
-   ```powershell
-   dotnet test src\Tasks.UnitTests\Microsoft.Build.Tasks.UnitTests.csproj `
-     -f net11.0 -- --filter-method "*MyFeature*"
-   ```
-2. **Or run the test exe directly** (fastest — no SDK overhead; build first if source changed):
-   ```powershell
-   dotnet build src\Tasks.UnitTests\Microsoft.Build.Tasks.UnitTests.csproj -c Debug -f net11.0
-   artifacts\bin\Microsoft.Build.Tasks.UnitTests\Debug\net11.0\Microsoft.Build.Tasks.UnitTests.exe `
-     --filter-method "*MyFeature*" --no-progress
-   ```
-   The exe path is TFM-specific: `Debug\net11.0\...exe` for net11.0, `Debug\net472\...exe` for net472. Switching TFM without rebuilding silently runs stale binaries.
-
-### Speeding up the dev loop further
-
-These trade safety for speed — use during iteration, **revert before final validation**:
-
--- **Single TFM**: pass `-f net11.0`. Halves runtime on Windows by skipping `net472`.
-- **Temporarily relax single-threaded execution**: drop a `xunit.runner.json` next to the test project (or override the existing one) with:
-  ```json
-  {
-    "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
-    "longRunningTestSeconds": 60,
-    "maxParallelThreads": -1,
-    "parallelizeTestCollections": true
-  }
-  ```
-  Or pass them as runner args after `--`: `-- xUnit.MaxParallelThreads=-1 xUnit.ParallelizeTestCollections=true`. Expect flakes in tests that touch env vars, cwd, the file system, or the global ProjectCollection — **don't ship a fix that depends on this being on**.
-- **Skip bootstrap packaging** for non-bootstrap test projects:
-  `dotnet build ... -p:CreateBootstrap=false` (useful when the local bootstrap SDK payload is missing).
-- **Narrow with traits**: `--filter-trait Category=mytraitduringdev` if you've tagged a focused subset.
-- **Skip code coverage on Linux/macOS**: run the test exe directly without `--coverage`. This repo does not expose a supported `dotnet test` property switch to disable the auto-added coverage arguments.
-
-## Final validation pass
-
-Before saying "done," run the heavy configuration. Don't skip TFMs and don't keep parallel-overrides.
-
-1. **Restore parallelism settings** (revert any local `xunit.runner.json` change).
-2. **Run all TFMs for affected projects**:
-   ```powershell
-   dotnet test src\Build.UnitTests\Microsoft.Build.Engine.UnitTests.csproj -c Release
-   dotnet test src\Tasks.UnitTests\Microsoft.Build.Tasks.UnitTests.csproj -c Release
-   # Add other UnitTests projects whose code paths you touched
-   ```
-3. **For broad changes (engine, framework, shared)**, run the full repo test suite (~9 minutes — do not cancel):
-   ```powershell
-   .\build.cmd -test -c Release       # Windows
-   ./build.sh --test -c Release       # Linux/macOS
-   ```
-4. **Capture a TRX** if reporting results to the user or CI:
-   ```powershell
-   dotnet test <project> -c Release `
-     --report-trx --report-trx-filename validation.trx `
-     --results-directory artifacts\TestResults
-   ```
-
-## Reading the summary line
-
-MTP's final summary reports `passed`, `failed`, and `skipped` separately. **Always check the `skipped` count** — platform-conditional attributes (`WindowsOnlyFact`, `UnixOnlyFact`, etc.) and the auto trait filters cause expected skips, but a sudden jump in skipped count can hide a regression where a test became inapplicable on the current platform without you intending it.
-
-## Picking the right project to run
-
-Match the source area you changed to its `*.UnitTests` project:
-
-| Source area | Test project |
-|-------------|--------------|
-| `src/Build/**` (engine, evaluation, backend) | `src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj` |
-| `src/Framework/**` | `src/Framework.UnitTests/Microsoft.Build.Framework.UnitTests.csproj` |
-| `src/Tasks/**` | `src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj` |
-| `src/Utilities/**` | `src/Utilities.UnitTests/Microsoft.Build.Utilities.UnitTests.csproj` |
-| `src/MSBuild/**` (CLI) | `src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj` |
-| `src/Build/BuildCheck/**` | `src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj` |
-| `src/Shared/**` | Run the consumers above (Build, Tasks, Utilities) — shared code is linked into all of them. |
-
-## Quick reference
-
-| Scenario | Command |
-|----------|---------|
-| Fast scoped dev loop | `dotnet test <proj> -f net11.0 -- --filter-method "*X*"` |
-| Direct test exe | `artifacts\bin\<Proj>\Debug\net11.0\<Proj>.exe --filter-method "*X*" --no-progress` |
-| Single test by name | `dotnet test <proj> -- --filter-method "*MyTestMethod*"` |
-| Final per-project validation | `dotnet test <proj> -c Release` (all TFMs) |
-| Final full validation | `.\build.cmd -test -c Release` / `./build.sh --test -c Release` |
-| TRX report | `--report-trx --report-trx-filename out.trx --results-directory artifacts\TestResults` |
-
-## See also
-
-- `.github/instructions/tests.instructions.md` — test authoring conventions (xUnit v3, Shouldly, `TestEnvironment`, `MockLogger`).
-- `src/Shared/UnitTests/xunit.runner.json` — repo-wide xUnit settings.
-- `src/Directory.Build.targets` — `XunitOptions`, auto trait filters, coverage wiring.
-- `documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md`
+- [Commands, direct executables, traits, coverage, and project map](references/runner-details.md).
+- [Test authoring conventions](../../instructions/tests.instructions.md).
+- [Bootstrap reproduction](../use-bootstrap-msbuild/SKILL.md) for tests of product executables or SDK integration.

--- a/.github/skills/running-unit-tests/references/runner-details.md
+++ b/.github/skills/running-unit-tests/references/runner-details.md
@@ -1,0 +1,91 @@
+# MSBuild runner details
+
+Read the section needed for the selected test path. Versions and configuration values below come from linked sources, not a permanently pinned copy of their current values.
+
+## SDK and runner selection
+
+[global.json](../../../../global.json) selects both the SDK and the MTP `dotnet test` experience. [Directory.Build.props](../../../../Directory.Build.props) selects `XUnitV3`, executable test projects, and **minimum** xUnit/MTP versions; Arcade can supply newer versions. [src/Directory.Build.props](../../../../src/Directory.Build.props) controls library/runtime TFMs and their platform conditions.
+
+For the MTP-native CLI, select with `--project` or `--solution`, not the legacy positional project syntax. Runner arguments can follow `--`; keep their names/values together. The selected SDK and registered test extensions determine supported options.
+
+The CI-only [MSBuild.VSTest.slnx](../../../../MSBuild.VSTest.slnx) uses separate `*.UnitTests.VSTest.csproj` wrappers for Clever Test Selection. Those deliberately disable the MTP runner; do not apply MTP flags to them or change their runner as part of an ordinary local test task.
+
+Authoritative references: [dotnet test runner selection](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test) and [MTP command reference](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-test-mtp). Use current local help when the installed SDK differs from the documentation.
+
+If a repo-local host needs runtime discovery, set its installation directory as `DOTNET_ROOT` and prepend that directory to `PATH` in the same shell invocation. Do not set it to a different SDK installation. A shell tool may start a fresh process on each call.
+
+## Scoped examples
+
+Replace the project, `<TFM>`, and selectors with the intended values:
+
+```powershell
+dotnet test --project src\Tasks.UnitTests\Microsoft.Build.Tasks.UnitTests.csproj `
+  --framework <TFM> -- --filter-method "*Feature*"
+```
+
+Choose the smallest existing method/class/trait filter supported by the runner. Preserve existing runner configuration and check the executed count. An empty selection can hide a misspelled method or the wrong project.
+
+Use `--no-build` only when the selected configuration/TFM's outputs are current; it also skips restore. It does not establish that an existing test executable corresponds to the edited source.
+
+For all applicable TFMs of an affected project, omit the single-framework selector. Add `--configuration Release` only when Release behavior or the requested validation requires it.
+
+## Direct executable path
+
+An already-built xUnit v3 test application can run without another SDK build:
+
+```powershell
+& '<actual-built-test-executable>' --filter-method "*Feature*" --no-progress
+```
+
+Build the intended project/configuration/TFM first if its source changed. Locate its actual `TargetPath`/apphost instead of guessing a fixed `artifacts\bin` path; architecture and TFM can change the output directory.
+
+Direct invocation bypasses MSBuild's test-launch arguments. Preserve required trait exclusions from [src/Directory.Build.targets](../../../../src/Directory.Build.targets); otherwise a "fast" invocation can run quarantined or platform-inapplicable tests.
+
+`CreateBootstrap=false` skips the [bootstrap target](../../../../eng/BootStrapMsBuild.targets), but does not make bootstrap-dependent tests independent of its output. Use it only for a deliberately scoped build whose tests do not need bootstrap, never as a generic missing-SDK workaround.
+
+## Isolation, traits, and coverage
+
+[xunit.runner.json](../../../../src/Shared/UnitTests/xunit.runner.json) disables collection parallelism and limits test threads because many tests mutate process-global state. Do not rewrite this configuration as an optimization.
+
+[src/Directory.Build.targets](../../../../src/Directory.Build.targets) supplies platform/TFM exclusions and the `Category=failing` quarantine filter through `XunitOptions` and `TestRunnerAdditionalArguments`. This is harness wiring: verify which arguments the selected native CLI/direct launch path actually forwards, and preserve required exclusions explicitly if it bypasses that wiring.
+
+Normal runs exclude quarantined tests. `RunQuarantinedTests=true` intentionally selects only those tests and ignores certain exit codes; it is not an ordinary validation mode. Use per-test results, not a successful quarantine process exit, to assess failures.
+
+Non-Windows normal runs add coverage; quarantined runs are excluded from that condition. Direct execution can omit coverage, but it also omits the injected trait arguments. Never describe coverage as unconditional or silently change filters along with it.
+
+[RunnerUtilities](../../../../src/UnitTests.Shared/RunnerUtilities.cs) configures child MSBuild environments, including the bootstrap host where appropriate. Do not override `DOTNET_HOST_PATH` inside a test to compensate for using the wrong parent SDK or stale bootstrap.
+
+## Results and escalation
+
+TRX support requires the corresponding registered extension. If supported by the selected test app:
+
+```powershell
+dotnet test --project <project> --results-directory artifacts\TestResults `
+  -- --report-trx --report-trx-filename validation.trx
+```
+
+Check passed, failed, skipped, and executed counts. Expected platform skips differ from a new skip that removes the regression scenario.
+
+For a justified full repository run, use the existing harness:
+
+```powershell
+.\build.cmd -test
+```
+
+On Unix use `./build.sh --test`. Allow long-running validation to finish; do not repeatedly restart a build whose original process is still running.
+
+## Source-to-test map
+
+| Changed source | Existing project |
+|---|---|
+| Engine/evaluation/backend | [Microsoft.Build.Engine.UnitTests](../../../../src/Build.UnitTests/Microsoft.Build.Engine.UnitTests.csproj) |
+| Engine object model | [Microsoft.Build.Engine.OM.UnitTests](../../../../src/Build.OM.UnitTests/Microsoft.Build.Engine.OM.UnitTests.csproj) |
+| Framework and its utilities | [Microsoft.Build.Framework.UnitTests](../../../../src/Framework.UnitTests/Microsoft.Build.Framework.UnitTests.csproj) |
+| Tasks | [Microsoft.Build.Tasks.UnitTests](../../../../src/Tasks.UnitTests/Microsoft.Build.Tasks.UnitTests.csproj) |
+| Utilities | [Microsoft.Build.Utilities.UnitTests](../../../../src/Utilities.UnitTests/Microsoft.Build.Utilities.UnitTests.csproj) |
+| CLI | [Microsoft.Build.CommandLine.UnitTests](../../../../src/MSBuild.UnitTests/Microsoft.Build.CommandLine.UnitTests.csproj) |
+| BuildCheck | [Microsoft.Build.BuildCheck.UnitTests](../../../../src/BuildCheck.UnitTests/Microsoft.Build.BuildCheck.UnitTests.csproj) |
+| StringTools | [StringTools.UnitTests](../../../../src/StringTools.UnitTests/StringTools.UnitTests.csproj); inspect its separate runtime/library variants |
+| Linked shared code | Find actual consuming projects and select their affected tests |
+
+This map is a starting point, not a requirement to execute every project. Some integration tests require a current bootstrap; use the [bootstrap skill](../../use-bootstrap-msbuild/SKILL.md) for that boundary.

--- a/.github/skills/use-bootstrap-msbuild/SKILL.md
+++ b/.github/skills/use-bootstrap-msbuild/SKILL.md
@@ -1,83 +1,41 @@
 ---
 name: use-bootstrap-msbuild
-description: Guide for testing bug reproductions against locally-built MSBuild. Use this when you have a repro project and want to verify a fix works before submitting a PR.
+description: "Prove a reproduction or fix using locally built MSBuild binaries. Use when source identity and the actual product host matter, not for ordinary source inspection or every unit-test run."
 ---
 
-# Testing Bug Reproductions with Bootstrap MSBuild
+# Reproduce with locally built MSBuild
 
-This skill guides you through testing a bug reproduction project against your locally-built MSBuild to verify a fix.
+## Establish identity first
 
-## Overview
+Identify the requested source revision, broken baseline, host/runtime, architecture, SDK, build mode, and assertion. An installed `dotnet` or a previous bootstrap is not automatically the code being reviewed.
 
-After making changes to MSBuild, you need to test them against a repro project. The "bootstrap" is a self-contained MSBuild installation built from your local changes. It includes all dependencies needed to build real projects.
+If "TaskHost" or "server" is ambiguous, use the [host map](references/host-map.md) before choosing a project or executable.
 
-## Step 1: Build MSBuild with Bootstrap
+Bootstrap layout is defined by [BootStrapMsBuild.props](../../../eng/BootStrapMsBuild.props) and [BootStrapMsBuild.targets](../../../eng/BootStrapMsBuild.targets); the SDK payload version comes from [Versions.props](../../../eng/Versions.props). Architecture can add another path component.
 
-Build MSBuild to create the bootstrap directory:
+## Workflow
 
-```powershell
-# Windows
-.\build.cmd
+1. Inspect existing outputs and their provenance. Build the relevant bootstrap when missing or stale, using the repo build entry point and its pinned prerequisites; do not rewrite SDK/feed configuration to force success.
+2. Run the reproduction through the actual bootstrap host, not a `dotnet` resolved from an unrelated `PATH`.
+3. Capture the command, working directory, product/SDK identity, exit status, assertion, and a binlog when it establishes the execution path.
+4. For a fix, execute the same scenario against baseline and candidate outputs with equivalent configuration. Keep their worktrees and output paths separate.
+5. Stop when the requested observable difference is established, or report the exact setup/runtime boundary preventing proof.
 
-# Unix/macOS
-./build.sh
-```
-
-This creates the bootstrap at `artifacts\bin\bootstrap\` with your changes.
-
-Rerun this after making any code change. If run in the default mode, there may be some errors on subsequent builds about locked files (due to MSBuild worker node processes lingering). If so, run `./artifacts/bin/bootstrap/core/dotnet build-server shutdown`.
-
-## Step 2: Run Your Repro Project
-
-### .NET Core / .NET SDK Projects
-
-Use the bootstrap `dotnet` CLI directly (preferred):
+Typical **Windows, default-architecture** entry points:
 
 ```powershell
-# Windows
-artifacts\bin\bootstrap\core\dotnet.exe build <path-to-repro.csproj>
+& .\artifacts\bin\bootstrap\core\dotnet.exe build <repro-project> -bl:<binlog>
+& .\artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\MSBuild.exe <repro-project> -bl:<binlog>
 ```
 
-```bash
-# Unix/macOS
-./artifacts/bin/bootstrap/core/dotnet build <path-to-repro.csproj>
-```
+Select the appropriate one and discover the actual layout before running it. On Unix, use the produced `dotnet` host and shell-appropriate paths. Do not assume `MSBuild.dll` sits at the bootstrap root; the Core bootstrap is an SDK layout.
 
-All of the usual command line arguments should work, including `-bl` to create binlogs.
+## Avoid false proof
 
-### .NET Framework Projects
+- Use an explicit working directory and executable in each shell invocation. Changing directory in one tool call may not affect the next.
+- After a source/base change, rebuild the affected output. File existence or a successful test from another TFM is insufficient evidence.
+- If stale servers/nodes or locked outputs interfere, identify the processes belonging to this exact task/bootstrap before stopping them by PID. Do not kill all dotnet/MSBuild processes or reset shared machine state.
+- Do not infer MT, worker, TaskHost, or server usage merely from requested flags; inspect relevant process/log evidence.
+- For a performance comparison, use the [benchmark protocol](../benchmarking-msbuild/SKILL.md). A functional repro is not a controlled timing experiment.
 
-If the problem is specific to the .NET Framework `MSBuild.exe` that is used in Visual Studio, and you're running on Windows, you can use the bootstrap MSBuild.exe directly:
-
-```powershell
-artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\MSBuild.exe <path-to-repro.csproj>
-```
-
-**Note**: The .NET Framework bootstrap output will only be complete when built on Windows using `MSBuild.exe`.
-
-### Changes not reflected
-
-1. Verify bootstrap was rebuilt: check `artifacts\bin\bootstrap\core\sdk\*\MSBuild.dll` timestamp
-2. Kill any lingering MSBuild server processes:
-   ```powershell
-   ./artifacts/bin/bootstrap/core/dotnet build-server shutdown
-   # Or use the helper function after sourcing msbuild-build-env.ps1
-   killdotnet
-   ```
-
-### Repro works with bootstrap but not with installed MSBuild
-
-Your fix is working! The repro uses your local changes while the installed MSBuild has the bug.
-
-## Quick Reference
-
-| Scenario | Command |
-|----------|---------|
-| Build bootstrap | `.\build.cmd` |
-| .NET Core repro | `artifacts\bin\bootstrap\core\dotnet.exe build <project>` |
-| .NET Framework repro | `artifacts\bin\bootstrap\net472\MSBuild\Current\Bin\MSBuild.exe <project>` |
-
-## See Also
-
-- [Bootstrap Documentation](https://github.com/dotnet/msbuild/blob/main/documentation/wiki/Bootstrap.md)
-- [Building and Debugging Guide](https://github.com/dotnet/msbuild/blob/main/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md)
+For deeper build setup, read the relevant section of [Bootstrap documentation](../../../documentation/wiki/Bootstrap.md) or [Framework build/debug guidance](../../../documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md), checking it against current configuration.

--- a/.github/skills/use-bootstrap-msbuild/references/host-map.md
+++ b/.github/skills/use-bootstrap-msbuild/references/host-map.md
@@ -1,0 +1,27 @@
+# Identify the host before investigating
+
+"TaskHost" can mean an object, a modern MSBuild child process, or a legacy executable. Resolve that ambiguity before building a project or tracing a transport.
+
+## Process roles
+
+The mappings come from [NodeMode](../../../../src/Framework/NodeMode.cs) and dispatch in [XMake](../../../../src/MSBuild/XMake.cs). Recheck them at the revision being investigated.
+
+| Evidence | Role | Starting point |
+|---|---|---|
+| MSBuild launched with `/nodemode:1` | Out-of-process build worker | Worker-node execution and logging |
+| MSBuild launched with `/nodemode:2` | Modern out-of-process TaskHost | [MSBuild/OutOfProcTaskHostNode.cs](../../../../src/MSBuild/OutOfProcTaskHostNode.cs) |
+| MSBuild launched with `/nodemode:3` | RAR service node | NodeMode/XMake dispatch |
+| MSBuild launched with `/nodemode:8` | MSBuild server | Server lifecycle and request forwarding |
+| `MSBuildTaskHost.exe` from its separate project | Legacy .NET Framework compatibility host | [MSBuildTaskHost README](../../../../src/MSBuildTaskHost/README.md) and its stricter local instructions |
+
+Do not choose `MSBuildTaskHost.csproj` merely because the symptom mentions a TaskHost. For ordinary MT task ejection, first inspect the modern MSBuild `/nodemode:2` path.
+
+The [task-host diagnostic resource](../../../../src/Build/Resources/Strings.resx) includes "ran in TaskHost process" with task/caller process IDs, new-host, sidecar, and node-reuse details. Search the relevant diagnostic/binlog output when available.
+
+A TaskHost process alone does not establish **why** the task ran there. Trace task compatibility/attestation, `UsingTask` factory/runtime/architecture settings, and launch evidence. Absence of a message is not proof that a different path ran.
+
+## Objects are not processes
+
+[TaskHost](../../../../src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs) implements the engine interface exposed to tasks. [TaskExecutionHost](../../../../src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs) manages task execution. Neither class name by itself identifies which OS process executed a task.
+
+For a reproducible claim, record the binary path, mode, process identity, and relevant code/transport boundary together. Keep baseline and candidate outputs isolated.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,253 +1,75 @@
-# Agent Instructions
+# Working in MSBuild
 
-Instructions for GitHub Copilot and other AI coding agents working with the MSBuild repository.
+MSBuild is the open-source Microsoft Build Engine. It evaluates project files and imports, schedules targets, executes tasks, and reports build results. It ships with the .NET SDK and Visual Studio and is also used through public APIs by third-party hosts, tasks, and loggers.
 
-## Repository Overview
+## Repository overview
 
-**MSBuild** is the Microsoft Build Engine - performance-critical infrastructure for .NET and Visual Studio builds. This repository contains the code for the MSBuild build engine, including its public C# API, its internal implementation of the MSBuild programming language, and core targets and tasks used for builds.
+| Area | Responsibility |
+|---|---|
+| `src/Build` | Project object model, evaluation, build scheduling/execution, graph builds, and logging |
+| `src/Framework` | Public task/logger contracts and events, plus shared utilities, interop, and transport support |
+| `src/Tasks` | Built-in tasks and the common `.props`/`.targets` build logic |
+| `src/Utilities` | Base classes and helpers for task and logger authors |
+| `src/MSBuild` | Command-line entry points, argument handling, and process/server hosting |
+| `src/*.UnitTests`, `src/UnitTests.Shared` | Component tests and shared test infrastructure |
+| `eng`, `documentation`, `plugins` | Build/release infrastructure, design/developer documentation, and repository-owned agent plugins |
 
-### Key Components
-- **Microsoft.Build**: Core MSBuild engine and public API
-- **Microsoft.Build.Framework**: Framework interfaces and base types
-- **Microsoft.Build.Tasks**: Built-in MSBuild tasks
-- **Microsoft.Build.Utilities**: Utility classes for task authors
-- **MSBuild CLI**: Command-line tool for invoking builds
+The main flow is project XML/imports -> evaluation of properties/items/targets -> scheduling -> task execution -> events and loggers. Evaluation and execution are distinct phases; tasks may run in shared-process or isolated-process environments.
 
-### Technology Stack
-- .NET 10.0 and .NET Framework 4.7.2
-- C# 14 features (especially collection expressions)
-- xUnit with Shouldly for testing
-- Multi-platform support (Windows, Linux, macOS)
+Compatibility and performance are central constraints. Discover the supported SDK, runtimes, and language settings from the configuration files below rather than assuming a version.
 
-## General
+## Public communication
 
-* Performance is the top priority - minimize allocations, avoid LINQ in hot paths, use efficient algorithms.
-* Always use the latest C# features, currently C# 14, especially collection expressions (`[]` over `new Type[]`).
-* Match the style of surrounding code when making edits, but modernize aggressively for substantial changes.
+This is a public open-source repository. PR descriptions, issues, review comments, and replies must be self-contained and use public, shareable evidence.
 
-## Code Review Instructions
+- Do not include Microsoft-internal context: proprietary Visual Studio source or implementation details, internal-only links/logs/discussions, or attribution such as which colleague said what internally. Access to internal material is not permission to publish it.
+- Translate findings into public source references, user-observable behavior, and independently authored minimal reproductions. Publicly documented Visual Studio behavior is fine; non-public evidence stays outside public contributions.
+- Review the outgoing text before publishing. If a conclusion depends on evidence that cannot be shared, describe only the publicly supportable result and its limitations.
 
-Official builds treat all warnings as errors, so do not introduce new warnings.
+## Establish the task
 
-### Performance Considerations
+1. Identify the requested outcome and authority: explanation/audit/review, local edits, or an external action. A review is read-only unless changes are requested; it does not authorize posting, merging, resolving threads, or changing CI.
+2. For a PR, establish repository, base, head, and actual diff. For repros/benchmarks, identify binaries, SDK, host, configuration, and mode. Recheck after a branch/base change.
+3. Inspect the worktree before editing. Preserve unrelated changes. Do not commit, push, or create a PR unless requested.
+4. Check claims against source/configuration at the relevant revision. Old specs, session summaries, and memory can be stale. Resolve contradictions against implementation or report them.
 
-When reviewing pull requests:
+## Load context progressively
 
-* **Flag any unnecessary allocations** in hot paths
-* **Flag LINQ usage** in performance-critical code paths
-* **Check for proper use of `Span<T>`** and `ReadOnlySpan<T>` for string parsing
-* **Ensure immutable collections** use the correct type (`ImmutableArray<T>` and `FrozenDictionary<TKey, TValue>` for read-heavy, `ImmutableList<T>` for incremental building)
+- Start with this file and the instructions matching the affected paths in [.github/instructions](.github/instructions). Read nested `AGENTS.md` files before changing their subtree.
+- Select the skill whose **description matches the task**, not every skill mentioning the same technology. Read its entry point, then only the reference needed for the current question. Do not recursively preload links.
+- Start with a focused source lookup; expand to callers, consumers, history, or external docs when evidence requires it.
+- Discover available tools before using them. Plugin availability is session-specific; do not assume a named plugin, agent, or MCP operation is installed. Report missing capabilities and use a supported read-only alternative where possible.
 
-### NuGet Feed Configuration
+## Repository invariants
 
-When reviewing pull requests:
+- Follow [.editorconfig](.editorconfig) and surrounding style. Use supported modern C# features, including collection expressions, without unrelated modernization.
+- New files use nullable reference types. In existing `#nullable disable` files, preserve that convention unless nullable migration is part of the task. Use `is null` / `is not null`.
+- Use `MSBuildNameIgnoreCaseComparer` for MSBuild names. Choose comparisons for other strings and paths from their actual contract, not a blanket culture/OS rule.
+- Avoid unnecessary allocations and repeated I/O on hot paths. Choose collections and APIs for the measured access pattern and supported target frameworks.
+- Preserve existing build semantics. New warnings can break `WarnAsError` builds. Use the compatibility skill to assess opt-in behavior and whether a ChangeWave is warranted; neither every bug fix nor every new diagnostic has the same policy.
+- Reuse existing helpers and resource-based diagnostics. Do not swallow failures, add broad catches, or replace a failure with a success-shaped result.
+- Tests use xUnit and Shouldly. Match the affected behavior with meaningful assertions, including the regression scenario; do not weaken isolation to make tests faster.
 
-* **Flag any changes to NuGet.config** that add external package sources without justification
-* Package sources should use approved internal feeds when possible
+## Build and test deliberately
 
-## Formatting
+- Read [global.json](global.json), [Directory.Build.props](Directory.Build.props), and [src/Directory.Build.props](src/Directory.Build.props) for the SDK, runner, TFMs, and language configuration. Do not copy version numbers from these instructions or use an arbitrary installed SDK.
+- For a scoped build, use `dotnet msbuild <project> -v:q` with the correct SDK and restored prerequisites. For repository setup or a justified full build, use `.\build.cmd -v quiet` on Windows or `./build.sh -v quiet` on Unix.
+- Use [running-unit-tests](.github/skills/running-unit-tests/SKILL.md) before choosing test commands, and [use-bootstrap-msbuild](.github/skills/use-bootstrap-msbuild/SKILL.md) when proving behavior in locally built MSBuild.
+- Start with the smallest existing validation covering the change. Escalate for uncovered consumers, TFMs, or integration boundaries, not because every task must run a full build. Documentation-only changes need link/content checks, not a product rebuild.
+- Do not redirect MSBuild output to a file. Use a binary logger or `-flp:"v=q;LogFile=ErrorsAndWarnings.log"` when a log is needed. Diagnose the **first** relevant errors.
+- Do not manually edit generated `artifacts` or `.dotnet` contents. Do not change `global.json` or `NuGet.config` without an explicit request.
+- Run independent builds in distinct output/worktree locations. Terminate only processes positively identified as belonging to the task, by PID; never kill all processes with a shared name.
 
-* Apply code-formatting style defined in `.editorconfig`.
-* Prefer file-scoped namespace declarations and single-line using directives.
-* Insert a newline before the opening curly brace of any code block.
-* Use pattern matching and switch expressions wherever possible.
-* Use `nameof` instead of string literals when referring to member names.
+## Finish with evidence, not repetition
 
-### Nullable Reference Types
+- A test passing is not proof that it exercises the changed code. For a regression claim, establish the failing baseline and successful fixed behavior under the same conditions when feasible.
+- Distinguish measured results, source-derived conclusions, and unverified hypotheses. A clean review or green retry is not proof that no edge cases remain.
+- Iterate for a finding, failed check, or uncovered requirement. Do not default to fixed review loops, per-dimension agent swarms, or model votes instead of evidence.
+- Keep the final handoff concise and matched to its audience. Preserve useful implementation guidance when shortening public-facing documentation.
+- Update related documentation at its authoring source, not an automation-generated mirror. Keep durable contributor-wide guidance in its owning context layer; do not append one-off session fixes or machine state to this file.
 
-* **New files**: Always use nullable reference types (do NOT add `#nullable disable`)
-* **Existing files with `#nullable disable`**: Match the existing style; don't add nullable annotations (`?`) to types
-* **Existing files with nullable enabled**: Use proper nullable annotations
-* Always use `is null` or `is not null` instead of `== null` or `!= null`
+## Ownership boundaries
 
-## Performance Best Practices
-
-### Range Pattern Matching
-
-```csharp
-// GOOD: Clear and efficient
-return errorNumber switch
-{
-    >= 3001 and <= 3999 => Category.Tasks,
-    >= 4001 and <= 4099 => Category.General,
-    >= 4100 and <= 4199 => Category.Evaluation,
-    _ => Category.Other
-};
-```
-
-### String Handling
-
-* Use `MSBuildNameIgnoreCaseComparer` for case-insensitive comparisons of MSBuild names; use `StringComparer.OrdinalIgnoreCase` only for non-MSBuild string comparisons
-* Use `char.ToUpperInvariant()` for single-character comparisons
-* Use `ReadOnlySpan<char>` and `Slice()` to avoid string allocations
-* Use `int.TryParse(span, out var result)` on .NET Core+ for allocation-free parsing
-
-### Inlining Hot Paths
-
-```csharp
-[MethodImpl(MethodImplOptions.AggressiveInlining)]
-private static bool IsCompilerPrefix(string value) => ...
-```
-
-### Immutable Collections
-
-**Build once, read many times** (most common in MSBuild):
-```csharp
-ImmutableArray<string> items = source.Select(x => x.Name).ToImmutableArray();
-FrozenDictionary<string, int> lookup = pairs.ToFrozenDictionary(x => x.Key, x => x.Value);
-```
-
-**Build incrementally over time**:
-```csharp
-ImmutableList<string> items = ...;  // Use when adding items one by one
-ImmutableDictionary<string, int> lookup = ...;
-```
-
-## Building
-
-NEVER pipe MSBuild output to a file. If you want a list of errors, add `-flp:"v=q;LogFile=ErrorsAndWarnings.log"` to the arguments.
-
-When considering a subset of build errors, always look at the BEGINNING of the set, not the end.
-
-## Individual projects
-
-Build individual projects with `dotnet msbuild {path/to/project.csproj} -v:q`.
-
-### Whole-repo Build Commands
-
-| Platform | Command | Timeout |
-|----------|---------|---------|
-| Windows | `.\build.cmd -v quiet` | 300+ seconds (~2-3 minutes) |
-| macOS/Linux | `./build.sh -v quiet` | 300+ seconds (~2-3 minutes) |
-
-### Bootstrap Environment Setup
-
-After building the whole repo, to use the just-built MSBuild to build things use the bootstrap environment (described in [`skills/use-bootstrap-msbuild](.github/skills/use-bootstrap-msbuild/SKILL.md)).
-
-### Build Troubleshooting
-
-* If build fails with "Could not resolve SDK", run the bootstrap environment script
-* Verify `dotnet --version` shows the preview/internal version
-* Use repository sample projects for testing, not external projects
-* Build artifacts go to `./artifacts/` directory
-
-### Running Tests
-
-**Windows:**
-```cmd
-# Full test suite (~9 minutes) - NEVER CANCEL
-.\build.cmd -test
-
-# Individual test project (recommended):
-dotnet test src/Framework.UnitTests/Microsoft.Build.Framework.UnitTests.csproj
-```
-
-**macOS/Linux:**
-```bash
-# Full test suite (~9 minutes) - NEVER CANCEL
-./build.sh --test
-
-# Individual test project (recommended):
-dotnet test src/Framework.UnitTests/Microsoft.Build.Framework.UnitTests.csproj
-```
-
-You can run a single unit test with `-- --filter-method "*{methodname}*"`, for example `dotnet test src/Framework.UnitTests/ -- --filter-method "*ExerciseBuildEventContext*"`.
-
-### Test Verification
-
-* **Individual Test Project**: ~10-60 seconds per project
-* **Full Test Suite**: ~9 minutes
-
-## Project Layout and Architecture
-
-### Directory Structure
-
-```
-src/
-├── Build/                    # Core MSBuild engine (Microsoft.Build)
-├── Build.UnitTests/          # Unit tests for core engine
-├── MSBuild/                  # MSBuild command-line tool
-├── Framework/                # MSBuild Framework (Microsoft.Build.Framework)
-├── Framework.UnitTests/      # Unit tests for framework
-├── Tasks/                    # Built-in MSBuild tasks (Microsoft.Build.Tasks)
-├── Tasks.UnitTests/          # Unit tests for tasks
-├── Utilities/                # MSBuild utilities (Microsoft.Build.Utilities)
-├── Utilities.UnitTests/      # Unit tests for utilities
-├── Shared/                   # Shared code across assemblies
-└── Samples/                  # Sample projects and extensions
-
-artifacts/
-├── bin/                      # Built binaries
-│   └── bootstrap/
-│       └── core/
-│           └── MSBuild.dll   # Built MSBuild executable
-├── sdk-build-env.sh          # Bootstrap script (Linux/macOS)
-├── msbuild-build-env.bat     # Bootstrap script (Windows)
-└── packages/                 # Built NuGet packages
-
-documentation/
-├── wiki/                     # Developer documentation
-├── specs/                    # Technical specifications
-└── *.md                      # Various documentation files
-```
-
-### Key Configuration Files
-
-* **`global.json`**: Pins .NET SDK version - never modify without explicit request
-* **`NuGet.config`**: Package source configuration - never modify without explicit request
-* **`.editorconfig`**: Code formatting rules
-* **`Directory.Build.props`**: Shared MSBuild properties across all projects
-* **`Directory.Packages.props`**: Centralized package version management
-* **`MSBuild.slnx`**: Main solution file
-
-## Validation Checklist
-
-Before completing any change:
-
-1. ✅ Full build completes successfully (`.\build.cmd` or `./build.sh`)
-2. ✅ Bootstrap environment activates correctly (`dotnet --version` shows preview)
-3. ✅ Sample project builds: `dotnet build src/Samples/Dependency/Dependency.csproj`
-4. ✅ Relevant unit tests pass
-5. ✅ `dotnet artifacts/bin/bootstrap/core/MSBuild.dll --help` works
-
-## Do NOT Modify
-
-* `artifacts/` directory contents - Generated during build
-* `.dotnet/` directory contents - Local SDK location
-
-See **Key Configuration Files** section for files that should not be modified without explicit request.
-
-## Documentation
-
-When making changes, check if related documentation exists in the `documentation/` folder (including `documentation/specs/`) and update it to reflect your changes. Keep documentation in sync with code changes.
-
-## Breaking Changes
-
-Because MSBuild is a critical part of the build process for a huge number of customers, we avoid breaking changes. Adding new errors or warnings, even when well-intentioned and pointing out things that are very likely to be wrong, is an unacceptable breaking change. Adding warnings is a breaking change because many production builds use `/WarnAsError`.
-
-The exception to this policy is in new, opt-in behavior. In new, opt-in functionality, liberally emit warnings and errors--they can always be removed later.
-
-When reviewing PRs, always consider whether the behavior change could be experienced as a break in existing builds and flag any new warnings or errors.
-
-## Development Workflow
-
-1. Make your changes to source code
-2. Run the full build (WAIT for completion - takes 2-3 minutes):
-   - Windows: `.\build.cmd -v quiet`
-   - macOS/Linux: `./build.sh -v quiet`
-4. Test your changes end-to-end using the bootstrap output: `dotnet build src/Samples/Dependency/Dependency.csproj`
-5. Run relevant individual tests, not the full test suite
-6. Commit your changes
-
-## Trust These Instructions
-
-These instructions are comprehensive and tested. Only search for additional information if:
-1. The instructions appear outdated or incorrect
-2. You encounter specific errors not covered here
-3. You need details about new features not yet documented
-
-For most development tasks, following these instructions should be sufficient to build, test, and validate changes successfully.
-
-## Updating these instructions
-
-When working on a task, if user input is required to complete the task or feedback is provided for guidance around a specific area of the code, evaluate that feedback/guidance and update this document to incorporate that feedback if it's missing.  This document should be a live, evolving set of instructions.
+- [eng/common](eng/common/AGENTS.md) is owned by Arcade; propose changes upstream rather than editing its generated copy.
+- [src/MSBuildTaskHost](src/MSBuildTaskHost/AGENTS.md) is a legacy compatibility component with stricter change rules.
+- Installed plugin caches and personal configuration are not repository policy. Audit them separately; fixes belong in the owning plugin source or an explicitly requested personal setting change.


### PR DESCRIPTION
Author's note: 
This stack was generated from auditing my history of sessions with GPT6. 
I read through this PR and think it is an improvement to our current state of repo context (though we can nitpick forever).

### Part 1 of 8

Keep MSBuild architecture and the public-contribution boundary visible in AGENTS.md, then clarify test, bootstrap, and benchmark entry points without loading every procedure.

Starts from main. Next: dotnet/msbuild#14963. Full index: dotnet/msbuild#14961.

This PR is based on `main`. Files changed shows only this chapter. Review bottom-up; after the preceding chapter lands, retarget this PR to `main` before merging. Do not merge later chapters into temporary stack-base branches.

### Scope and evidence

Restores the high-level project map and public-communication rules; test/bootstrap commands are tied to the checkout. No newly broken local references.

Agentic-workflow changes remain separate. This stack does not include personal plugin overrides, plugin auto-activation changes, or SDK/feed version changes. The public descriptions use public repository evidence, not internal discussions or proprietary source.
