### PR TITLE
[2/8] Correct compatibility and diagnostic guidance

### DIFF
--- a/.github/instructions/backend-execution.instructions.md
+++ b/.github/instructions/backend-execution.instructions.md
@@ -2,47 +2,24 @@
 applyTo: "src/Build/BackEnd/**"
 ---
 
-# BackEnd & Execution Engine Instructions
+# Execution engine
 
-MSBuild's multi-process execution engine: `BuildManager`, node communication, scheduler, result caching, and task execution.
+## State and scheduling
 
-## Concurrency & Thread Safety (Critical)
+- Establish thread/process ownership before adding synchronization. Distinguish in-process nodes, worker processes, multithreaded nodes, and external TaskHosts; they do not have the same isolation.
+- Preserve `BuildManager` lifecycle invariants across initialization failure, cancellation, shutdown, and repeated builds. Invalid lifecycle calls should follow existing validation, not acquire a silent recovery path.
+- For scheduler changes, construct the actual request/target sequence and check deadlock, starvation, yield/unyield, and cached-result behavior.
+- Document lock order when introducing interacting locks. A mutable field is not itself proof of a race; trace all relevant owners and callbacks.
 
-* All shared mutable state must be synchronized — tasks run across in-proc and out-of-proc nodes concurrently.
-* `BuildManager.cs` is the most complex file — `BeginBuild`/`EndBuild`/`ResetCaches` sequences must remain correct.
-* Test in **both** in-proc and out-of-proc scenarios — they differ in state isolation, type loading, and serialization.
-* Lock ordering must be consistent to prevent deadlocks. Document acquisition order when introducing new locks.
+## Caching and IPC
 
-## Node Communication & IPC
+- Trace configuration identity and target results through the actual caches rather than assuming a single `(path, properties, targets)` key. See [Results Cache](../../documentation/wiki/Results-Cache.md).
+- Identify which peers can actually connect before changing packet layout. Inspect handshake/reuse compatibility and any negotiated version; do not assume arbitrary old/new workers support rolling updates.
+- Preserve packet ordering and read/write symmetry for supported peers. Do not assume old streams contain optional fields or that a new version number alone makes them compatible.
+- SDK resolver changes can affect cached state across evaluations/builds. Define its owner and invalidation boundary rather than banning all persistent state.
 
-* Never change the IPC packet format without versioning — old nodes must communicate with new ones during rolling updates.
-* IPC message ordering matters — race conditions cause intermittent, hard-to-reproduce failures.
-* Task host node (`NodeProviderOutOfProcTaskHost.cs`) has additional isolation constraints for type loading.
+## Evidence and deeper context
 
-## Scheduler Correctness
+Use representative in-proc, worker-process, MT, or TaskHost cases according to the changed boundary, not all modes for every edit. For an executable claim, use the [bootstrap skill](../skills/use-bootstrap-msbuild/SKILL.md).
 
-* Changes can cause deadlocks, starvation, or incorrect parallelism.
-* Yield/unyield semantics must be preserved — tasks that yield allow their node to process other requests.
-
-## Result Caching
-
-* Results are cached by `(project path, global properties, targets)` — changes to cache key computation break incremental builds.
-* Cache coherence between nodes is critical — stale results cause incorrect builds.
-* See [Results Cache](../../documentation/wiki/Results-Cache.md) and [Cache Flow](../../documentation/wiki/CacheFlow.png).
-
-## SDK Resolution
-
-* `SdkResolverService.cs` resolves SDK references during evaluation — changes affect every SDK-style project.
-* SDK resolution must not have side effects that persist across evaluations.
-
-## BuildManager Lifecycle
-
-* `BeginBuild` → submissions → `EndBuild` is the required sequence. Handle reentrant calls and out-of-order events gracefully.
-* `ResetCaches` must not lose in-flight results.
-
-## Related Documentation
-
-* [Nodes Orchestration](../../documentation/wiki/Nodes-Orchestration.md)
-* [Results Cache](../../documentation/wiki/Results-Cache.md)
-* [Logging Internals](../../documentation/wiki/Logging-Internals.md)
-* [Threading spec](../../documentation/specs/threading.md)
+Read [node orchestration](../../documentation/wiki/Nodes-Orchestration.md), [logging internals](../../documentation/wiki/Logging-Internals.md), or the [threading spec](../../documentation/specs/threading.md) only for the relevant investigation. Check design prose against current implementation.

--- a/.github/instructions/buildcheck.instructions.md
+++ b/.github/instructions/buildcheck.instructions.md
@@ -2,48 +2,21 @@
 applyTo: "src/Build/BuildCheck/**,src/Framework/BuildCheck/**"
 ---
 
-# BuildCheck Instructions
+# BuildCheck
 
-MSBuild's analyzer infrastructure enabling built-in and third-party build analyzers.
+## Contracts and failure handling
 
-## Analyzer Authoring
+- Public analyzer APIs live in [Build/BuildCheck/API](../../src/Build/BuildCheck/API); Framework also carries internal BuildCheck contracts. Determine visibility and consumers from source, not folder names.
+- Analyzer state must have an explicit project/build lifetime and concurrency model.
+- Keep failure isolation at the infrastructure boundary. [BuildCheckCentralContext](../../src/Build/BuildCheck/Infrastructure/BuildCheckCentralContext.cs) already catches callback failures and removes affected checks; do not add broad catch-and-ignore blocks to every analyzer.
+- Loading/configuration failures and analyzer-result diagnostics have different paths. Preserve their reporting and scope.
 
-* Analyzers must not throw — wrap logic in try/catch and report failures via infrastructure.
-* Must be stateless between projects or explicitly manage state via context. Shared mutable state causes concurrency bugs in multi-node builds.
-* Built-in analyzers serve as examples for third-party authors — keep them clean and idiomatic.
+## Diagnostics and performance
 
-## Diagnostic Codes
+- Use the [code registry](../../documentation/specs/BuildCheck/Codes.md) and current configuration API; do not reuse assigned codes.
+- [CheckResultSeverity](../../src/Build/BuildCheck/API/CheckResultSeverity.cs) includes `Default` and `None` as well as `Suggestion`, `Warning`, and `Error`. Preserve configuration/disable semantics, not just severity escalation.
+- Match default severity to the opted-in feature contract and compatibility policy. New warnings in existing behavior can break warning-as-error builds.
+- Select callbacks and cache lifetimes for the data actually needed. Measure meaningful overhead rather than promise that an analyzer has no measurable cost.
+- Test configuration precedence, disabled checks, callback failure isolation, and cross-node results when the change touches those boundaries.
 
-* Every diagnostic must have a unique code — see [Codes](../../documentation/specs/BuildCheck/Codes.md).
-* Codes are permanent — once assigned, cannot be reused or reassigned.
-* Messages must be actionable: state what was detected and what to do.
-
-## Severity Handling
-
-* Escalation chain: `Suggestion` → `Warning` → `Error`.
-* Users configure severity per-analyzer in `.editorconfig` or MSBuild properties.
-* Default to `Suggestion` or `Warning` — `Error` blocks builds and requires high confidence.
-
-## Acquisition & Extensibility
-
-* Third-party analyzers load via NuGet packages — changes to the loading pipeline affect the ecosystem.
-* Analyzer interfaces in `Framework/BuildCheck/` are public API — version contract interfaces, breaking changes require a new version.
-
-## Performance Impact
-
-* Analyzers must not measurably slow down builds.
-* Avoid per-item/per-property callbacks for analyzers that only need project-level data.
-* Cache results when the same check runs across projects with identical configuration.
-
-## Architecture
-
-* Engine logic in `src/Build/BuildCheck/`, contracts in `src/Framework/BuildCheck/`.
-* Data flow: evaluation/execution → BuildCheck infrastructure → analyzer → diagnostic output.
-* Cross-node remoting must be handled correctly — see [architecture doc](../../documentation/specs/BuildCheck/BuildCheck-Architecture.md).
-
-## Related Documentation
-
-* [BuildCheck Architecture](../../documentation/specs/BuildCheck/BuildCheck-Architecture.md)
-* [BuildCheck Feature Spec](../../documentation/specs/BuildCheck/BuildCheck.md)
-* [Custom BuildCheck Analyzers](../../documentation/specs/BuildCheck/CustomBuildCheck.md)
-* [Diagnostic Codes](../../documentation/specs/BuildCheck/Codes.md)
+Read only the relevant [architecture](../../documentation/specs/BuildCheck/BuildCheck-Architecture.md), [feature](../../documentation/specs/BuildCheck/BuildCheck.md), or [custom analyzer](../../documentation/specs/BuildCheck/CustomBuildCheck.md) section; proposals are not proof of implemented behavior.

--- a/.github/instructions/cli.instructions.md
+++ b/.github/instructions/cli.instructions.md
@@ -2,47 +2,15 @@
 applyTo: "src/MSBuild/**"
 ---
 
-# MSBuild CLI Instructions
+# MSBuild command line
 
-Command-line entry point (`XMake.cs`), argument parsing, server mode, and CLI-specific logic.
+- Preserve accepted switch names/aliases, exit codes, response-file behavior, and existing project discovery unless an intentional compatibility change is in scope.
+- Switch aliases are explicitly listed and compared in [CommandLineSwitches](../../src/MSBuild/CommandLine/CommandLineSwitches.cs); do not invent shortest-unique-prefix matching.
+- Check the specific switch's parameter rules. Not every switch accepts bare, `:true`, and `:false` forms.
+- Trace `XMake` parsing through server selection and build parameters. A `dotnet` verb may have a separate SDK parser/forwarding path; use the [SDK integration skill](../skills/integrating-sdk-and-msbuild/SKILL.md) at that boundary.
+- Avoid unnecessary startup initialization. Server-mode changes must account for repeated builds, environment changes, and state reset.
+- Preserve the existing exception boundary. Do not catch every exception or turn an internal failure into an apparently successful invocation.
+- Use resource-based diagnostics and existing exit behavior. Assess user-visible differences with the [compatibility skill](../skills/assessing-breaking-changes/SKILL.md), rather than requiring a ChangeWave for every edit.
+- Validate the affected combinations of explicit arguments, response files, environment defaults, and host/mode. Confirm which executable handled the command.
 
