### PR TITLE
[3/8] Clarify evaluation, SDK, and performance context

### DIFF
--- a/.github/instructions/evaluation.instructions.md
+++ b/.github/instructions/evaluation.instructions.md
@@ -2,42 +2,14 @@
 applyTo: "src/Build/Evaluation/**"
 ---
 
-# Evaluation Engine Instructions
+# Evaluation
 
-The evaluation engine (`Evaluator.cs`, `Expander.cs`, `LazyItemEvaluator.cs`) is MSBuild's hottest code path. Every project load passes through here.
+- Trace the relevant passes in [Evaluator](../../src/Build/Evaluation/Evaluator.cs). Property/import processing, item definitions, items, and targets do not share one universal "condition evaluated immediately" rule.
+- Global properties normally override project assignments; account for `TreatAsLocalProperty`. Do not generalize last-write-wins to every property source.
+- Preserve item/metadata scope, escaping, evaluation order, and lazy-item semantics. Undefined versus empty metadata must follow the specific API/operation contract.
+- Expansion caches need the correct property/item/metadata context and lifetime. Repeating the same expression text does not imply the same result.
+- Measure hot paths before optimizing. Avoid repeated allocations and filesystem work, but do not invent invocation counts or add caches without invalidation.
+- For intrinsic/property functions, check the actual allowlist, feature guards, runtime availability, and existing error behavior. File/environment access is not uniformly an opt-in feature.
+- Test the affected import, condition, global-property, and reevaluation scenarios. Assess observable changes with the [compatibility skill](../skills/assessing-breaking-changes/SKILL.md).
 
-## Evaluation Model Integrity
-
-* Strict evaluation order: environment → global properties → project properties (file order with imports) → item definitions → items. Never alter this order.
-* Conditions are evaluated at the point they appear, not deferred.
-* Undefined metadata and empty-string metadata must be treated equivalently.
-* Property precedence is last-write-wins within the import chain.
-* Gate evaluation behavior changes behind a [ChangeWave](../../documentation/wiki/ChangeWaves.md).
-
-## Expander Safety
-
-* `Expander.cs` is called millions of times per evaluation — every allocation counts.
-* Cache expanded values when the same expression is expanded repeatedly.
-
-## IntrinsicFunctions
-
-* New intrinsic functions are permanent public API — can never be removed once shipped.
-* Validate all inputs; called from user-authored MSBuild with arbitrary arguments.
-* Security-sensitive functions (file I/O, registry, environment) must check for opt-in.
-* Test edge cases: null, empty strings, very long strings, culture-sensitive formatting.
-
-## Condition Evaluation
-
-* Condition parsing is allocation-sensitive — prefer `Span<char>`-based parsing.
-* Boolean conditions must short-circuit correctly.
-* String comparisons in conditions use MSBuild semantics (case-insensitive for identifiers).
-
-## ProjectRootElementCache
-
-* Cache invalidation bugs cause stale evaluations or memory leaks — test eviction scenarios.
-* Thread safety is critical — the cache is accessed from multiple nodes.
-
-## Related Documentation
-
-* [ChangeWaves](../../documentation/wiki/ChangeWaves.md)
-* [Target Maps](../../documentation/wiki/Target-Maps.md)
+Load [performance guidance](../skills/optimizing-msbuild-performance/SKILL.md) for an actual performance change and [SDK integration](../skills/integrating-sdk-and-msbuild/SKILL.md) for SDK/import-boundary work.

--- a/.github/instructions/globbing.instructions.md
+++ b/.github/instructions/globbing.instructions.md
@@ -1,38 +1,15 @@
 ---
-applyTo: "src/Build/Globbing/**"
+applyTo: "src/Build/Globbing/**,src/Framework/Utilities/FileMatcher.cs"
 ---
 
-# Globbing Instructions
+# Globbing
 
-Resolves file patterns (e.g., `**/*.cs`) for item includes/excludes. Runs during evaluation — performance-critical.
+- Preserve the established wildcard, escaping, include/exclude/remove, and relative-root semantics. Do not replace them with general-purpose filesystem glob assumptions.
+- [FileMatcher](../../src/Framework/Utilities/FileMatcher.cs) is the implementation boundary for filesystem matching; it is not in `src/Shared`.
+- Excludes can prune recursion during enumeration. Preserve that optimization and its equivalence to the intended result; do not force all excludes into a post-processing pass.
+- Distinguish evaluation-time globs from item operations inside executing targets. Filesystem state and expansion context belong to the actual operation.
+- Cache results only with a defined root, matching options, filesystem-state assumptions, and invalidation lifetime.
+- Test relevant literal/wildcard patterns, nested excludes, separator/case behavior, symlinks, and missing paths. Assert MSBuild's established behavior rather than assuming OS filesystem rules alone define it.
+- Measure enumeration and allocation costs before changing algorithms. Use [compatibility assessment](../skills/assessing-breaking-changes/SKILL.md) for observable matching changes.
 