-## CLI Switch Stability (Critical)
-
-* **Never remove or rename existing switches or aliases** — build scripts worldwide depend on them.
-* New switches must not conflict with existing switches or their abbreviations.
-* Switch abbreviation rules must be preserved — existing shortest-unique prefixes must continue to work.
-
-## XMake.cs Entry Point
-
-* Exit codes must remain stable — scripts check specific exit codes.
-* Startup performance matters — avoid unnecessary initialization on the critical path.
-* Top-level error handling must catch and report all exceptions with actionable messages.
-
-## Server Mode
-
-* Server mode keeps processes alive between builds — state leaks cause intermittent failures.
-* Ensure all per-build state is properly reset between builds.
-* See [threading spec](../../documentation/specs/threading.md) for concurrency constraints.
-
-## Command-Line Parsing
-
-* Backward compatible — existing valid command lines must work identically.
-* Boolean switches: `-switch`, `-switch:true`, `-switch:false` — handle all forms.
-* Response file (`@file`) processing must maintain ordering and nesting semantics.
-
-## CLI Behavior Compatibility
-
-* Default verbosity, output format, and behavior must not change without a [ChangeWave](../../documentation/wiki/ChangeWaves.md).
-* The set of automatically-forwarded properties to child nodes must remain stable.
-* Changes to project discovery (`.sln` vs `.slnx` handling) require careful compatibility analysis.
-
-## Error Messages
-
-* CLI-level errors (bad arguments, missing project files) must be immediately actionable.
-* Include the `/help` pointer when appropriate.
-
-## Related Documentation
-
-* [MSBuild Environment Variables](../../documentation/wiki/MSBuild-Environment-Variables.md)
-* [ChangeWaves](../../documentation/wiki/ChangeWaves.md)
-* [MSBuild apphost spec](../../documentation/specs/msbuild-apphost.md)
+Relevant references: [environment variables](../../documentation/wiki/MSBuild-Environment-Variables.md), [threading](../../documentation/specs/threading.md), and [apphost](../../documentation/specs/msbuild-apphost.md). Read the one matching the changed path.

--- a/.github/instructions/framework.instructions.md
+++ b/.github/instructions/framework.instructions.md
@@ -2,46 +2,24 @@
 applyTo: "src/Framework/**"
 ---
 
-# MSBuild Framework Instructions
+# Framework contracts and shared implementation
 
-`Microsoft.Build.Framework` defines MSBuild's public API contracts: interfaces, base types, event args, and extensibility points. Referenced by every task and logger author.
+This assembly contains both public task/logger contracts and internal utilities, interop, and transport code. Do not assume everything in this folder is public API.
 
-## API Surface Discipline (Critical)
+## Preserve the boundary
 
-* Default to `internal`. Every `public` member is a permanent commitment.
-* New public API **must** be recorded in `PublicAPI.Unshipped.txt`.
-* Add XML doc comments to all public members.
-* Seal classes unless explicitly designed for inheritance. Prefer interfaces for extensibility.
+- Default new implementation to `internal`; public additions need compatibility rationale and XML documentation.
+- Preserve existing public signatures and third-party implementors. Do not add interface members assuming default implementations work on every supported runtime; follow the existing numbered `IBuildEngine` pattern where appropriate.
+- Inspect actual implementors, including [TaskHost](../../src/Build/BackEnd/Components/RequestBuilder/TaskHost.cs) and out-of-process hosts. `TaskExecutionHost` is not the `IBuildEngine` implementation.
+- The [project](../../src/Framework/Microsoft.Build.Framework.csproj) uses reference-assembly generation and package validation. Follow that machinery and the current baseline configuration; do not create nonexistent `PublicAPI.Unshipped.txt` files because a generic guide mentions them.
+- Check the library TFMs in [src/Directory.Build.props](../../src/Directory.Build.props). Availability on modern .NET does not establish availability on .NET Framework or the reference-only target.
 
-## Public API Compatibility
+## Implementation changes
 
-* Never remove or change signatures of existing public members — add new overloads.
-* Interface additions require default interface method implementations to avoid breaking implementors.
-* Binary compatibility matters — task assemblies compiled against older Framework versions must continue to work.
+- Preserve type/assembly identity and resource ownership when moving formerly linked code into Framework.
+- Trace actual callers before changing shared utilities; use the performance skill only for a relevant hot path.
+- For IPC, inspect the supported peer/handshake and actual translator. Missing data does not automatically become a default value in an unframed stream.
+- For event changes, use [binary-log compatibility](../skills/maintaining-binary-log-compatibility/SKILL.md) and trace forwarding separately.
+- For Windows interop or COM, load only the matching interop skill and retain platform/feature guards.
 
-## Event Args & Build Events
-
-* Event args are serialized in binary logs — adding fields requires backward-compatible serialization. See [Binary Log](../../documentation/wiki/Binary-Log.md).
-* New event types must integrate with `IEventSource`, forwarding loggers, and binary log reader/writer.
-* `MessageImportance` levels: `High` = user-critical, `Normal` = standard, `Low` = verbose.
-
-## BuildCheck Contracts
-
-* Analyzer interfaces define the contract with third-party analyzers — treat as public API.
-* See [BuildCheck Architecture](../../documentation/specs/BuildCheck/BuildCheck-Architecture.md).
-
-## Serialization Stability
-
-* Types serialized across IPC or persisted in binary logs must maintain format stability.
-* When adding fields, handle the case where the field is missing (backward compat with older writers).
-* Use `ITranslatable` for IPC serialization; follow existing patterns.
-
-## Interface Design
-
-* `IBuildEngine` versions follow a progression pattern — new task capabilities go in the next numbered interface.
-* Ensure new interfaces are implemented on `TaskExecutionHost`.
-
-## Related Documentation
-
-* [Microsoft.Build.Framework](../../documentation/wiki/Microsoft.Build.Framework.md)
-* [BuildCheck specs](../../documentation/specs/BuildCheck/BuildCheck.md)
+BuildCheck has public APIs in [Build/BuildCheck/API](../../src/Build/BuildCheck/API) and internal transport contracts here; use the [BuildCheck instructions](buildcheck.instructions.md) for that boundary.

--- a/.github/instructions/logging.instructions.md
+++ b/.github/instructions/logging.instructions.md
@@ -2,43 +2,15 @@
 applyTo: "src/Build/Logging/**"
 ---
 
-# Logging Infrastructure Instructions
+# Logging
 
-Binary logger, console loggers, terminal logger, and event forwarding infrastructure.
+- Distinguish node IPC, task-host forwarding, and the persisted binlog format. They have different serialization and compatibility mechanisms.
+- Use [binary-log compatibility](../skills/maintaining-binary-log-compatibility/SKILL.md) for reader/writer changes. Preserve supported old-log reading and follow the actual record/version contract; not every old reader can read every newer log.
+- Trace event subscriptions and forwarding configuration. A central logger sees what reaches it, not automatically every event generated anywhere.
+- Check filtering in the actual logger. [BaseConsoleLogger](../../src/Build/Logging/BaseConsoleLogger.cs) maps `High` to minimal verbosity, `Normal` to normal, and `Low` to detailed; `High` is not visible at quiet verbosity by definition.
+- Preserve structured event payloads and available locations through round trips. A text message is not equivalent to preserving event type and fields.
+- For terminal output, cover redirected/non-TTY output, narrow/resized terminals, concurrency, and supported platforms when affected.
+- Use `RenderImmediateMessage`, not direct terminal writes, for messages that must appear outside the normal node-status rendering cycle, including user-intervention messages and long-delay explanations. Direct writes bypass node-display coordination and can corrupt rendered output.
+- Assess changed output or importance as a compatibility surface. Do not add logging to every internal change merely to satisfy a generic checklist.
 
-## Binary Log Format Stability
-
-* `.binlog` format must maintain backward compatibility — older readers must handle newer logs.
-* `BuildEventArgsWriter.cs`/`BuildEventArgsReader.cs` are the serialization boundary — field additions must be versioned.
-* Always write new fields at the end of existing records. Readers must handle missing fields.
-* Test round-trip: write → read → compare for all modified event types.
-
-## Terminal Logger (FancyLogger)
-
-* Must handle terminal width changes, very narrow terminals, and non-TTY output (piped to file).
-* Concurrent project builds must render without corruption.
-* ANSI escape sequences must be cross-platform compatible.
-* Use `RenderImmediateMessage` (not direct terminal writes) for any message that must appear immediately outside the normal node-status rendering cycle, like messages that require user intervention or explain long delays. Direct terminal writes bypass the node-display logic and corrupt the rendered output.
-
-## Console Logger
-
-* `ParallelConsoleLogger.cs` handles multi-project console output.
-* `MessageImportance` filtering: `High` always shows, `Normal` at normal verbosity, `Low` at detailed.
-* Never change the default output format without a [ChangeWave](../../documentation/wiki/ChangeWaves.md) — build log parsers depend on it.
-
-## Build Event Handling
-
-* Event forwarding between nodes must preserve ordering and completeness.
-* Central loggers see all events; distributed loggers see only their node's events. See [Logging Internals](../../documentation/wiki/Logging-Internals.md).
-
-## Diagnostics Completeness
-
-* Behavioral changes must produce corresponding binary log entries.
-* Error/warning events must include file, line, and column when available.
-* Prefer structured events over string messages for programmatic consumption.
-
-## Related Documentation
-
-* [Binary Log](../../documentation/wiki/Binary-Log.md)
-* [Logging Internals](../../documentation/wiki/Logging-Internals.md)
-* [Providing Binary Logs](../../documentation/wiki/Providing-Binary-Logs.md)
+Read [logging internals](../../documentation/wiki/Logging-Internals.md) or [binary logs](../../documentation/wiki/Binary-Log.md) for the relevant boundary, then confirm the source behavior.