-## Glob Pattern Correctness
-
-* Semantics: `*` matches within a directory, `**` across directories, `?` a single character.
-* Include and exclude patterns must use the same matching rules.
-* Handle edge cases: empty patterns, only-wildcard patterns, literal special characters, trailing separators.
-* Relative vs absolute patterns must produce consistent results regardless of working directory.
-
-## Performance
-
-* Minimize filesystem enumeration — prune directory traversal early using glob structure.
-* Cache results when the same pattern is evaluated multiple times (common with `**/*.cs` across imports).
-* Avoid allocating intermediate string collections — use lazy evaluation where possible.
-
-## Exclude Patterns
-
-* Excludes are applied after includes, not during.
-* `Remove` with globs must use the same matching engine.
-* Test with nested excludes (e.g., `**/*.cs` include with `**/obj/**` exclude).
-
-## Evaluation-Time Behavior
-
-* Globs resolve at evaluation time — filesystem state at that point determines the item list.
-* Changes affect all SDK-style projects (implicit `**/*.cs` includes).
-* Gate behavioral changes behind a [ChangeWave](../../documentation/wiki/ChangeWaves.md).
-
-## Cross-Platform
-
-* Glob patterns must work with both `\` and `/` separators.
-* Case sensitivity must follow OS filesystem conventions.
-* Symlink traversal must be safe (no infinite loops).
+Start with [FileMatcher tests](../../src/Framework.UnitTests/FileMatcher_Tests.cs) and the tests nearest the changed matching path; expand only for additional affected semantics.

--- a/.github/instructions/targets.instructions.md
+++ b/.github/instructions/targets.instructions.md
@@ -2,46 +2,15 @@
 applyTo: "src/Tasks/**/*.targets,src/Tasks/**/*.props"
 ---
 
-# Targets & Props Authoring Instructions
+# Targets and props
 
-`.targets` and `.props` files define MSBuild's default build logic. Changes here affect every .NET project.
+- Preserve target names and extensibility contracts. Use `DependsOnTargets` for required dependencies and `BeforeTargets`/`AfterTargets` for the appropriate extension relationship; the latter are not inherently inferior.
+- Distinguish evaluation-time property/item groups from those inside executing targets. A target condition is not evaluated merely when its XML is first encountered.
+- Use conditional property defaults when user values should win. Some targets deliberately compute/override internal properties; preserve their actual contract rather than prohibiting every assignment after imports.
+- Quote string values in conditions and follow existing escaping/comparison conventions.
+- Define `Inputs`/`Outputs` when target-level incremental skipping is appropriate. Include the dependencies and outputs needed for correctness, and account for output inference, batching, removed inputs, and clean behavior.
+- Test relevant no-op, source-change, project-reference, multitargeting, and import-order cases. A successful clean build alone does not establish incremental correctness.
+- Use the [SDK integration skill](../skills/integrating-sdk-and-msbuild/SKILL.md) for SDK imports, restore/build, or project-reference protocol changes.
+- Assess changed defaults, item sets, ordering, or output with the [compatibility skill](../skills/assessing-breaking-changes/SKILL.md); do not assume every targets edit needs a ChangeWave.
 
-## Target Ordering
-
-* Use `DependsOnTargets` for required predecessors — primary ordering mechanism.
-* Use `BeforeTargets`/`AfterTargets` sparingly — harder to reason about and debug.
-* Test execution order with project references and multi-targeting scenarios.
-* New targets must hook into the correct extensibility point (e.g., `BuildDependsOn`, `CompileDependsOn`).
-
-## Condition Patterns
-
-* Use `Condition="'$(PropertyName)' == ''"` to set defaults without overriding user values.
-* `.props` files set defaults; `.targets` files should not override user-set properties.
-* Conditions are evaluated in file order — cannot reference properties set later.
-* Always use single-quotes for MSBuild string comparisons in conditions.
-
-## Backwards Compatibility
-
-* Changing property defaults breaks projects that relied on the previous default.
-* Removing or renaming a target is a breaking change — may be referenced by `DependsOnTargets` in user projects.
-* Adding items to existing item types can change build output unexpectedly.
-* Gate behavioral changes behind a [ChangeWave](../../documentation/wiki/ChangeWaves.md).
-
-## Incremental Build Correctness
-
-* `Inputs`/`Outputs` declarations must be precise:
-  - `Inputs`: all files that affect the target's output.
-  - `Outputs`: all files the target produces.
-  - Missing inputs → stale builds. Missing outputs → unnecessary rebuilds.
-* See [Rebuilding when nothing changed](../../documentation/wiki/Rebuilding-when-nothing-changed.md).
-
-## SDK Target Interaction
-
-* SDK `.props` import before user project content; SDK `.targets` import after.
-* Property defaults in SDK props must use `Condition="'$(Prop)' == ''"` so user values win.
-* Do not assume execution order between SDK targets and user-authored targets.
-
-## Related Documentation
-
-* [ChangeWaves](../../documentation/wiki/ChangeWaves.md)
-* [Target Maps](../../documentation/wiki/Target-Maps.md)
+Read [target maps](../../documentation/wiki/Target-Maps.md) or [unexpected rebuilding](../../documentation/wiki/Rebuilding-when-nothing-changed.md) only for the behavior under investigation.

--- a/.github/skills/integrating-sdk-and-msbuild/SKILL.md
+++ b/.github/skills/integrating-sdk-and-msbuild/SKILL.md
@@ -1,121 +1,31 @@
 ---
 name: integrating-sdk-and-msbuild
-description: 'Guides work on the SDK-MSBuild integration boundary. Consult when authoring or modifying SDK targets, working on dotnet CLI to MSBuild invocation, handling project-reference protocol, coordinating cross-repo changes with dotnet/sdk, debugging property resolution or import ordering, working on restore/build/publish/pack target chains, or dealing with Directory.Build.props/targets interaction.'
-argument-hint: 'Describe the SDK integration scenario or cross-repo coordination need.'
+description: "Investigate or change a concrete MSBuild/SDK/NuGet boundary: imports, restore evaluations, project-reference contracts, or host-specific target behavior. Not ordinary target customization or automatic multi-repository coordination."
+argument-hint: "Identify the host, project/SDK, properties or targets, and observed boundary failure."
 ---
 
-# SDK-MSBuild Integration Patterns
+# Work across the SDK/MSBuild boundary
 
-MSBuild operates as a component within the .NET SDK. This boundary is the most complex integration point in the .NET build stack, spanning MSBuild (engine), SDK (target implementations), NuGet (restore), and Roslyn (compilation).
+**Use for:** determining which producer/consumer owns a property, import, restore/build transition, reference negotiation, or CLI/IDE target contract.
 
-## The Evaluation Boundary
+**Do not use for:** turning every props/targets edit into an SDK investigation, general CI diagnosis, or automatically filing issues in multiple repositories.
 
-Understanding MSBuild's evaluation order is critical for SDK target authoring:
+## Source preflight
 
-```
-1. Environment variables
-2. Global properties (from CLI: -p:Foo=Bar)
-3. Project-level properties (file order, with imports):
-   ┌─ Sdk.props (SDK defaults)
-   ├─ Directory.Build.props (user overrides BEFORE project)
-   ├─ <Project> properties (the .csproj itself)
-   ├─ Directory.Build.targets (user overrides AFTER project)
-   └─ Sdk.targets (SDK target definitions)
-4. Item definitions
-5. Items (including SDK default globs)
-```
+Establish the actual SDK, MSBuild binaries/host, project shape, requested targets, and global properties. [global.json](../../../global.json) describes this checkout's SDK selection, not necessarily the host that produced a supplied log.
 
-### Key Import Order Rules
+Start with the affected imports in [Common props](../../../src/Tasks/Microsoft.Common.props), [Common targets](../../../src/Tasks/Microsoft.Common.targets), or [Common CurrentVersion targets](../../../src/Tasks/Microsoft.Common.CurrentVersion.targets). Inspect the selected SDK's implementation when the boundary leaves this repository.
 
-- **SDK props import BEFORE user project** — SDK defaults can be overridden by the user
-- **SDK targets import AFTER user project** — SDK targets see user-specified properties
-- **`Directory.Build.props` is imported from `Microsoft.Common.props` as an early user extension point after core defaults are computed** — use it for solution-wide customization
-- **Property defaults set in SDK must not override user-specified values** — always use `Condition="'$(Prop)' == ''"`
+Follow [evaluation instructions](../../instructions/evaluation.instructions.md) or [target instructions](../../instructions/targets.instructions.md) for the affected code.
 
-```xml
-<!-- CORRECT: SDK default that respects user override -->
-<OutputType Condition="'$(OutputType)' == ''">Library</OutputType>
+## Workflow
 
-<!-- WRONG: Unconditional set clobbers user's .csproj -->
-<OutputType>Library</OutputType>
-```
+1. State the observed producer/consumer mismatch and choose one primary trace: [evaluation/restore](references/evaluation-and-restore.md) or [references/target contracts](references/project-references-and-targets.md).
+2. Trace the actual nested imports, global-property sets, or reference metadata. Do not infer ordering from a flattened SDK diagram.
+3. Compare relevant CLI/IDE or outer/inner-build branches. Establish the required contract before changing defaults or hooks.
+4. If a cross-repository change is necessary, identify compatible sequencing and consumption evidence. Do not assume MSBuild must always land first or that diagnosis authorizes external posting.
+5. Select a focused reproduction or existing integration evidence; use [bootstrap guidance](../use-bootstrap-msbuild/SKILL.md) only when locally built behavior must be exercised.
 
-## Restore and Build Separation
+## Evidence and stop condition
 
-**Restore and Build must never run in the same evaluation.** The restore phase generates `.g.props` and `.g.targets` files that must be imported during evaluation — but they don't exist until restore completes.
-
-- `dotnet build` implicitly runs restore then build as **separate invocations**
-- `dotnet build --no-restore` skips restore, assuming it already happened
-- Running both targets in one invocation (`/t:Restore;Build`) is a known anti-pattern that causes intermittent failures
-
-## Project Reference Protocol
-
-The project-reference protocol spans MSBuild, SDK, and NuGet. It is the most complex integration boundary.
-
-### How It Works
-
-1. Outer build dispatches to `_GetProjectReferenceTargetFrameworkProperties` to determine inner build parameters
-2. Inner build runs with the resolved `TargetFramework` (singular) for each referenced project
-3. `GetTargetPath` returns the output assembly for the referencing project to consume
-
-### Rules
-
-- Protocol changes must be coordinated across MSBuild, SDK, and NuGet teams
-- Multi-targeting projects (`<TargetFrameworks>`) dispatch multiple inner builds
-- The outer build must not assume a single target framework
-- `SetTargetFramework` is how the outer build communicates the chosen framework to inner builds
-
-## Target Authoring in SDK Context
-
-### Extension Points
-
-SDK provides well-known extension points for targets:
-
-| Extension Point | Use For |
-|----------------|---------|
-| `$(BuildDependsOn)` | Adding to the Build chain |
-| `$(CompileDependsOn)` | Pre-compilation steps |
-| `$(PublishDependsOn)` | Publish pipeline additions |
-| `$(PackDependsOn)` | NuGet pack pipeline additions |
-| `BeforeTargets="Build"` | Use sparingly; prefer `DependsOnTargets` |
-
-### Ordering Rules
-
-1. **Use `DependsOnTargets` for required predecessors** — it's explicit and predictable
-2. **`BeforeTargets`/`AfterTargets` should be used sparingly** — they create implicit ordering that's hard to debug
-3. **Incremental build targets need precise `Inputs` and `Outputs`** — incorrect declarations cause either rebuild-every-time or stale-output bugs
-4. **Test with multi-targeting** — target chains execute once per `TargetFramework` in the inner build
-
-## Cross-Repo Coordination
-
-Changes that touch the MSBuild-SDK boundary often require coordinated PRs:
-
-1. **MSBuild engine change** → may need SDK target updates
-2. **SDK target change** → may need MSBuild API additions
-3. **NuGet restore change** → affects both MSBuild evaluation and SDK targets
-
-### Coordination Protocol
-
-- File an issue in both repos describing the cross-cutting change
-- Land the MSBuild change first (lower in the stack)
-- Update SDK to consume the new MSBuild via dependency flow
-- Test end-to-end with the SDK's MSBuild integration tests
-
-## Design-Time Builds
-
-Visual Studio uses design-time builds with different target contracts:
-
-- Design-time builds call `ResolveProjectReferences` but not `Build`
-- They set `$(DesignTimeBuild)=true` and `$(BuildingProject)=false`
-- Targets that should not run during design-time must check these properties
-- Design-time builds must be fast — avoid expensive I/O or compilation
-
-## Common Integration Bugs
-
-| Symptom | Likely Cause |
-|---------|-------------|
-| Property has wrong value | Import ordering — check if SDK prop overrides user setting |
-| Target runs in wrong order | Missing `DependsOnTargets` declaration |
-| Build works, restore fails | Evaluation-time dependency on restore-generated files |
-| Works single-target, fails multi-target | Target assumes single `$(TargetFramework)` |
-| CLI build works, VS build fails | Design-time build target contract violation |
+Stop when the responsible boundary, old/new contract, and scoped evidence or blocker are clear. A property/import explanation does not require builds in multiple repositories. Do not claim all design-time or multi-targeting scenarios are covered from a single CLI build.

--- a/.github/skills/integrating-sdk-and-msbuild/references/evaluation-and-restore.md
+++ b/.github/skills/integrating-sdk-and-msbuild/references/evaluation-and-restore.md
@@ -1,0 +1,67 @@
+# Evaluation, imports, and restore
+
+## Follow nested imports
+
+An SDK-style project's implicit imports are created at the top and bottom by [ProjectRootElement.GetImplicitImportNodes](../../../../src/Build/Construction/ProjectRootElement.cs). For an SDK using the common .NET target chain, the shape is approximately:
+
+```text
+implicit Sdk.props
+  ... Microsoft.Common.props
+    Directory.Build.props
+    ... Common defaults and project-extension props
+  ... remaining SDK props
+project body and its explicit imports
+implicit Sdk.targets
+  ... language/Common target imports
+    Microsoft.Common.CurrentVersion.targets
+    generated project-extension targets
+    Directory.Build.targets
+  ... remaining SDK target imports
+```
+
+This is a navigation model, not a universal import list for every SDK. Read the selected SDK and project imports to establish the real sequence.
+
+[Microsoft.Common.props](../../../../src/Tasks/Microsoft.Common.props) imports `Directory.Build.props` before important defaults such as `BaseIntermediateOutputPath`. Its location is an early extension point, not "after all core defaults."
+
+[Microsoft.Common.targets](../../../../src/Tasks/Microsoft.Common.targets) imports Common CurrentVersion targets, project-extension targets, and `Directory.Build.targets`. The directory targets are nested in this chain; they are not a separate stage preceding every statement in `Sdk.targets`.
+
+The normal directory-file search selects the nearest applicable file unless paths/import controls change it. Ancestor layering requires explicit imports; do not assume every ancestor's `Directory.Build.props` or targets is automatically merged.
+
+## Evaluation order versus precedence
+
+Full evaluation initializes properties, processes property/import declarations, then item definitions/items and using-task/target registration. Some APIs/commands can request a partial evaluation; inspect the entry point when that matters.
+
+XML position alone does not determine whether a property can be replaced. Global properties normally retain precedence over project assignments, with exceptions such as `TreatAsLocalProperty`. See [Evaluator](../../../../src/Build/Evaluation/Evaluator.cs), especially initial-property setup and `EvaluatePropertyElement`.
+
+For an overridable fallback default, an empty-value condition is appropriate:
+
+```xml
+<PropertyGroup>
+  <OutputType Condition="'$(OutputType)' == ''">Library</OutputType>
+</PropertyGroup>
+```
+
+That is not a rule to conditionalize every assignment. Computed properties, normalization, and deliberate appends have different contracts. Trace when their inputs become available and where later imports overwrite them.
+
+For a wrong value, establish the global inputs, first/default assignment, reassignment, import condition, and actual consumer. Existing binlogs or import traces can help, but a cached/partial log is not proof of every intermediate value.
+
+## Restore is a distinct evaluation context
+
+Standard NuGet/SDK restore can generate imports needed by the subsequent build. Running `Restore;Build` as targets in the same evaluated project instance does not refresh those imports.
+
+Use the supported restore-then-build path, such as MSBuild's `-restore`, rather than requiring separate process invocations. [XMake.ExecuteRestore](../../../../src/MSBuild/XMake.cs) creates a restore request with a different global-property/evaluation context and then executes the build request through the build manager.
+
+`dotnet build` normally includes restore; `--no-restore` assumes restore inputs/outputs are already available. Identify what the actual host requested rather than assuming a textual target list means the supported transition was used.
+
+The Common imports also change behavior during restore:
+
+- [Common props](../../../../src/Tasks/Microsoft.Common.props) controls project-extension props through `MSBuildIsRestoring` and `ImportProjectExtensionProps`.
+- [Common targets](../../../../src/Tasks/Microsoft.Common.targets) has the corresponding project-extension target controls.
+
+Do not casually unify global-property sets or reuse an evaluated instance to remove a perceived redundant evaluation. Restore can change which files exist and which imports are valid; the standard path also owns cache invalidation and missing-import handling.
+
+## Choosing evidence
+
+For import/default changes, cover the actual SDK/import style and property precedence at issue. For restore transitions, use the relevant missing/stale generated-import scenario and distinguish first restore from an already-restored build.
+
+If the required SDK/host implementation is not available, state that boundary. Do not change `global.json`, install a different SDK, or claim a locally installed unrelated SDK proves the requested behavior.

--- a/.github/skills/integrating-sdk-and-msbuild/references/project-references-and-targets.md
+++ b/.github/skills/integrating-sdk-and-msbuild/references/project-references-and-targets.md
@@ -1,0 +1,61 @@
+# Project references and target contracts
+
+## Reference negotiation is not outer-build dispatch
+
+The common implementation is in [Microsoft.Common.CurrentVersion.targets](../../../../src/Tasks/Microsoft.Common.CurrentVersion.targets) and [Microsoft.Common.CrossTargeting.targets](../../../../src/Tasks/Microsoft.Common.CrossTargeting.targets).
+
+For the consuming project's reference pipeline:
+
+1. Configuration/platform and reference items are prepared.
+2. `_GetProjectReferenceTargetFrameworkProperties` calls referenced projects' `GetTargetFrameworks` where needed and supported.
+3. NuGet's framework-selection task chooses a compatible referenced framework; Common targets construct metadata such as `SetTargetFramework`.
+4. `ResolveProjectReferences` invokes the appropriate referenced target and collects outputs.
+
+`SetTargetFramework` is reference-item metadata containing a property assignment, not a universal outer-build dispatch property.
+
+A cross-targeting outer build separately enumerates its own `TargetFrameworks` and dispatches to its own inner builds. `GetTargetFrameworksWithPlatformFromInnerBuilds`, `_ComputeTargetFrameworkItems`, and `DispatchToInnerBuilds` show that protocol; the inner-build items carry `AdditionalProperties`.
+
+Do not assume an outer build has a single `TargetFramework`, or that a target runs only in inner builds without inspecting its import/dispatch conditions.
+
+## Referenced target and returned data
+
+| Branch | Expected behavior |
+|---|---|
+| IDE or `BuildProjectReferences` disabled | Common targets normally query `GetTargetPath`, without building the output |
+| Normal CLI project-reference build | Invoke the reference's requested/default targets and collect their returned outputs |
+| Framework negotiation | `GetTargetFrameworks` reports available choices and metadata; it is not the actual compile |
+| Custom referenceable project | Implement the applicable contracts or rely only on explicitly skippable optional targets |
+
+`GetTargetPath` should not itself compile the reference. The host/user contract determines whether its output already exists.
+
+Inspect reference metadata including `BuildReference`, `ReferenceOutputAssembly`, `Targets`, `SetConfiguration`, `SetPlatform`, `SetTargetFramework`, and `GlobalPropertiesToRemove`. For example, not passing an output assembly to the compiler is different from not building the reference.
+
+The [ProjectReference protocol document](../../../../documentation/ProjectReference-Protocol.md) provides broader context, including optional targets and additional metadata. Some historical names/examples can lag implementation; use the current target files to resolve exact names, schemas, and conditions.
+
+## Extension ordering
+
+Use `DependsOnTargets` when a target requires predecessors. Use documented `BeforeTargets`/`AfterTargets` hooks to extend another target without replacing its body. These mechanisms solve different problems.
+
+The import position matters for dependency-list properties. Common targets assign `BuildDependsOn`; an append earlier in an implicitly imported SDK project can be overwritten. Inspect the final assignment or use the appropriate supported hook.
+
+`BeforeTargets="Build"` does not mean "before everything Build depends on." [TargetBuilder](../../../../src/Build/BackEnd/Components/RequestBuilder/TargetBuilder.cs) schedules dependencies before the before-target hook and the target body. Select the actual consumer boundary for pre-compilation or generated-file work.
+
+A hook does not simply inherit the target's condition. Give it the appropriate condition and, where incremental behavior is needed, accurate `Inputs`/`Outputs`. Check repeated/no-op builds only for the relevant changed outputs, not as a blanket requirement that every target be skipped.
+
+For publish/pack/compile extensions, inspect the selected SDK/target owner and final dependency properties. Do not assume a name such as `PublishDependsOn` or `PackDependsOn` has identical placement/meaning across project types and SDK versions.
+
+## Design-time and host behavior
+
+Inspect requested targets and properties including `DesignTimeBuild`, `BuildingProject`, `BuildingInsideVisualStudio`, and `BuildProjectReferences`.
+
+Common targets default `BuildProjectReferences` differently for design-time work and use `BuildingProject` in several failure/reporting decisions. That does not define a universal target list for every Visual Studio project system.
+
+Keep expensive work and side effects out of paths that only need design-time information, but do not indiscriminately skip targets that supply required IDE data. Establish the actual target/input/output contract before adding a design-time condition.
+
+## Cross-repository coordination
+
+Determine which repository owns the producer, consumer, and deployment/consumption step. An additive engine change may land first; another change may need consumer tolerance or an opt-in before a producer changes. Choose sequencing from compatibility, not stack order alone.
+
+Document the contract, expected version/feature availability, fallback behavior, and end-to-end evidence needed. Creating issues, posting comments, or opening PRs requires authority separate from diagnosing the boundary.
+
+Stop after the actual integration question is answered or the scoped change is evidenced. Record untested project systems, frameworks, or consumption paths rather than claiming universal integration coverage.

--- a/.github/skills/optimizing-msbuild-performance/SKILL.md
+++ b/.github/skills/optimizing-msbuild-performance/SKILL.md
@@ -1,102 +1,29 @@
 ---
 name: optimizing-msbuild-performance
-description: 'Guides performance optimization for MSBuild engine code. Consult when working on hot paths in evaluation or execution, reducing allocations, choosing collection types, handling strings efficiently, modifying Expander.cs or Evaluator.cs, using Span<T>/stackalloc, caching values, or profiling build performance. Also applies when reviewing PRs for performance regression.'
-argument-hint: 'Describe the performance-sensitive code area or optimization goal.'
+description: "Investigate or optimize a measured MSBuild engine hot path, allocation pattern, or performance regression. Not every Span/LINQ edit, generic slow-project diagnosis, or automatic benchmark/agent orchestration."
+argument-hint: "Describe the workload, measured bottleneck or hypothesis, runtime, and success metric."
 ---
 
-# MSBuild Performance Guidelines
+# Optimize engine performance
 
-MSBuild evaluates and builds thousands of projects in enterprise solutions. Performance is an architectural concern, not an afterthought.
+**Use for:** an engine implementation hypothesis or measured regression in evaluation, expansion, execution, collections, logging, or I/O.
 
-## Guiding Principle
+**Do not use for:** mechanically replacing language constructs, treating all caches as safe, or expanding a small source question into a benchmark campaign. Use [benchmarking-msbuild](../benchmarking-msbuild/SKILL.md) for an actual comparison experiment.
 
-**Profile before optimizing; measure, do not guess.** Use BenchmarkDotNet, the evaluation profiler (`/profileevaluation`), or ETW traces to identify actual bottlenecks before optimizing.
+## Source preflight
 
-See [evaluation-profiling.md](../../../documentation/evaluation-profiling.md) and [General_perf_onepager.md](../../../documentation/specs/proposed/General_perf_onepager.md) for profiling tools.
+Identify workload, binaries, runtime/TFM, build mode, cache state, and metric. Distinguish measured results from a source-derived hypothesis. Read current [framework configuration](../../../src/Directory.Build.props) and the affected [path instructions](../../instructions).
 
-## Allocation Awareness on Hot Paths
+Start at the measured operation and its callers. [Engine hot-path guidance](references/engine-hot-paths.md) maps relevant implementations and runtime-sensitive tradeoffs; read only the part needed for the hypothesis.
 
-The evaluation and execution engines process millions of operations per build. Unnecessary allocations cause GC pressure that compounds across large solutions.
+## Workflow
 
-### Rules
+1. Establish the baseline and bottleneck using existing measurements, the [evaluation profiler](../../../documentation/evaluation-profiling.md), or an appropriate existing profiling/benchmark workflow.
+2. Identify the actual mechanism: repeated work/I/O, allocation/capture/boxing, lookup cost, synchronization, or retained state.
+3. Preserve semantics, ordering, comparison, lifetime, and concurrency while making the smallest coherent optimization.
+4. Compare the relevant workload/metric under controlled conditions. Check affected runtime/TFM paths; JIT behavior and API availability need not match.
+5. Report the measured effect and tradeoffs, or label the proposal unmeasured. Load another workflow only for a concrete uncovered boundary.
 
-1. **Avoid LINQ in hot paths.** `Where`, `Select`, `Any`, `First` all allocate enumerator objects and delegate closures. Use `foreach` loops instead.
+## Evidence and stop condition
 
-   ```csharp
-   // BAD — allocates iterator + delegate
-   var match = items.FirstOrDefault(i => i.Name == name);
-
-   // GOOD — zero allocations
-   foreach (var item in items)
-   {
-       if (item.Name == name) { /* found */ break; }
-   }
-   ```
-
-2. **Avoid string allocations in formatting.** Use `string.Concat`, interpolation with `Span<T>`, or `StringBuilder` reuse — not `string.Format` on hot paths.
-
-3. **Prefer `Span<T>` and `stackalloc` for short-lived buffers** when parsing or slicing strings. Avoid `Substring` when you only need to compare or inspect a portion.
-
-4. **Cache computed values.** If a value is computed in a loop but doesn't change, hoist it out. If it's expensive and reused across calls, use a field or `Lazy<T>`.
-
-## String Comparison Rules
-
-MSBuild property, item, and target names are **case-insensitive**. Getting this wrong causes subtle bugs and perf issues.
-
-| Scenario | Use |
-|----------|-----|
-| Property/item/target names | `MSBuildNameIgnoreCaseComparer` |
-| General MSBuild identifiers | `StringComparison.OrdinalIgnoreCase` |
-| Dictionary keys for MSBuild names | `MSBuildNameIgnoreCaseComparer` as comparer |
-| File paths on Windows | `StringComparison.OrdinalIgnoreCase` |
-| File paths on Linux | `StringComparison.Ordinal` |
-
-**Never** use `ToLower()`/`ToUpper()` for comparisons — they allocate a new string every time.
-**Never** use `CurrentCulture` for MSBuild identifiers — build behavior must not vary by locale.
-
-## Collection Type Selection
-
-| Access Pattern | Recommended Type |
-|---------------|-----------------|
-| Small fixed set (< ~8 items) | Array or `ReadOnlySpan<T>` |
-| Build-once, read-many | `ImmutableArray<T>` (not `ImmutableList<T>`) |
-| Keyed lookup, many items | `Dictionary<TKey, TValue>` with appropriate comparer |
-| Keyed lookup, few items (< 5) | Linear scan over array (cache-friendly, avoids dict overhead) |
-| Concurrent reads, rare writes | `ImmutableDictionary` or snapshot pattern |
-| Ordered iteration needed | `List<T>` or array; avoid `HashSet<T>` if order matters |
-
-**`ImmutableList<T>` is almost never the right choice** — it has O(log n) access vs O(1) for `ImmutableArray<T>`.
-
-## Hot Path Identification
-
-These areas are performance-critical and require extra scrutiny:
-
-- **`Expander.cs`** — property/item/metadata expansion during evaluation
-- **`Evaluator.cs`** — project evaluation orchestration
-- **`ItemSpec.cs` / `LazyItemEvaluator.cs`** — item evaluation and globbing
-- **`TaskExecutionHost.cs`** — task parameter marshaling
-- **File I/O paths** — `FileMatcher.cs`, glob operations, project loading
-
-### Inlining Considerations
-
-For extremely hot methods, consider:
-- `[MethodImpl(MethodImplOptions.AggressiveInlining)]` for small methods called millions of times
-- Avoiding virtual dispatch in inner loops
-- Using `struct` enumerators to avoid heap allocation
-
-## Evaluation Performance Specifics
-
-- **Import chain depth** affects evaluation time linearly. Minimize unnecessary imports.
-- **Glob patterns** are evaluated per-project. Overly broad globs (`**/*`) are expensive.
-- **Condition evaluation** should use short-circuit logic — put cheap checks first.
-- **Property functions** (`$([System.IO.Path]::...)`) are interpreted and slower than built-in operations.
-
-## Anti-Patterns
-
-| Anti-Pattern | Why It's Bad | Fix |
-|-------------|-------------|-----|
-| `items.Count() > 0` | Enumerates entire collection | `items.Any()` or check `.Count` property |
-| `string.Format` in log messages at Low importance | Allocates even if message is filtered | Use structured logging or guard with verbosity check |
-| `new List<T>(enumerable).ToArray()` | Double allocation | `enumerable.ToArray()` directly |
-| `dict.ContainsKey(k) then dict[k]` | Double lookup | `dict.TryGetValue(k, out var v)` |
-| Regex in a loop without `RegexOptions.Compiled` | Reinterprets pattern each time | Compile or use static `Regex` field |
+Stop when evidence answers the scoped performance question or identifies the missing measurement. A faster-looking construct, fixed collection-size threshold, or one successful build is not a performance result. Do not run unrelated full suites or claim every workload improved.

--- a/.github/skills/optimizing-msbuild-performance/references/engine-hot-paths.md
+++ b/.github/skills/optimizing-msbuild-performance/references/engine-hot-paths.md
@@ -1,0 +1,92 @@
+# Engine hot-path guidance
+
+## Establish the mechanism
+
+Use [benchmarking-msbuild](../../benchmarking-msbuild/SKILL.md) for experiment design, binary identity, and controlled comparisons. The [evaluation profiler](../../../../documentation/evaluation-profiling.md) can identify expensive evaluation locations/passes. Existing traces can distinguish CPU, allocation, I/O, and waiting.
+
+[General performance goals](../../../../documentation/specs/proposed/General_perf_onepager.md) is background, not an executable profiling recipe or a measurement baseline.
+
+Useful source starting points:
+
+| Area | Implementation |
+|---|---|
+| Expansion and property functions | [Expander](../../../../src/Build/Evaluation/Expander.cs), [Expander.Function](../../../../src/Build/Evaluation/Expander.Function.cs), [WellKnownFunctions](../../../../src/Build/Evaluation/Expander/WellKnownFunctions.cs) |
+| Evaluation | [Evaluator](../../../../src/Build/Evaluation/Evaluator.cs) |
+| Lazy item operations | [LazyItemEvaluator](../../../../src/Build/Evaluation/LazyItemEvaluator.cs) and its partial implementations |
+| Glob matching/enumeration | [FileMatcher](../../../../src/Framework/Utilities/FileMatcher.cs), [MSBuildGlob](../../../../src/Build/Globbing/MSBuildGlob.cs) |
+| Task parameters | [TaskExecutionHost](../../../../src/Build/BackEnd/TaskExecutionHost/TaskExecutionHost.cs) |
+| Temporary buffers | [BufferScope](../../../../src/Framework/Utilities/BufferScope.cs) |
+
+These are potential hot paths, not instructions to profile or edit every file.
+
+## Allocations and iteration
+
+Avoid unnecessary allocation on a demonstrated hot path, but identify what actually allocates:
+
+- `Where`/`Select` commonly create iterator objects; a capturing lambda can allocate a closure. Not every LINQ call creates both, and runtime optimizations differ.
+- A `foreach` over a concrete collection can use a struct enumerator; iterating through an interface can box or allocate. For example, [OrderedItemDataCollection.Builder](../../../../src/Build/Evaluation/LazyItemEvaluator.OrderedItemDataCollection.cs) exposes enumerators through interfaces.
+- `Enumerable.Count()` does not always enumerate the whole sequence: it can use an `ICollection<T>` count. Prefer an appropriate known `Count`/`Length` property, or an existence operation when that is the actual question. See [the API contract](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.count).
+- When replacing iteration, preserve ordering, short-circuiting, side effects, and single/multiple-enumeration behavior.
+
+Do not label a generic loop "zero allocations" without its receiver type, body, and measured/runtime context.
+
+String operations need the same analysis. Slicing via spans can avoid a substring allocation when the consumer only compares/parses. Producing a final string still has a cost; `Concat`, interpolation, and `StringBuilder` are not universal allocation-free replacements for `string.Format`.
+
+Reusing a builder or pooled buffer introduces ownership, reset, retention, and concurrency obligations. Use bounded stack allocation and the existing pool/scope pattern where appropriate; consider element size and stack depth, not an unexplained universal byte limit.
+
+## Comparisons and normalization
+
+Use [MSBuildNameIgnoreCaseComparer](../../../../src/Framework/MSBuildNameIgnoreCaseComparer.cs) for the MSBuild-name contract. It has constrained-name and TFM-specific implementation details; do not substitute a culture-sensitive comparison while optimizing.
+
+For other identifiers and paths, follow the actual consumer's contract and existing helpers. [FileMatcher](../../../../src/Framework/Utilities/FileMatcher.cs) intentionally uses case-insensitive behavior in several cross-platform paths; changing every Linux path comparison to ordinal can change builds.
+
+Avoid allocating a lowercase/uppercase string merely to perform one comparison when a correct comparer can do it directly. Deliberate canonicalization for storage is a different operation; preserve its semantics, escaping, and lifetime.
+
+## Collections and snapshots
+
+| Access pattern | Candidates / considerations |
+|---|---|
+| Fixed contiguous data | Array, `ImmutableArray<T>`, or a span with valid lifetime |
+| Read-mostly keyed lookup | Dictionary with the correct comparer; consider frozen/read-only alternatives only when supported and worthwhile |
+| Frequent updates with persistent snapshots | Persistent collections or a snapshot design; account for copying and structural sharing |
+| Ordered mutable sequence | List/array or the existing ordered abstraction |
+| Small lookup | Compare linear scan and keyed lookup for actual data/access distribution; no universal cutoff |
+| Concurrent access | Choose synchronization/publication and ownership before a collection type |
+
+`ImmutableArray<T>` has cheap indexed access and contiguous storage. `ImmutableList<T>` has different indexing/update tradeoffs and can suit persistent snapshots. The engine's [OrderedItemDataCollection](../../../../src/Build/Evaluation/LazyItemEvaluator.OrderedItemDataCollection.cs) uses `ImmutableList` and builders; replacing it mechanically can increase copying or break snapshot expectations.
+
+Check all affected TFMs and package references before introducing a collection/API. Availability on the development runtime does not establish support on every library target.
+
+## Caches and concurrency
+
+Hoist work that is invariant for a loop. For cross-call caching, first establish the correct lifetime and invalidation key: project/evaluation, global properties, filesystem state, environment, toolset, or process.
+
+A field or `Lazy<T>` is not automatically correct. Consider concurrent requests, reentrancy, disposal, negative-result caching, retained memory, and whether a reused process sees changed inputs. Preserve the intended behavior when a cached result becomes stale.
+
+Avoid duplicate dictionary lookups with `TryGetValue` where it preserves semantics. Avoid unnecessary intermediate collection materialization, but do not remove a snapshot required for correctness.
+
+## Evaluation and property functions
+
+Evaluation cost depends on visited files, cache behavior, conditions, glob expansion, I/O, and repeated work, not import depth alone. An import-tree change can also alter properties/items; it is not merely a traversal optimization.
+
+Broad globs can be expensive; inspect actual enumeration roots and pruning. Follow [globbing instructions](../../../instructions/globbing.instructions.md) rather than disabling valid exclusion/pruning optimizations.
+
+Condition short-circuiting can save work when semantics permit reordering. Preserve observable errors and dependencies.
+
+Property functions are not uniformly reflection-interpreted slow paths. [Expander.Function](../../../../src/Build/Evaluation/Expander.Function.cs) dispatches known operations through [WellKnownFunctions](../../../../src/Build/Evaluation/Expander/WellKnownFunctions.cs). Identify the actual selected path before replacing an expression.
+
+## Regex and inlining
+
+Compilation trades initialization cost/code size for execution behavior. [MSBuildGlob](../../../../src/Build/Globbing/MSBuildGlob.cs) intentionally avoids compiled regex on Framework for its workload and enables it on the relevant runtime path. Preserve its caching, culture, and compatibility gates.
+
+Reusing a regex and compiling a regex are different decisions. Do not rewrite every regex loop with `RegexOptions.Compiled` without measuring the affected runtime and startup/steady-state tradeoff.
+
+For very hot small methods, investigate inlining, struct enumerators, or dispatch costs. `AggressiveInlining` is a hint, not proof of an improvement; excess code size or changed JIT behavior can offset the gain.
+
+## Logging and result evidence
+
+Formatting a message or constructing arguments before a filtered call still costs time. Inspect the existing logging context's importance/lazy/resource-based path rather than inventing a new logging framework or an assumed `IsEnabled` API.
+
+Diagnostic logging can be intentionally omitted or gated for cost/size; [binary-log event content](../../maintaining-binary-log-compatibility/references/event-content.md) describes the existing limits. Preserve the information required by the changed consumer.
+
+Report the scenario, metric, baseline/candidate identity, effect, and uncertainty. Include relevant allocation/retention or startup effects when an optimization moves cost rather than removing it. Stop at the measured question; a source-derived recommendation should remain labeled as such.


### PR DESCRIPTION
### Part 3 of 8

Correct property/import ordering, globbing and target semantics, and replace blanket optimization rules with contract-specific, measured guidance.

Depends on dotnet/msbuild#14963. Next: dotnet/msbuild#14965. Full index: dotnet/msbuild#14961.

This PR is based on `janprovaznik/context-02-contracts`. Files changed shows only this chapter. Review bottom-up; after the preceding chapter lands, retarget this PR to `main` before merging. Do not merge later chapters into temporary stack-base branches.

### Scope and evidence

Guidance is checked against the referenced source/configuration, and this chapter introduces no new broken local references. No product runtime behavior is claimed to have been re-executed by a documentation change.

Agentic-workflow changes remain separate. This stack does not include personal plugin overrides, plugin auto-activation changes, or SDK/feed version changes. The public descriptions use public repository evidence, not internal discussions or proprietary source.