--- a/.github/instructions/shared-code.instructions.md
+++ b/.github/instructions/shared-code.instructions.md
@@ -2,30 +2,13 @@
 applyTo: "src/Shared/**"
 ---
 
-# Shared Code Instructions
+# Linked shared code
 
-Code in `src/Shared/` is linked (compiled) into multiple MSBuild assemblies. A bug here breaks multiple assemblies simultaneously.
+- Find actual `Compile` includes and their conditions before editing a shared file. Not every file is compiled into every assembly, and some former shared utilities now live in Framework.
+- Preserve assembly/type identity, resource lookup, feature guards, and runtime-specific behavior when moving or changing linked source.
+- Scope validation to affected consumers and configurations; do not run every test project merely because the path contains `Shared`.
+- For node/task-host packets, trace read/write order and the supported peers' handshake/version behavior. An unframed translator cannot silently supply fields absent from an older packet.
+- For mutable structs, avoid translating through a cast that boxes a copy; follow the existing constrained-generic translation pattern where applicable.
+- Use the owning path/IO helper when it implements the required semantics, not as a blanket ban on `System.IO`. Check relative roots, separators, normalization, long/UNC paths, and filesystem effects for the specific operation.
 
-## Cross-Assembly Impact
-
-* Compiled into `Microsoft.Build`, `Microsoft.Build.Tasks`, `Microsoft.Build.Utilities`, and the CLI.
-* Test changes against all consuming assemblies, not just one.
-* `#if` conditional compilation is used extensively — verify behavior for all target configurations (`FEATURE_*`, `RUNTIME_TYPE_NETCORE`, etc.).
-
-## IPC Packet Stability
-
-* `NodePacketTranslator` and `ITranslatable` implementations define the wire format between MSBuild nodes.
-* Never change packet layout without versioning — old out-of-proc nodes must communicate with new in-proc nodes.
-* Serialization must handle missing fields gracefully (forward compatibility).
-* Test IPC round-trip for all modified packet types.
-
-## FileUtilities Safety
-
-* Use `FileUtilities.cs` instead of raw `System.IO.Path` calls.
-* Must handle: UNC paths, long paths (> MAX_PATH), trailing separators, relative paths, embedded `.`/`..` segments.
-* Avoid unnecessary file system calls — slow and can fail on network paths.
-
-## Cross-Platform Correctness
-
-* Handle .NET Framework vs .NET Core differences with appropriate `#if` guards.
-* Environment variable access patterns differ across platforms — use the shared helpers.
+For shared tests, also use the [test authoring instructions](tests.instructions.md). For binlog events, load the [binary-log skill](../skills/maintaining-binary-log-compatibility/SKILL.md); do not confuse it with IPC compatibility.

--- a/.github/skills/assessing-breaking-changes/SKILL.md
+++ b/.github/skills/assessing-breaking-changes/SKILL.md
@@ -1,88 +1,29 @@
 ---
 name: assessing-breaking-changes
-description: 'Guides assessment of backward compatibility for MSBuild changes. Consult when modifying behavior, adding warnings or errors, changing defaults, altering target ordering, removing or deprecating features, deciding whether a change needs a ChangeWave, reviewing blast radius of behavioral changes, or when a PR introduces user-visible output differences.'
-argument-hint: 'Describe the change and its potential compatibility impact.'
+description: "Assess compatibility risk in changes to existing MSBuild behavior, diagnostics, defaults, or public contracts. Not ChangeWave implementation or a mandatory review of semantics-preserving refactoring."
+argument-hint: "Describe the old and proposed behavior and affected consumers."
 ---
 
-# Backward Compatibility in MSBuild
+# Assess MSBuild compatibility
 
-Backward compatibility is the default — any change that could alter existing build behavior must be explicitly justified.
+**Use for:** deciding whether an observable change is acceptable, needs an opt-in or temporary opt-out, or requires a migration plan.
 
-This skill covers **how to evaluate compatibility risk**. For the mechanics of ChangeWave implementation, see the [changewaves skill](../changewaves/SKILL.md).
+**Do not use for:** implementing an already-decided wave, assigning diagnostic codes, or expanding an internal refactor into a full compatibility matrix.
 
-## Core Philosophy
+## Source preflight
 
-1. **Existing builds must not break.** If a project built successfully yesterday, it must build successfully today with identical semantics.
-2. **New warnings are breaking changes.** Builds that use `-WarnAsError` or `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` will fail if you introduce a new warning. Always gate new warnings behind a ChangeWave or emit them as `Message` importance instead.
-3. **Output changes are behavioral changes.** Even "improvements" to output formatting, file paths, or diagnostic text can break downstream consumers that parse MSBuild output.
-4. **Removal is nearly impossible.** Never remove CLI switches, public APIs, or property names. Deprecate with warnings first, then gate removal behind a ChangeWave after multiple release cycles.
+Identify the baseline, changed behavior, callers, and supported hosts/TFMs. Read the [instructions for the affected paths](../../instructions) and the current [framework configuration](../../../src/Directory.Build.props).
 
-## Blast Radius Checklist
+For diagnostic changes, inspect the actual [warning-promotion logic](../../../src/Build/BackEnd/Components/Logging/LoggingService.cs), not just similarly named project properties. For an opt-out, inspect [ChangeWaves](../../../src/Framework/ChangeWaves.cs).
 
-Before merging any behavioral change, evaluate:
+## Workflow
 
-| Question | If Yes |
-|----------|--------|
-| Does this change what gets built or how? | ChangeWave required |
-| Does this add a new warning? | ChangeWave required (WarnAsError impact) |
-| Does this change a property default? | ChangeWave required (existing .csproj files depend on defaults) |
-| Does this alter target execution order? | Test with real-world solutions; likely ChangeWave |
-| Does this change console or binlog output format? | Consider downstream tool impact |
-| Does this affect only internal code paths with no user-visible effect? | No ChangeWave needed |
-| Is this a pure bug fix restoring documented behavior? | Usually no ChangeWave; use judgment on blast radius |
+1. Describe a concrete existing build or consumer that can observe the difference: success/failure, outputs, ordering, API availability, logs, or performance.
+2. Separate existing behavior from genuinely new opt-in functionality. A bug fix still needs a blast-radius assessment; not every bug fix needs a wave.
+3. Apply the relevant part of [compatibility decisions](references/compatibility-decisions.md). New warnings can fail warning-as-error builds; changing a warning into an error is not a compatibility workaround.
+4. Choose the mitigation and evidence needed for the affected boundary. A ChangeWave is default-on risk management, not proof that existing builds remain unchanged.
+5. Record the decision and remaining uncertainty. Use [changewaves](../changewaves/SKILL.md) only for implementation, or [diagnostic authoring](../authoring-errors-and-warnings/SKILL.md) for the selected diagnostic.
 
-## When ChangeWave Is NOT Needed
+## Evidence and stop condition
 
-- Internal refactoring with no observable behavior change
-- Performance improvements that don't change semantics
-- New opt-in features gated by a new property or switch
-- Bug fixes that restore clearly-intended behavior with limited blast radius
-
-For detailed ChangeWave mechanics, see [ChangeWaves-Dev.md](../../../documentation/wiki/ChangeWaves-Dev.md) and [ChangeWaves.md](../../../documentation/wiki/ChangeWaves.md).
-
-## The Warnings-as-Errors Rule
-
-This is the most commonly missed compatibility concern:
-
-```xml
-<!-- Many enterprise builds set this globally -->
-<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-```
-
-Any new `MSBxxxx` warning you add will **break these builds**. Options:
-1. **Gate behind ChangeWave** — preferred for genuinely important warnings
-2. **Use `MessageImportance.Low` or `Normal`** — for informational diagnostics
-3. **Add as an error from the start** — if the condition is always wrong
-
-## Deprecation Protocol
-
-1. Add a deprecation warning (behind ChangeWave if broad impact)
-2. Document the deprecation in release notes
-3. Maintain the old behavior for at least two major .NET versions
-4. Only remove after the ChangeWave has rotated out
-
-## Compatibility Test Matrix
-
-When testing backward compatibility, verify:
-
-- **Multi-targeting projects** — `<TargetFrameworks>net472;net8.0</TargetFrameworks>`
-- **Solution builds with mixed project types** — C#, F#, VB, C++/CLI
-- **Incremental builds** — second build should be a no-op
-- **Design-time builds** — Visual Studio calls different target contracts
-- **Cross-platform** — path separator differences, case sensitivity on Linux
-- **WarnAsError builds** — explicitly test with `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>`
-
-## Decision Framework
-
-```
-Is the change user-visible?
-├── No → Ship it (no ChangeWave needed)
-└── Yes
-    ├── Is it a new opt-in feature? → Ship it (no ChangeWave needed)
-    └── Does it change existing behavior?
-        ├── Bug fix with low blast radius? → Ship it, add regression test
-        └── Behavioral change or new warning?
-            └── Gate behind ChangeWave, test opt-out path
-```
-
-Document the compatibility decision in your PR description so reviewers can validate it.
+Stop when the observable difference, affected consumers, compatibility decision, and scoped evidence are clear. An assessment-only request does not authorize code changes or executing a broad test matrix. For a fix, require evidence for the changed contract rather than claiming all builds are compatible.

--- a/.github/skills/assessing-breaking-changes/references/compatibility-decisions.md
+++ b/.github/skills/assessing-breaking-changes/references/compatibility-decisions.md
@@ -1,0 +1,68 @@
+# Compatibility decisions
+
+## Classify the change before selecting a mechanism
+
+| Change | Assess |
+|---|---|
+| Internal refactor with unchanged semantics | Whether callers, exception behavior, synchronization, or allocations actually remain equivalent |
+| Performance optimization | Correctness and measured behavior under the affected runtime, build mode, cache lifetime, and workload |
+| Narrow bug fix | Which existing inputs relied on the old behavior, and whether an opt-out is useful |
+| New explicit opt-in | Whether diagnostics and changed behavior stay inside the opted-in path |
+| Changed default, parsing, execution order, or output | Existing project/SDK assumptions and a practical mitigation or migration path |
+| Public API, CLI, or property removal | Source/binary/tooling contracts; a runtime flag cannot restore a missing declaration |
+
+A ChangeWave groups risky, default-on behavior behind a temporary opt-out. It can make a justified transition manageable, but it does not prevent a break for users who have not opted out. The implementation enables all waves when the environment variable is unset: see `ApplyChangeWave` and `AreFeaturesEnabled` in [ChangeWaves.cs](../../../../src/Framework/ChangeWaves.cs).
+
+New opt-in functionality can appropriately reject invalid input with errors or warnings. Check that the opt-in is real: a new API parameter or property is not isolation if an existing build starts reaching the new diagnostic by default.
+
+## Warning promotion is not one property
+
+| Setting | Relevant contract |
+|---|---|
+| CLI `-warnAsError` without codes | Promotes warnings through the engine across the build, subject to configured exceptions |
+| CLI `-warnAsError:code1;code2` | Promotes the specified codes, not every new warning |
+| `MSBuildTreatWarningsAsErrors` | Project-level engine warning promotion |
+| `MSBuildWarningsAsErrors` / `MSBuildWarningsNotAsErrors` | Project-level code lists consumed by the engine |
+| `TreatWarningsAsErrors` | Passed to compilers and some tasks; not the general engine switch for all MSB warnings |
+| `WarningsAsErrors` / `WarningsNotAsErrors` | Also used by compiler/task contracts; Common targets supply these as defaults for the corresponding MSBuild code lists |
+
+Sources:
+- [LoggingService.ShouldTreatWarningAsError](../../../../src/Build/BackEnd/Components/Logging/LoggingService.cs) contains global/project promotion and exception handling.
+- [MSBuildConstants](../../../../src/Framework/MSBuildConstants.cs) identifies the engine property names.
+- [Common targets](../../../../src/Tasks/Microsoft.Common.CurrentVersion.targets) map the code-list defaults; [C# targets](../../../../src/Tasks/Microsoft.CSharp.CurrentVersion.targets) pass compiler settings.
+- [WarningsAsMessagesAndErrors_Tests](../../../../src/Build.UnitTests/WarningsAsMessagesAndErrors_Tests.cs) cover selected codes, additive properties, project contexts, and task-host behavior.
+
+Use the setting that exercises the changed logging path. Merely setting `TreatWarningsAsErrors` in an arbitrary project is not evidence that engine warning promotion was tested.
+
+An informational `BuildMessageEventArgs` is not promoted by the engine's warning promotion. However, moving an existing warning to a message changes observability and tooling contracts. Choose message importance for its audience; it is separate from diagnostic severity. For event-content limits, see [binary-log event content](../../maintaining-binary-log-compatibility/references/event-content.md).
+
+## Concrete blast-radius questions
+
+Select the questions relevant to the change rather than executing every row.
+
+| Boundary | Useful evidence |
+|---|---|
+| Build result or generated output | Same input, baseline and candidate result, output contents and paths |
+| Incremental behavior | Relevant clean, source-edit, and no-op cases; do not assume every target should be skipped on a second build |
+| Target/project-reference ordering | Dependency/extension contracts and the actual CLI or IDE invocation |
+| Evaluation | Property precedence, item ordering, imports, escaping, and affected project APIs |
+| Logging | Event kind/code, importance, location metadata, text consumers, and log-size/cost implications |
+| Exceptions | Type, timing, error code, cleanup, and whether a caller continues or exits |
+| Platform or TFM | The affected configurations from current props, including reference-only and source-build exclusions where relevant |
+| Host/process lifetime | Standalone MSBuild, in-process hosts, reused nodes, task hosts, or multithreaded execution as implicated by the change |
+
+For example, replacing a COM exception with `false` is not automatically equivalent just because some caller catches COM exceptions. The exception may have skipped later work, and another caller may rely on it propagating.
+
+For execution evidence, use the [test workflow](../../running-unit-tests/SKILL.md) or [bootstrap reproduction](../../use-bootstrap-msbuild/SKILL.md) only when the question requires it. Identify the binaries and scenario actually exercised.
+
+## Deprecation and removal
+
+Do not invent a universal number of releases or major .NET versions for retaining behavior. Agree on the particular contract, consumers, migration, and release policy.
+
+Deprecation warnings and compiler-obsolete annotations can themselves break warning-as-error consumers. A ChangeWave can gate runtime behavior; it cannot make removing a public API binary-compatible.
+
+Wave rotation is a separate lifecycle described in [ChangeWaves.md](../../../../documentation/wiki/ChangeWaves.md). Retiring a wave does not authorize removing unrelated APIs, CLI switches, or properties.
+
+## Decision record
+
+Keep the handoff specific: old behavior, new behavior, affected users, rationale, mitigation or explicit acceptance of risk, evidence obtained, and remaining gaps. Do not replace these with a blanket "non-breaking" label.

--- a/.github/skills/authoring-errors-and-warnings/SKILL.md
+++ b/.github/skills/authoring-errors-and-warnings/SKILL.md
@@ -1,135 +1,29 @@
 ---
 name: authoring-errors-and-warnings
-description: 'Guides authoring of MSBuild errors, warnings, and diagnostic messages. Consult when adding new MSBxxxx codes, writing or modifying user-facing diagnostic text, deciding between error/warning/message severity, working with Strings.resx resource files, formatting paths in error output, or evaluating whether a new warning could break WarnAsError builds.'
-argument-hint: 'Describe the error/warning being added or modified.'
+description: "Author or change MSBuild user-facing errors, warnings, messages, and resource strings. Not general compiler diagnostics, compatibility triage alone, or binary-log format implementation."
+argument-hint: "Describe the diagnostic, its caller, and whether behavior changes."
 ---
 
-# Error and Warning Authoring in MSBuild
+# Author MSBuild diagnostics
 
-Error messages are MSBuild's primary user interface. They must help developers fix problems without reading source code.
+**Use for:** selecting the resource/helper, code, text, arguments, and location for an MSBuild diagnostic.
 
-For the mechanics of error code assignment, see [assigning-msb-error-code.md](../../../documentation/assigning-msb-error-code.md).
+**Do not use for:** assigning another product's diagnostic codes, broad review, or deciding compatibility without a concrete diagnostic change.
 
-## Error Message Quality Rules
+## Source preflight
 
-Every error message must answer three questions:
+Find the actual producer and its neighboring logging calls. Inspect its resource owner: [Tasks Strings.resx](../../../src/Tasks/Resources/Strings.resx), [Engine Strings.resx](../../../src/Build/Resources/Strings.resx), or shared [Framework SR.resx](../../../src/Framework/Resources/SR.resx), as applicable.
 
-1. **What happened?** — State the problem clearly
-2. **Why?** — Provide context (file, property, expected value)
-3. **What should the user do?** — Give actionable guidance
+Read the [diagnostic reference](references/diagnostic-authoring.md) for code allocation, current helper examples, localization, and paths. Follow the relevant [path instructions](../../instructions) rather than copying their invariants here.
 
-```xml
-<!-- BAD: What is "it"? What should I do? -->
-<value>MSB4999: Invalid configuration.</value>
+## Workflow
 
-<!-- GOOD: States the problem, context, and fix -->
-<value>MSB4999: The project "{0}" specifies TargetFramework "{1}" which is not installed. Install the SDK for "{1}" or update the TargetFramework in the project file.</value>
-```
+1. Establish the condition and current behavior. For new severity or a newly reached diagnostic, use [compatibility assessment](../assessing-breaking-changes/SKILL.md); "always wrong" does not alone justify a new failure in existing builds.
+2. Choose error, warning, or message for the caller's contract and audience. Message importance is not warning severity.
+3. Reuse an existing resource when its meaning fits; otherwise allocate within the appropriate code bucket and check live/retired usage. Do not assume every resx has a "next code" counter.
+4. Use the owning resource-based helper with the exact argument count. Give enough context and an actionable remedy where one is known; preserve separate file/line metadata.
+5. Cover the changed diagnostic's code, arguments, location, and result/promotion behavior. Use the existing localization process when resources change, not a mandatory full build for every diagnostic discussion.
 
-## Severity Decision Framework
+## Evidence and stop condition
 
-```
-Is the condition always wrong (invalid input, impossible state)?
-├── Yes → ERROR (build should fail)
-└── No
-    ├── Could this cause subtle build correctness issues?
-    │   ├── Yes, likely → WARNING (but see WarnAsError impact below)
-    │   └── Yes, maybe → MESSAGE at Normal importance
-    └── Is this purely informational?
-        └── Yes → MESSAGE at Low importance
-```
-
-### The WarnAsError Constraint
-
-**New warnings are breaking changes** for builds using:
-- `-WarnAsError` (CLI)
-- `<TreatWarningsAsErrors>true</TreatWarningsAsErrors>` (project)
-- `<WarningsAsErrors>MSBxxxx</WarningsAsErrors>` (specific codes)
-
-Before adding a new warning, consider:
-1. **Is the warning important enough to justify breaking WarnAsError builds?** If yes, gate behind a ChangeWave (see [changewaves skill](../changewaves/SKILL.md)).
-2. **Could this be a Message instead?** Messages never break builds but still appear in binary logs.
-3. **Should this be an error from the start?** If the condition is always wrong, skip the warning stage.
-
-## MSB Error Code Assignment
-
-### Code Ranges
-
-| Range | Area |
-|-------|------|
-| `MSB1xxx` | Command-line handling |
-| `MSB3xxx` | Tasks (`Microsoft.Build.Tasks.Core.dll`) |
-| `MSB4xxx` | Engine (`Microsoft.Build.dll`) |
-| `MSB5xxx` | Shared code across assemblies |
-| `MSB6xxx` | Utilities (`Microsoft.Build.Utilities`) |
-
-### Assignment Process
-
-1. Open the `Strings.resx` file for the appropriate assembly
-2. Find the "Next message code" comment at the bottom of the file
-3. Search the repo to confirm the code is not already in use
-4. Use the code; update the comment to the next available number
-
-See [assigning-msb-error-code.md](../../../documentation/assigning-msb-error-code.md) for detailed steps.
-
-## Resource String Format
-
-```xml
-<data name="FeatureArea.DescriptiveName">
-  <value>MSBxxxx: Clear description with {0} placeholders for runtime values.</value>
-  <comment>{StrBegin="MSBxxxx: "}{0} is the project file path. {1} is the property name.</comment>
-</data>
-```
-
-### Rules
-
-- Resource name uses `FeatureArea.DescriptiveName` convention
-- Value starts with `MSBxxxx: ` (code, colon, space)
-- Comment documents the `{StrBegin}` marker and explains each `{N}` placeholder
-- Comments guide translators — mention untranslatable tokens
-
-## Consuming Error Resources in Code
-
-Use the standard formatting method that extracts and applies the error code:
-
-```csharp
-// For errors
-Log.LogErrorWithCodeFromResources("Copy.Error", sourceFile, destFile, ex.Message);
-
-// For warnings
-Log.LogWarningWithCodeFromResources("ResolveAssemblyReference.Conflict", assemblyName);
-
-// For engine-level errors (not in tasks)
-ProjectFileErrorUtilities.ThrowInvalidProjectFile(
-    elementLocation,
-    "InvalidProjectFile",
-    arg1, arg2);
-```
-
-**Never** construct error messages by string concatenation — always use resource strings for localization support.
-
-## Localization Requirements
-
-- Error **codes** (`MSBxxxx`) are never localized
-- Error **text** is localized into all supported languages
-- After adding/modifying resource strings, run a full build to generate `.xlf` placeholder translations
-- Use `<comment>` elements to help translators understand context
-- See [Localization.md](../../../documentation/wiki/Localization.md) for the full localization process
-
-## Path Formatting in Error Messages
-
-- Show paths relative to the project directory when possible
-- Use the path exactly as the user specified it (don't normalize slashes)
-- Include file and line number via `IElementLocation` when available — this enables IDE click-to-navigate
-- For paths that could contain spaces, ensure they're quoted in the message
-
-## Checklist for New Errors/Warnings
-
-- [ ] Error code assigned from correct `Strings.resx` range
-- [ ] "Next message code" comment updated in the resx
-- [ ] Message answers: what happened, why, what to do
-- [ ] `{StrBegin}` comment and placeholder documentation added
-- [ ] Severity chosen (error vs warning vs message) with WarnAsError considered
-- [ ] If warning: ChangeWave gating evaluated
-- [ ] Full build run to generate `.xlf` files
-- [ ] Test verifies the error is produced with correct code and text
+Stop when the requested diagnostic contract is implemented or explained with source-backed resource/helper choices and appropriately scoped evidence. Do not invent new warnings to satisfy a checklist, manually author placeholder translations, or expand the work into unrelated message modernization.

--- a/.github/skills/authoring-errors-and-warnings/references/diagnostic-authoring.md
+++ b/.github/skills/authoring-errors-and-warnings/references/diagnostic-authoring.md
@@ -1,0 +1,87 @@
+# Diagnostic authoring reference
+
+## Severity and audience
+
+First distinguish a user input/build condition from an internal programming failure. [ProjectFileErrorUtilities](../../../../src/Shared/ProjectFileErrorUtilities.cs) explicitly warns against using project-file errors in place of internal invariant checks.
+
+For an existing build path, consider compatibility before introducing any new error or warning. A default-on ChangeWave is a temporary opt-out, not immunity from warning-as-error breaks. The [compatibility reference](../../assessing-breaking-changes/references/compatibility-decisions.md) owns that decision and the engine/compiler warning-property distinctions.
+
+For genuinely new opt-in behavior, errors can reject invalid input and warnings can identify actionable risk. Use messages for informational progress or diagnostic detail. `MessageImportance` has High, Normal, and Low; `LoggerVerbosity.Diagnostic` is a different concept.
+
+Useful diagnostic text explains the problem, the relevant context, and a remedy when known. Do not fabricate a remedy or force every short diagnostic into three sentences. SDK selection, target frameworks, and targeting packs are different concepts; prefer a real nearby resource over an invented "framework is not installed" example.
+
+## Resource ownership and code allocation
+
+Historical code areas are:
+
+| Prefix | Area |
+|---|---|
+| MSB1xxx | Command-line handling |
+| MSB2xxx | Historical conversion component |
+| MSB3xxx | Built-in tasks |
+| MSB4xxx | Engine |
+| MSB5xxx | Shared code |
+| MSB6xxx | Utilities |
+
+These areas do not imply that every resource physically resides in that assembly today. Shared resources are in [Framework SR.resx](../../../../src/Framework/Resources/SR.resx), which includes diagnostics used by other assemblies.
+
+1. Find the caller's resource manager and nearest analogous resource/call.
+2. Read that file's allocation information. [Tasks Strings.resx](../../../../src/Tasks/Resources/Strings.resx) has per-task buckets and a bucket table; other files may not have a "Next message code" comment.
+3. Search for the proposed code across the repository and available retirement/history information. An absent live string does not prove that a shipped code can be reused.
+4. Stay within the allocated area. If a task bucket is exhausted, follow the allocation/overflow process rather than borrowing another task's number.
+5. Update an existing allocation index when applicable. Do not invent or rewrite an unrelated index just because a generic recipe expects one.
+
+[Assigning MSB error codes](../../../../documentation/assigning-msb-error-code.md) supplies the allocation background. Verify its examples and index descriptions against the actual current resource file.
+
+Match resource-key naming and ordering in the affected area. Dotted task keys such as `Copy.Error` are common; engine keys are not all dotted.
+
+## Resource and call-site examples
+
+This is the existing Copy diagnostic shape, not a code available for reassignment:
+
+```xml
+<data name="Copy.Error">
+  <value>MSB3021: Unable to copy file "{0}" to "{1}". {2}</value>
+  <comment>{StrBegin="MSB3021: "}</comment>
+</data>
+```
+
+Call-site fragments following the resource-based helpers:
+
+```csharp
+Log.LogErrorWithCodeFromResources(
+    "Copy.Error", sourceFile, destinationFile, exception.Message);
+
+Log.LogWarningWithCodeFromResources(
+    "ResolveAssemblyReference.FoundConflicts", assemblyName, conflictDetails);
+
+ProjectFileErrorUtilities.ThrowInvalidProjectFile(
+    new BuildEventFileInfo(elementLocation),
+    "InvalidProjectFile",
+    exception.Message);
+```
+
+The warning resource has **two** placeholders. The engine's `InvalidProjectFile` resource has **one**, and its file location is supplied separately. These are examples for their respective resource owners, not interchangeable calls from any logger.
+
+Sources: [Tasks resources](../../../../src/Tasks/Resources/Strings.resx), [Engine resources](../../../../src/Build/Resources/Strings.resx), [ProjectFileErrorUtilities](../../../../src/Shared/ProjectFileErrorUtilities.cs), and [BuildEventFileInfo](../../../../src/Shared/BuildEventFileInfo.cs).
+
+Use resource-based formatting for localizable diagnostic text rather than ad hoc concatenation. For a new resource, make placeholder meanings and non-translatable tokens clear to translators. Keep `{StrBegin="MSBxxxx: "}` markers consistent with neighboring coded resources; replace the schematic code with the allocated one. Do not document placeholders that are absent from the value.
+
+## Paths and locations
+
+Separate the structured location from paths appearing as message arguments.
+
+- When an `IElementLocation` exists, construct `BuildEventFileInfo` from it so file, line, and column reach loggers and IDE navigation.
+- Match the existing path contract. Relative paths can be ambiguous across project references; normalizing or changing user-supplied path spelling can also change diagnostic output.
+- Preserve the appropriate escaped/unescaped representation at the helper boundary.
+- Quote path arguments consistently with the existing resources, especially when spaces are possible.
+
+Do not impose a universal "always relative" or "never normalize" rule. The `InvalidProjectFile` resource itself explains why the project filename is supplied separately to loggers.
+
+## Localization and evidence
+
+[Localization.md](../../../../documentation/wiki/Localization.md) describes neutral resources, XLF files, generated localized resources, and translation ownership. Ordinary diagnostic edits belong in the neutral resx; use the repository's localization generation flow for placeholder updates. A translation correction is a different task with its own process.
+
+Select evidence for the change: code/severity, argument formatting, location, build result, warning promotion, or message importance. Full localized-text assertions are useful only where that text is the intended contract; avoid making a locale-dependent assertion stand in for a stable code/location assertion.
+
+Follow [running-unit-tests](../../running-unit-tests/SKILL.md) for runner selection. Resource changes may need generated localization updates, but an explanation or Markdown-only diagnostic audit does not require a product build.

--- a/.github/skills/changewaves/SKILL.md
+++ b/.github/skills/changewaves/SKILL.md
@@ -1,74 +1,29 @@
 ---
 name: changewaves
-description: 'Manage MSBuild Change Waves: create new waves, condition features behind opt-out flags, write tests for wave-gated features, document change waves in ChangeWaves.md, and retire expired waves. Use when adding changes that need an opt-out or rotating out old change waves. Changes that introduce a user-visible behavior change should consider whether to use a changewave.'
-argument-hint: 'Add, query, or remove changewaves and changewave checks.'
+description: "Implement an already-justified MSBuild ChangeWave, inspect an opt-out, or retire a wave when explicitly requested. Not a requirement to gate every behavioral fix or to rotate waves during unrelated work."
+argument-hint: "Describe the feature gate, opt-out behavior, or requested retirement."
 ---
 
-# Managing MSBuild Change Waves
+# Manage MSBuild ChangeWaves
 
-A Change Wave is an opt-out flag that groups risky features together. Users disable features by setting the environment variable `MSBUILDDISABLEFEATURESFROMVERSION` to the wave version. This skill covers the **how** — the full lifecycle: creating a wave, conditioning code on it, testing, documenting, and retiring.
+**Use for:** selecting/registering the release's wave, conditioning a feature, proving opt-out behavior, or an authorized retirement.
 
-For the **when** — deciding whether a change is a breaking change and whether it needs a ChangeWave at all — see [assessing-breaking-changes](../assessing-breaking-changes/SKILL.md).
+**Do not use for:** automatic retirement, a new feature already isolated by an explicit opt-in, or deciding compatibility without first using [assessing-breaking-changes](../assessing-breaking-changes/SKILL.md).
 
+## Source preflight
 
-## Decide Whether a Change Wave Is Appropriate
+Read [eng/Versions.props](../../../eng/Versions.props) for the development version and [ChangeWaves.cs](../../../src/Framework/ChangeWaves.cs) for named fields, ordered `AllWaves`, and cached opt-out state. Do not copy a version number from a skill or old example.
 
-Use a change wave when a change is valuable but has meaningful compatibility risk for existing builds.
+Inspect the affected caller and [current wave documentation](../../../documentation/wiki/ChangeWaves.md). Follow [framework instructions](../../instructions/framework.instructions.md) when changing the wave registry.
 
-Good candidates:
-- User-visible behavior changes that may regress some build graphs.
-- Changes in parsing/evaluation/execution semantics where real-world usage is broad or hard to predict.
-- Changes that may require customer adaptation time and benefit from a temporary opt-out.
+## Workflow
 
-Usually avoid a change wave for:
-- Pure bug fixes that restore intended existing behavior with low compatibility risk.
-- Internal refactoring/perf work with no externally observable behavior change.
-- New functionality that is already explicitly opt-in (for example, gated by a new property, switch, or API surface).
+1. Use the development release's existing named wave; add one only if the justified feature requires it and that wave is absent.
+2. Gate the changed behavior with `AreFeaturesEnabled`, preserving the old path. Use the feature's named wave, not a moving `HighestWave` lookup.
+3. Cover the new behavior and the same scenario with the wave disabled. Follow the [lifecycle reference](references/lifecycle.md) for process-cached state and test isolation.
+4. Add the feature to the matching current-rotation heading in `ChangeWaves.md`; use the real PR link when available.
+5. Retire a wave only when requested, following the separate retirement procedure and checking affected callers.
 
-If uncertain, default to safety:
-1. Assess blast radius and rollback difficulty.
-2. Check whether the change could be experienced as a breaking change in production builds.
-3. Use a wave if an opt-out is likely needed while customers adapt.
+## Evidence and stop condition
 
-Document the decision in PR notes so reviewers can validate the call.
-
-If a changewave is appropriate, consult [ChangeWaves-Dev.md](../../../documentation/wiki/ChangeWaves-Dev.md) (developer-facing) and [ChangeWaves.md](../../../documentation/wiki/ChangeWaves.md) (public-facing) for details on how to follow the below steps.
-
-## Step 1: Determine the Correct Wave Version
-
-Look up the current MSBuild version. If a wave already exists for that version in `src/Framework/ChangeWaves.cs`, use it. Otherwise, create a new one.
-
-## Step 2: Condition Your Feature on the Wave
-
-C# and MSBuild examples are in [ChangeWaves-Dev.md](../../../documentation/wiki/ChangeWaves-Dev.md). Prefer to put checks inline rather than abstracting out a method to host the check.
-
-## Step 3: Write Tests
-
-Write normal tests for the new behavior. Then add at least one test that verifies the old behavior is **preserved** when the wave is opted out.
-
-## Step 4: Document the Feature
-
-Add an entry to the **Current Rotation of Change Waves** section in [ChangeWaves.md](../../../documentation/wiki/ChangeWaves.md).
-
-- If a heading for this wave already exists, add a bullet under it.
-- If not, add a new `### {Major}.{Minor}` heading at the top of the current rotation list.
-
-Each entry is a bullet with a link to the PR:
-
-```markdown
-### 18.6
-- [Short description of the change.](https://github.com/dotnet/msbuild/pull/NNNNN)
-```
-
-## Only when explicitly requested: Retire an Expired Wave
-
-Waves rotate out when a new major .NET version will be released. When retiring a wave, follow the detailed description in [ChangeWaves-Dev.md](../../../documentation/wiki/ChangeWaves-Dev.md).
-
-## Checklist
-
-- [ ] Decision made: change wave needed?
-- [ ] Correct wave version chosen from `eng/Versions.props`
-- [ ] Wave field and `AllWaves` entry added in `ChangeWaves.cs` (if new wave)
-- [ ] Feature code wrapped with `AreFeaturesEnabled`
-- [ ] Test verifying opt-out disables the feature
-- [ ] Entry added to `documentation/wiki/ChangeWaves.md`
+Stop after the requested gate or retirement, its scoped evidence, and documentation are complete. An unset variable enables waves by default; a successful default-path test does not prove opt-out. Do not sweep unrelated waves, invent release-retention promises, or require a full build for a wave-documentation question.

--- a/.github/skills/changewaves/references/lifecycle.md
+++ b/.github/skills/changewaves/references/lifecycle.md
@@ -1,0 +1,73 @@
+# ChangeWave lifecycle
+
+## Select and register
+
+The authoritative inputs are [eng/Versions.props](../../../../eng/Versions.props), [ChangeWaves.cs](../../../../src/Framework/ChangeWaves.cs), and the feature's intended release.
+
+Use the named static `Version` field for that release. If it is absent, add it and insert it into `AllWaves` in ascending order. `LowestWave`, `HighestWave`, clamping, and rounding depend on that ordering.
+
+Do not gate a shipped feature against `HighestWave`: its meaning moves when another wave is added. Prefer a direct check at the behavior boundary; introduce an abstraction only when it genuinely owns a shared decision.
+
+[ChangeWaves-Dev.md](../../../../documentation/wiki/ChangeWaves-Dev.md) describes the lifecycle, but its historical example versions and test snippets are not the current registry. Use current implementation/tests when choosing fields and assertions.
+
+## Gate the behavior
+
+C# callers use `ChangeWaves.AreFeaturesEnabled` with the selected named field. Tasks/targets can use the `[MSBuild]::AreFeaturesEnabled` property function with the selected version. Keep the previous behavior available when the wave is disabled.
+
+For an existing inline use, see [MSBuildGlob](../../../../src/Build/Globbing/MSBuildGlob.cs). For property-function use and expected results, see [ChangeWaves_Tests](../../../../src/Build.UnitTests/ChangeWaves_Tests.cs).
+
+The environment variable is `MSBUILDDISABLEFEATURESFROMVERSION`. It disables that wave **and later waves**, not just one feature.
+
+| Input | Resolution |
+|---|---|
+| Unset or empty | All waves enabled |
+| Current named wave | Disable that wave and later waves |
+| Version between current waves | Round up to the next current wave |
+| Version outside the current rotation | Clamp to the boundary; the caller can report the conversion warning |
+| Invalid version format | Enable all waves; the caller can report the conversion warning |
+| The registry's `EnableAllFeatures` sentinel | Enable all waves |
+
+Use `DisabledWave` and `ConversionState` from the implementation rather than duplicating this parsing algorithm in a caller.
+
+## Process lifetime and tests
+
+`ApplyChangeWave` caches the resolved value. Changing the environment variable in an already-running process does not by itself establish a new test condition.
+
+Given the selected `Version wave` in a test, the existing reset pattern is:
+
+```csharp
+using TestEnvironment env = TestEnvironment.Create();
+
+ChangeWaves.ResetStateForTests();
+env.SetEnvironmentVariable("MSBUILDDISABLEFEATURESFROMVERSION", wave.ToString());
+BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly();
+```
+
+See the private `SetChangeWave` helper in [ChangeWaves_Tests](../../../../src/Build.UnitTests/ChangeWaves_Tests.cs). It is **not** a public method on `TestEnvironment`. [TestEnvironment cleanup](../../../../src/UnitTests.Shared/TestEnvironment.cs) restores test state and resets the wave/build-environment caches.
+
+Exercise the actual feature in both states and assert opposite behavior where appropriate. The wave tests' `buildSimpleProjectAndValidateChangeWave` derives whether the target should run from the resolved wave; it does not always expect the message to appear.
+
+For a feature that builds a project, use an appropriate existing fixture and logger, with the [test isolation instructions](../../../instructions/tests.instructions.md) and [test-runner workflow](../../running-unit-tests/SKILL.md). A cache reset without a feature assertion is not opt-out coverage.
+
+Reused processes also matter outside tests. The [user-facing wave documentation](../../../../documentation/wiki/ChangeWaves.md) explains worker/server handshake behavior and the deliberately different task-host case. Do not assume changing the parent's environment reconfigures every already-running child.
+
+## Document
+
+Add a concise feature bullet under the selected version in **Current Rotation of Change Waves** in [ChangeWaves.md](../../../../documentation/wiki/ChangeWaves.md). Reuse its heading, or add the new release heading in the existing ordering. Link the actual change when a PR exists; do not publish a placeholder PR URL as a real reference.
+
+Explain the compatibility reason and observable old/new behavior where needed. A wave is temporary risk mitigation, not a guarantee that a default-on behavior change cannot break a consumer.
+
+## Retire only when requested
+
+Consult current release policy and the eligibility/rotation description in [ChangeWaves.md](../../../../documentation/wiki/ChangeWaves.md). Do not infer authorization to retire from a date or from noticing an old field.
+
+For an authorized retirement:
+
+1. Remove the selected registry field and `AllWaves` entry.
+2. Find C# and property-function gates for that wave.
+3. Keep the intended permanent behavior and remove the obsolete branch.
+4. Remove only opt-out-specific tests; retain regression coverage for permanent behavior.
+5. Remove newly dead helpers/usings and update the rotation documentation.
+6. Cover affected behavior and configuration boundaries rather than mechanically deleting every similarly named construct.
+
+Wave retirement is not authorization to remove public APIs or invent a general two-major-version deprecation policy.

--- a/.github/skills/maintaining-binary-log-compatibility/SKILL.md
+++ b/.github/skills/maintaining-binary-log-compatibility/SKILL.md
@@ -1,130 +1,29 @@
 ---
 name: maintaining-binary-log-compatibility
-description: 'Guides changes to MSBuild binary log infrastructure. Consult when modifying BinaryLogger or BinaryLogReplayEventSource, adding new BuildEventArgs types, changing event serialization/deserialization, modifying ProjectImportsCollector, adjusting message importance levels, or making changes that affect .binlog content. Also applies when verifying that behavioral changes are properly reflected in binary log output.'
-argument-hint: 'Describe the binary log change or event serialization concern.'
+description: "Change MSBuild structured build events, binary-log codecs, replay compatibility, or import collection. Not routine binlog analysis, ordinary diagnostic severity selection, or a requirement to add logging for every behavior change."
+argument-hint: "Identify the event/codec/content change and required reader or host compatibility."
 ---
 
-# Binary Log Considerations
+# Maintain binary-log contracts
 
-The binary log (`.binlog`) is MSBuild's primary diagnostic format and source of truth for build analysis. It captures the complete build event stream with full fidelity. Format changes have strict compatibility requirements.
+**Use for:** a changed serialized event, record/field format, replay path, event-content contract, or embedded-import behavior.
 
-For general binary log usage, see [Binary-Log.md](../../../documentation/wiki/Binary-Log.md).
+**Do not use for:** merely opening a binlog or adding an ordinary resource-based diagnostic. Use [diagnostic authoring](../authoring-errors-and-warnings/SKILL.md) when no format/content boundary changes.
 
-## Core Principles
+## Source preflight
 
-1. **The binlog captures everything.** All meaningful build events must be represented. If your change alters build behavior, it must be observable in the binlog.
-2. **Format changes must be backward-compatible.** Older versions of MSBuild Structured Log Viewer and other tools must be able to read binlogs produced by newer MSBuild, at minimum gracefully degrading.
-3. **Forward compatibility matters too.** Newer viewers should handle binlogs from older MSBuild without crashing, even if some events are unrecognized.
+Read the affected producer and [logging instructions](../../instructions/logging.instructions.md). Inspect [BinaryLogger](../../../src/Build/Logging/BinaryLogger/BinaryLogger.cs), [BuildEventArgsWriter](../../../src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs), and [BuildEventArgsReader](../../../src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs).
 
-## Architecture Overview
+For a new/changed event class, also inspect its separate [node transport](../../../src/Shared/LogMessagePacketBase.cs) and [Framework instructions](../../instructions/framework.instructions.md). Do not infer binlog support from event `WriteToStream` methods.
 
-```
-Build Engine
-  → BuildEventArgs (structured events)
-    → BinaryLogger (serializes to .binlog)
-      → ProjectImportsCollector (embeds project/targets files)
+## Workflow
 
-Replay:
-  .binlog file
-    → BinaryLogReplayEventSource (deserializes)
-      → Any ILogger (console, structured log viewer, analyzers)
-```
+1. Classify the change: emitted content, node transport, binlog codec, reader behavior, or more than one.
+2. Follow [format and replay](references/format-and-replay.md) for the required registrations, codecs, version decision, and supported compatibility boundary.
+3. Follow [event content](references/event-content.md) for importance, output events, filtering, import modes, and privacy. A binlog is not a guaranteed full-fidelity snapshot.
+4. Preserve null/empty distinctions, existing field contracts, and version-specific reading. Coordinate the relevant Structured Log implementation when its codec must change.
+5. Select round-trip, historical/future-version, transport, or content evidence for the changed boundary. Do not promise every old reader can gracefully read every new format.
 
-Key source files:
-- `src/Build/Logging/BinaryLogger/BinaryLogger.cs` — the logger itself
-- `src/Framework/BuildEventArgs.cs` — base class for all build events
-- `src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs` — captures imported files
+## Evidence and stop condition
 
-## Adding New Build Event Types
-
-When adding a new `BuildEventArgs` subclass:
-
-1. **Define the new event class** inheriting from the appropriate base (`BuildMessageEventArgs`, `BuildWarningEventArgs`, etc.)
-2. **Add serialization support** — implement `WriteToStream` and `CreateFromStream` methods
-3. **Increment the binary log version** if the new event type changes the format
-4. **Add a new record type constant** in the binary logger's record type enum
-5. **Handle the unknown-type case** in the replay source — older readers must skip gracefully
-
-### Serialization Compatibility Rules
-
-- **Never remove fields** from existing event args serialization
-- **New fields must be appended** to the end of the serialization stream
-- **Use version checks** when reading — if the binlog version is older, use defaults for new fields
-- **Nullable fields** should serialize a presence flag before the value
-
-```csharp
-// Pattern for backward-compatible field addition
-if (logVersion >= newFieldVersion)
-{
-    writer.Write(newField);
-}
-
-// Reading with backward compatibility
-if (logVersion >= newFieldVersion)
-{
-    newField = reader.ReadString();
-}
-else
-{
-    newField = defaultValue;
-}
-```
-
-## Message Importance Levels
-
-Importance controls what appears in console output, but **everything goes to binlog** regardless of importance.
-
-| Level | Use For | Console Verbosity |
-|-------|---------|------------------|
-| `High` | Critical user-facing information | Minimal and above |
-| `Normal` | Standard build progress | Normal and above |
-| `Low` | Detailed diagnostic information | Detailed and above |
-| `Diagnostic` | Internal debugging | Diagnostic only |
-
-### Rules
-
-- Default to `Normal` for user-relevant information
-- Use `Low` for information useful when debugging but noisy in normal builds
-- `High` is reserved for important warnings/status — use sparingly
-- Never skip logging because "it's too verbose" — log at `Low` instead
-
-## ProjectImportsCollector
-
-The `ProjectImportsCollector` embeds all imported `.props`, `.targets`, and project files into the binlog. This enables the "preprocessed view" in log viewers.
-
-### Considerations
-
-- `MSBUILDLOGIMPORTS=1` (or the `/bl` switch) enables import collection
-- Imported file content is captured at evaluation time — reflects the actual content used
-- Large import chains increase binlog size — this is acceptable for diagnostic completeness
-- Sensitive content in imported files will be embedded — document this for users
-
-## Changes That Affect Binlog Content
-
-When modifying MSBuild behavior, verify binlog impact:
-
-| Change Type | Binlog Consideration |
-|------------|---------------------|
-| New property set during evaluation | Appears in `PropertyInitialValue` or `PropertyReassignment` events |
-| New target added | Produces `TargetStarted`/`TargetFinished` events |
-| Changed task behavior | Task output items/properties captured in `TaskFinished` |
-| New warning/error | Captured as `BuildWarningEventArgs`/`BuildErrorEventArgs` |
-| Modified import chain | Changes which files `ProjectImportsCollector` captures |
-
-## Testing Binlog Changes
-
-- **Round-trip test**: Write a binlog, replay it, verify all events are reconstructed
-- **Version compatibility test**: Verify older replay sources handle new events gracefully
-- **Content verification**: Assert specific events appear in the binlog for behavioral changes
-- **Size regression**: Monitor binlog size for unexpectedly large increases
-- Use `BinaryLogReplayEventSource` in tests to verify binlog content programmatically
-
-## Checklist
-
-- [ ] New event types have `WriteToStream`/`CreateFromStream` implementations
-- [ ] Binary log format version incremented if format changed
-- [ ] Backward compatibility: older readers skip/degrade gracefully
-- [ ] Forward compatibility: newer readers handle old format
-- [ ] Importance levels set correctly for new messages
-- [ ] Behavioral changes produce observable binlog events
-- [ ] Round-trip test passes (serialize → deserialize → verify)
+Stop when the requested contract is supported by the necessary source/round-trip/content evidence and remaining reader/host limits are stated. An investigation does not authorize producing or uploading logs, changing unrelated diagnostics, or running a full build merely because logging code exists.

--- a/.github/skills/maintaining-binary-log-compatibility/references/event-content.md
+++ b/.github/skills/maintaining-binary-log-compatibility/references/event-content.md
@@ -1,0 +1,67 @@
+# Binary-log event content and collection
+
+## Capture is conditional
+
+[BinaryLogger](../../../../src/Build/Logging/BinaryLogger/BinaryLogger.cs) defaults to diagnostic verbosity and requests detailed data such as evaluation properties/items and target outputs. It cannot recover events a producer did not emit, information a transport dropped, or arbitrary custom fields its writer does not support.
+
+Examples of intentional limits:
+
+- [Common props](../../../../src/Tasks/Microsoft.Common.props) suppress selected verbose task parameters/metadata by default.
+- [PropertyTrackingEvaluatorDataWrapper](../../../../src/Build/Evaluation/PropertyTrackingEvaluatorDataWrapper.cs) makes structured property tracking conditional and skips costly/redundant cases.
+- [BuildEventArgsWriter](../../../../src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs) filters environment information and falls back for unknown event shapes.
+- [TaskExecutionHost](../../../../src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs) checks task-parameter logging and critical-event settings.
+
+Do not add expensive logging merely to satisfy "the binlog captures everything." Preserve appropriate observability, but consider emission cost, size, privacy, and the intended diagnostic audience.
+
+## Importance is not severity or verbosity
+
+[MessageImportance](../../../../src/Framework/BuildMessageEventArgs.cs) defines three levels:
+
+| Importance | Typical console threshold / use |
+|---|---|
+| High | Minimal and above; important user-facing status |
+| Normal | Normal and above; ordinary progress |
+| Low | Detailed and above; diagnostic detail |
+
+These are typical console mappings; another logger can present events differently. There is no `MessageImportance.Diagnostic`. Diagnostic is a `LoggerVerbosity` level.
+
+Warnings/errors have their own event contracts, not "High importance" equivalents. Use [diagnostic authoring](../../authoring-errors-and-warnings/SKILL.md) when selecting a new diagnostic's severity and resource.
+
+Low importance does not make constructing arguments or payloads free. Use the established producer/logging helper's enabled/lazy path where appropriate, without suppressing information needed by a subscribed consumer.
+
+## Find the correct event
+
+| Information | Source/event to inspect |
+|---|---|
+| Final evaluated properties/items | Requested `ProjectEvaluationFinishedEventArgs` data |
+| Structured initial property assignment | `PropertyInitialValueSetEventArgs`, when tracking is enabled |
+| Property reassignment | Structured tracking or the existing message path, subject to filtering |
+| Target execution/skipping | Target started/finished or skipped events for the actual execution path |
+| Task input/output values | `TaskParameterEventArgs` and its input/output kind, subject to logging controls |
+| Task completion | `TaskFinishedEventArgs`; it does not itself contain all output items/properties |
+| Warnings/errors | Their structured event kind, code, message, and location |
+| Imports | Import events plus the configured collection path |
+
+Assert the event/field that represents the changed contract rather than searching only formatted text or assuming a task-finished event is a parameter dump.
+
+## Project imports
+
+[ProjectImportsCollector](../../../../src/Build/Logging/BinaryLogger/ProjectImportsCollector.cs) can collect project/import files and in-memory content. [BinaryLogger](../../../../src/Build/Logging/BinaryLogger/BinaryLogger.cs) controls whether it is used:
+
+| Mode | Result |
+|---|---|
+| `ProjectImports=None` | No collected import archive |
+| `ProjectImports=Embed` | Embed the collected archive in the binlog |
+| `ProjectImports=ZipFile` | Write a separate project-import archive |
+
+`MSBUILDLOGIMPORTS` requests import logging; setting it alone is not equivalent to configuring a file collector or embedding every source file.
+
+The collector normally queues disk-file collection on a background task and opens the file when that work runs. It deduplicates paths, checks availability, and can encounter I/O failures. This is not an atomic snapshot of exactly the bytes evaluation consumed. In-memory collection is a separate path.
+
+For an import-collection change, distinguish disk and in-memory sources, already-processed files, collection mode, I/O behavior, and raw replay as relevant. Do not present a preprocessed viewer display as proof that every historical input byte is preserved.
+
+## Sensitive content and evidence
+
+Collected project/targets files and event values can contain sensitive information. `ProjectImports=None` avoids that archive, but does not scrub sensitive values from other events. Producing a binlog does not authorize uploading it or attaching it to a public issue.
+
+Use a focused content assertion or existing reproduction when the task needs evidence. [Binary-Log.md](../../../../documentation/wiki/Binary-Log.md) describes general usage; [format and replay](format-and-replay.md) describes codec changes. State missing/filtered data rather than interpreting its absence as proof an operation did not happen.

--- a/.github/skills/maintaining-binary-log-compatibility/references/format-and-replay.md
+++ b/.github/skills/maintaining-binary-log-compatibility/references/format-and-replay.md
@@ -1,0 +1,78 @@
+# Binary-log format and replay
+
+## Two serialization channels
+
+| Channel | Owning implementation |
+|---|---|
+| Build-event transport between MSBuild processes | Event `WriteToStream` / `CreateFromStream` and [LogMessagePacketBase](../../../../src/Shared/LogMessagePacketBase.cs) |
+| Binlog event encoding | [BuildEventArgsWriter](../../../../src/Build/Logging/BinaryLogger/BuildEventArgsWriter.cs), [BinaryLogRecordKind](../../../../src/Build/Logging/BinaryLogger/BinaryLogRecordKind.cs), and [BuildEventArgsReader](../../../../src/Build/Logging/BinaryLogger/BuildEventArgsReader.cs) |
+| Replay routing | [BinaryLogReplayEventSource](../../../../src/Build/Logging/BinaryLogger/BinaryLogReplayEventSource.cs) and [EventArgsDispatcher](../../../../src/Build/Logging/BinaryLogger/EventArgsDispatcher.cs) |
+
+An event class implementing its transport methods is not enough to preserve new fields in a binlog. `BuildEventArgsWriter.WriteCore` and its typed dispatch determine what is encoded. Its fallback can convert unrecognized events to messages, preserving only the supported message/extended data.
+
+For external task/logger extension data, inspect the supported `Extended*EventArgs` contract rather than assuming an arbitrary subclass's fields will round-trip. Internal product event additions need the relevant explicit registrations.
+
+## Adding or changing an event
+
+1. Identify the event's base contract and every producer/consumer that needs the new information.
+2. Check node transport separately, including known event construction/dispatch and affected host versions.
+3. Add or update binlog writer dispatch and the typed encoder.
+4. Add a record kind when the wire contract requires a distinct kind; preserve existing enum values.
+5. Add reader dispatch/decoding and relevant replay routing.
+6. Decide format/minimum-reader version implications and coordinate the matching Structured Log codec.
+
+[BinaryLogger.cs](../../../../src/Build/Logging/BinaryLogger/BinaryLogger.cs) keeps the format history and explicitly calls out synchronization with the Structured Log writer. A repository-only encoder change is not proof that downstream tooling consumes it.
+
+## Field encoding
+
+Preserve existing field ordering and meaning. Append fields where that preserves the supported reader contract, and supply appropriate defaults when reading older formats. A writer generally emits the current format; readers retain historical branches. Do not copy pseudocode implying the writer has an arbitrary `logVersion` variable.
+
+Use the existing field helpers:
+
+- Strings/name-value data can be deduplicated and encoded by IDs, rather than written inline.
+- `BuildEventArgsWriter.HashString` distinguishes null (ID 0) from the empty string (ID 1).
+- Existing common-field flags encode the presence of various fields.
+- A nullable field does not universally require a newly inserted Boolean; follow the particular codec.
+- Preserve timestamp, event context, location, and other structured metadata as required, not just formatted `Message`.
+
+The writer buffers records and emits dependent string/name-value records in the required order. Changes to auxiliary records or deduplication can affect more than one event type.
+
+## Version decisions
+
+Read the constants and history in [BinaryLogger.cs](../../../../src/Build/Logging/BinaryLogger/BinaryLogger.cs), rather than copying current version numbers into a procedure.
+
+| Constant | Purpose |
+|---|---|
+| `FileFormatVersion` | Current emitted representation; update when the format changes |
+| `MinimumReaderVersion` | Earliest reader capable of the format's fundamental representation |
+| `ForwardCompatibilityMinimalVersion` | Historical boundary at which framed records support forward-compatible reading; not a release counter |
+
+A new event or appended field can often leave the minimum reader unchanged because compatible readers can skip unknown data. A change to framing/auxiliary representation may require raising it. Derive the decision from what an older reader can actually parse.
+
+Use explicit directions:
+
+- **Backward reading:** a newer reader reads older logs using its historical decode/default branches.
+- **Forward-compatible reading:** an older reader encounters a newer log, when the format/minimum-reader contract supports it and the reader opts into skipping unknown content.
+
+`BinaryLogReplayEventSource.AllowForwardCompatibility` is opt-in. `OpenBuildEventsReader` rejects unsupported combinations, including a minimum reader newer than the implementation. Unknown-content skipping also depends on framed records and the version relationship.
+
+Direct `BuildEventArgsReader` skipping requires the recoverable-error notification contract; inspect `CheckErrorsSubscribed` rather than silently discarding unknown data. Partial recovery is not proof of complete event fidelity.
+
+Raw replay/transcoding and structured replay differ. [BinaryLogger](../../../../src/Build/Logging/BinaryLogger/BinaryLogger.cs) preserves source version information when copying raw records; stamping a new version over unchanged old bytes would misdescribe the payload.
+
+## Select evidence for the changed contract
+
+[BinaryLogger_Tests](../../../../src/Build.UnitTests/BinaryLogger_Tests.cs) contains round-trip/equality scenarios, raw versus structured replay, and forward-compatibility acceptance/rejection cases.
+
+Choose the relevant assertions:
+
+| Change | Evidence |
+|---|---|
+| New field/event | Required structured data survives the relevant serialization/replay paths |
+| Historical reader branch | Representative older-format data yields the intended defaults/fields |
+| Forward-compatible recovery | Accepted/rejected version combinations, recoverable unknown content, and visible limits |
+| Node transport | The event reaches the consumer with needed data in the affected process/host path |
+| Import/embedded content | Correct collection mode and embedded/external content, including applicable failures |
+| Large/repeated payload | Meaningful size/allocation regression evidence |
+
+Do not require every row for an ordinary message-text change. Do not infer compatibility with every third-party viewer or host from one local round trip.


### PR DESCRIPTION
### Part 2 of 8

Replace incorrect API, warning, ChangeWave, logging, and transport claims with source-backed guidance and focused references. Preserve current-main TerminalLogger instructions.

Depends on dotnet/msbuild#14962. Next: dotnet/msbuild#14964. Full index: dotnet/msbuild#14961.

This PR is based on `janprovaznik/context-01-foundations`. Files changed shows only this chapter. Review bottom-up; after the preceding chapter lands, retarget this PR to `main` before merging. Do not merge later chapters into temporary stack-base branches.

### Scope and evidence

Guidance is checked against the referenced source/configuration, and this chapter introduces no new broken local references. No product runtime behavior is claimed to have been re-executed by a documentation change.

Agentic-workflow changes remain separate. This stack does not include personal plugin overrides, plugin auto-activation changes, or SDK/feed version changes. The public descriptions use public repository evidence, not internal discussions or proprietary source.
