### PR TITLE
[8/8] Add optional context maintenance tooling

### DIFF
--- a/.github/skills/maintaining-agent-context/SKILL.md
+++ b/.github/skills/maintaining-agent-context/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: maintaining-agent-context
+description: "Audit or repair repository skills, instructions, agents, workflow prompts, and context routing using source and session evidence. Not product code review, cloud-runner setup, or automatic changes to installed plugins."
+---
+
+# Maintain agent context
+
+## Scope and ownership
+
+Inventory the repository's root/nested instructions, scoped instructions, skills and references, agents, and automation prompts. Distinguish checked-in source from generated workflow output, vendored files, personal settings, and installed plugin caches.
+
+Audit installed providers read-only unless the user explicitly requests changing their source or personal configuration. Use current CLI documentation and capability discovery, not remembered tool names or inferred activation.
+
+## Workflow
+
+1. Inspect the worktree and context inventory. Record current entry-point size and the files actually in scope.
+2. Sample relevant session history when available: distinguish user corrections from injected skills, notifications, and delegated prompts. Keep private history out of committed reports.
+3. Check substantive claims against current source/configuration or authoritative documentation. Identify incorrect rules, contradictory routing, unclear authority, duplication, missing links, and compulsory work unrelated to the task.
+4. Repair the owning layer. Keep invariant policy small and move corrected domain procedures into focused references; do not discard useful knowledge just to meet a length target.
+5. Use the [framework guide](../../../documentation/agent-context.md) and [task briefs](../../../documentation/agent-context/task-briefs.md) to exercise progressive retrieval and realistic failure cases.
+6. Run the offline [context validator](../../../scripts/Validate-AgentContext.ps1). Report semantic limitations and provider/upstream changes that remain outside scope.
+
+For a large audit, delegate disjoint file/provider groups, not multiple labeled passes over the same files. Agree on the common architecture before parallel edits.
+
+## Stop condition
+
+Every in-scope context surface has a disposition, confirmed defects have an owning repair or explicit blocker, useful references remain reachable, and representative tasks route without unnecessary work or authority escalation. Static checks cannot guarantee an agent will never misunderstand.

--- a/.github/workflows/validate-agent-context.yml
+++ b/.github/workflows/validate-agent-context.yml
@@ -1,0 +1,54 @@
+name: Validate Agent Context
+
+on:
+  pull_request:
+    paths:
+      - 'AGENTS.md'
+      - '**/AGENTS.md'
+      - '.github/copilot-instructions.md'
+      - '.github/instructions/**'
+      - '.github/skills/**'
+      - '.github/agents/**'
+      - 'plugins/**'
+      - '.github/workflows/validate-agent-context.yml'
+      - 'documentation/agent-context*'
+      - 'documentation/agent-context/**'
+      - 'scripts/Validate-AgentContext.ps1'
+  push:
+    branches: [main]
+    paths:
+      - 'AGENTS.md'
+      - '**/AGENTS.md'
+      - '.github/copilot-instructions.md'
+      - '.github/instructions/**'
+      - '.github/skills/**'
+      - '.github/agents/**'
+      - 'plugins/**'
+      - '.github/workflows/validate-agent-context.yml'
+      - 'documentation/agent-context*'
+      - 'documentation/agent-context/**'
+      - 'scripts/Validate-AgentContext.ps1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: agent-context-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Validate agent context
+        shell: pwsh
+        run: ./scripts/Validate-AgentContext.ps1
+      - name: Exercise offline health collector contracts
+        shell: pwsh
+        run: ./.github/skills/pipelines-health-check/tests/Collectors.Tests.ps1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ This is a public open-source repository. PR descriptions, issues, review comment
 
 - Start with this file and the instructions matching the affected paths in [.github/instructions](.github/instructions). Read nested `AGENTS.md` files before changing their subtree.
 - Select the skill whose **description matches the task**, not every skill mentioning the same technology. Read its entry point, then only the reference needed for the current question. Do not recursively preload links.
+- Use the routing and authoring guide in [Agent context](documentation/agent-context.md) when the right workflow is unclear or when changing instructions, skills, agents, or prompts.
 - Start with a focused source lookup; expand to callers, consumers, history, or external docs when evidence requires it.
 - Discover available tools before using them. Plugin availability is session-specific; do not assume a named plugin, agent, or MCP operation is installed. Report missing capabilities and use a supported read-only alternative where possible.
 

--- a/documentation/agent-context.md
+++ b/documentation/agent-context.md
@@ -1,0 +1,102 @@
+# Agent context: routing, evidence, and ownership
+
+This is the maintenance guide for the repository's agent context, not a second always-loaded policy file. Start with [AGENTS.md](../AGENTS.md); use this page to choose a workflow or change the context framework.
+
+## Layers and responsibility
+
+| Layer | Owns | Does not own |
+|---|---|---|
+| `AGENTS.md` | Small, durable repository invariants; authority and evidence boundaries | Tutorial content, machine state, copied SDK versions |
+| `.github/copilot-instructions.md` | Pointer to the canonical root guidance | A competing or duplicated policy |
+| `.github/instructions/*.instructions.md` | Local invariants selected by `applyTo`, links to implementation and relevant skills | General C# tutorials or full build requirements for every edit |
+| `.github/skills/<name>/SKILL.md` and plugin-owned skills | Task trigger, exclusions, preflight, short workflow, stopping criteria | Every example and every possible subtask |
+| Skill `references/` and scripts | Detailed, source-backed procedures needed for a particular step | Automatic instructions to run every linked procedure |
+| `.github/agents` | A specialist's role, boundaries, and result contract | Mandatory fan-out, fixed models, implied GitHub write authority |
+| Workflow prompts | The authorized automation task and its supported tools/outputs | An interactive workflow copied into a different execution environment |
+| Personal/plugin context | Portable personal preferences and provider capabilities | Repository-specific policy copied into an installed cache |
+
+Checked-in plugin sources under `plugins` are maintained here, but their installed copies have a separate lifecycle. Audit their manifests, skills, agents, and references as well as `.github`; directory location alone does not prove they are active.
+
+Context is additive only when relevant. A more verbose document is not more authoritative, and a newer session summary is not automatically more correct than current source. Higher-priority platform and user instructions still apply; these layers do not redefine the host's instruction precedence.
+
+## Retrieval loop
+
+1. **Frame:** outcome, read/write authority, repository/ref, environment, and required artifact.
+2. **Route:** choose one primary skill from its description; add another only for a distinct boundary encountered during the task.
+3. **Retrieve:** read the entry point and the single relevant reference or implementation. A reference link is a navigation option, not an instruction to load an entire directory.
+4. **Resolve:** check claims against source/configuration at the requested revision. Distinguish observed behavior from a proposal or an old design document.
+5. **Act:** do the scoped work. Delegate only independent, substantial scopes with explicit ownership, relevant evidence, and a result contract.
+6. **Evaluate:** inspect the requested observable outcome. Continue for a concrete gap; otherwise stop and state any limitation.
+
+For an ambiguous workflow, pick a reasonable read-only starting point. Ask for clarification when the wrong choice would cause material rework or an unauthorized external action, not for routine formatting choices.
+
+## Route by outcome, not keywords
+
+| Requested outcome | Primary context | Load later only if needed |
+|---|---|---|
+| Review an MSBuild diff | [reviewing-msbuild-code](../.github/skills/reviewing-msbuild-code/SKILL.md) | A domain skill for the changed boundary; CI investigation for a failing check |
+| Compare build modes or SDKs | [benchmarking-msbuild](../.github/skills/benchmarking-msbuild/SKILL.md) | Performance diagnosis after the experiment identifies a bottleneck |
+| Optimize engine implementation | [optimizing-msbuild-performance](../.github/skills/optimizing-msbuild-performance/SKILL.md) | Benchmark protocol, evaluation, allocation, or interop details for the hypothesis |
+| Run local tests | [running-unit-tests](../.github/skills/running-unit-tests/SKILL.md) | Bootstrap reproduction when the assertion must exercise the product executable |
+| Prove an installed/local behavior change | [use-bootstrap-msbuild](../.github/skills/use-bootstrap-msbuild/SKILL.md) | The domain implementation and the exact regression scenario |
+| Assess compatibility or diagnostics | [assessing-breaking-changes](../.github/skills/assessing-breaking-changes/SKILL.md) | ChangeWave mechanics or diagnostic authoring after the policy decision |
+| Check broad pipeline/insertion health | [pipelines-health-check](../.github/skills/pipelines-health-check/SKILL.md) | Installed CI/Helix/codeflow specialist for the identified failing leg or flow |
+| Triage bot updates | [merge-dependency-updates](../.github/skills/merge-dependency-updates/SKILL.md) | Codeflow tracing or merge actions only for the selected PRs |
+| Manage issues or release state | [project-management](../.github/skills/project-management/SKILL.md) or [release](../.github/skills/release/SKILL.md) | Only the requested phase and its current service data |
+| Change docs or prepare a handoff | [Task brief examples](agent-context/task-briefs.md) | Authoring-source discovery and the relevant API/implementation |
+| Audit or improve agent context | [maintaining-agent-context](../.github/skills/maintaining-agent-context/SKILL.md) | Current provider inventory, source-backed corrections, and relevant session evidence |
+
+Optional plugins are accelerators, not prerequisites for understanding the repository. In Copilot CLI, `/env` describes the running session, while `copilot plugins list` inventories discovered configuration for a new invocation. Recheck capability availability after configuration changes; do not assume a long-lived session has reloaded.
+
+## Provider boundaries and overrides
+
+Do not assume a conflicting repository instruction automatically overrides a provider's workflow. Repair the owning rule, narrow its routing, or use a deliberate supported adapter.
+
+Copilot CLI's [plugin loading rules](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference#loading-order-and-precedence) resolve same-name skills before plugin contributions, with personal/project sources preceding plugins. Avoid accidental shadowing. A workaround for one user's installed provider is not automatically appropriate for shared repository guidance.
+
+Use `copilot plugins list` to inventory contributing sources and `copilot skill list --json` to inspect resolved skill paths. The inventory can show both a plugin and repository copy; that alone does not identify which one is selected. Verify the resolved path after a change, especially if a personal skill has the same name.
+
+If a deliberate adapter is needed, document its scope and removal condition. Do not let a permanent local copy hide future provider improvements.
+
+Instruction edits need a new/resumed session; `/skills reload` refreshes skill discovery. Custom-agent profile changes require restarting the CLI according to its [agent documentation](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/create-custom-agents-for-cli). Ordinary installed plugin copies require a supported update/reinstall; a local path-sourced plugin has different refresh behavior. Consult the current CLI help instead of assuming one reload mechanism refreshes every layer.
+
+## Writing or repairing context
+
+Use this structure for skill entry points:
+
+```markdown
+---
+name: directory-name
+description: Specific task and boundary; exclude the most likely false trigger.
+---
+# Task
+## Use when / Do not use when
+## Before acting
+## Workflow
+## Evidence and stop condition
+## References
+```
+
+The headings can vary when a shorter structure communicates the same contract.
+
+- Descriptions are routing metadata, not a list of every adjacent technology. Avoid triggers such as "any .NET work" for a specialized procedure.
+- Give each substantive rule one owner. Link to that owner instead of copying its checklist into the root, agent, skill, and workflow.
+- Keep useful detail. Move a long procedure into focused references, correct its claims, and repair its links; shortening an entry point is not permission to discard the procedure.
+- Put repository links in Markdown so they can be checked. Prefer links to an implementation/configuration plus the symbol to inspect over a prose copy of a volatile value.
+- Label commands by execution environment and side effects. Shell syntax, available tools, runner modes, generated paths, and resource IDs must be discovered or verified before use.
+- Include a read-only path and a meaningful stopping condition. "Everything is complete," a fixed number of rounds, or agreement among models is not an evidence standard.
+- Do not turn a task-specific correction into a universal rule. Feedback about concise public docs does not imply deleting detailed migration guidance.
+
+## Maintenance and regression checks
+
+Run `pwsh -NoProfile -File scripts\Validate-AgentContext.ps1` from the repo root after context edits. It covers `.github`, checked-in `plugins`, root guidance, and these framework docs: required metadata, local Markdown file targets outside code fences, and the tracked pointer file type. It does not build MSBuild, contact services, or validate remote URLs, heading anchors, or the full YAML grammar.
+
+Suggested entry-point targets are 100 lines / 6 KiB for root guidance and skill/interactive-agent entries, and 80 lines / 4 KiB for path instructions. References carry the detail. These are authoring aids, not mandatory contribution limits, a claim about token usage, or an excuse to remove necessary knowledge. Add `-CheckBudgets` to the validator to assess these targets explicitly; the default CI invocation does not enforce them.
+
+The optional size assessment uses a separate 20-line / 1 KiB target for the Copilot pointer, to discourage a second copy of the root policy.
+
+Keep that pointer a regular tracked file. With `core.symlinks=false`, Windows can show a tracked symlink as a tiny ordinary file; replacing its target text with prose without changing the Git file type creates a broken symlink on other systems.
+
+Then walk the [task briefs](agent-context/task-briefs.md) against the changed routing. Check that a small task stays small, a proof task reaches executable evidence, and an external mutation requires authority. Static checks cannot prove semantic correctness; implementation-backed review and real workflow feedback remain necessary.
+
+When a failure recurs, record the cause, owning layer, correcting evidence, and a regression scenario. Change the owner, not every consumer. Keep personal history, credentials, machine-specific observations, and temporary operational state out of committed context.

--- a/documentation/agent-context/task-briefs.md
+++ b/documentation/agent-context/task-briefs.md
@@ -1,0 +1,53 @@
+# Task briefs and context regression scenarios
+
+These are copy/paste examples and maintenance scenarios, not automatically discovered CLI prompt commands. Fill in the placeholders; do not paste private logs or credentials into public artifacts.
+
+## Review with proof, not repeated reassurance
+
+> Review `<repo/PR or local diff>` against `<base>` at `<head>`, read-only. First map the intended behavior and supported configurations. For each potential blocker, show the source trace or a reproducible failing scenario; distinguish regression evidence from missing coverage. Produce one concise table of confirmed defects and a short list of unverified boundaries. Do not post, fix, or launch one agent per review dimension.
+
+Expected route: review entry point -> relevant review lens -> changed implementation and callers -> targeted reproduction if needed. A no-findings result must not become "all possible cases proved correct."
+
+## Compare the intended build experiment
+
+> Compare `<SDK/build A>` and `<SDK/build B>` on `<workload>`, with `<default/-m/-mt>` explicit. Measure `<clean/source-edit incremental/no-op>` and `<cold/warm>` as separate cases. Identify executable paths and prove the expected server/task-host behavior before timing. Keep commands and workload identical except for the chosen variable, use paired interleaved rounds, and return measurements plus uncertainty and diagnostic artifacts.
+
+Expected route: benchmark entry point -> experiment preflight -> measurements -> diagnostics only for an observed difference. Clean outputs, a warm MSBuild server, a warm compiler server, and warm filesystem caches are different conditions; none should be inferred from another.
+
+## Fix a regression in the actual product
+
+> Reproduce `<issue>` using `<host/runtime/mode>`. Pin the failing baseline and candidate fix. Use the same minimal project and assertion on both, and show which binaries were executed. Make the local fix only after the failure is understood; do not change SDK/feed configuration or publish anything.
+
+Expected route: bootstrap reproduction -> source identity -> baseline/fix comparison. Passing tests against an installed unrelated MSBuild is not evidence about the edited source.
+
+For a TaskHost symptom, consult the [host map](../../.github/skills/use-bootstrap-msbuild/references/host-map.md) before selecting a project. Modern MSBuild `/nodemode:2` must not be confused with the separate legacy `MSBuildTaskHost.exe`.
+
+## Update documentation without rewriting its contract
+
+> Update the authoring source for `<topic>`, for `<public API users / migration authors / management>`. Preserve existing useful examples and detailed internal guidance. Add only `<specific semantic clarification>`. First identify which repositories/files are authoritative and which are generated mirrors. Return the smallest accurate change; no external PR or comment until requested.
+
+Expected route: source discovery -> implementation contract -> scoped doc edit. A review consideration is not automatically a warning, an implementation detail is not automatically a public guarantee, and shorter public prose must not erase agent reference material.
+
+## Handle a changed PR base
+
+> The target base is now `<branch>`. Before continuing, refresh base/head identity, inspect the actual PR diff for unrelated commits, and identify which earlier conclusions or artifacts are invalidated. Do not rewrite history unless I request it.
+
+Expected route: identity preflight before more code work. Knowledge of the old checkout must not substitute for source at the new base.
+
+## Triage CI without treating a retry as a fix
+
+> Inspect `<PR/build/leg>`, read-only. Distinguish product failure, test flake, infrastructure failure, and unavailable evidence. Retrieve only the failing leg's relevant logs initially. State what a retry could establish and what it cannot; do not retry, quarantine, merge, or post.
+
+Expected route: high-level status -> one failing boundary -> relevant CI/Helix/binlog specialist if available. Missing access is unknown status, not green. A successful retry does not prove a deterministic defect was fixed.
+
+## Test a small change without changing test isolation
+
+> Run the existing tests covering `<behavior>` in `<project>`. Determine the SDK, test runner, and applicable TFM from this checkout, use a targeted filter, and confirm it actually selects tests. Preserve parallelism, traits, and quarantine settings. Escalate only for an uncovered boundary or a failure.
+
+Expected route: local test entry point -> current runner syntax -> scoped run. It must not activate a large test-generation pipeline, rewrite runner settings, or require a full product build for Markdown edits.
+
+## Distinguish task intent from capability keywords
+
+> Audit these skills and instructions for stale context and unclear routing.
+
+Expected route: context maintenance guide and the files being audited. Mentioning agents is not a request to configure cloud-agent runners; mentioning tests is not a request to generate tests; a PR URL is not permission to publish a review.

--- a/plugins/mt-migration/README.md
+++ b/plugins/mt-migration/README.md
@@ -36,6 +36,10 @@ Distinguish contributing-source inventory from effective skill resolution and fr
 
 Aim for small skill and interactive-agent entry points; 100 lines and 6 KiB are useful authoring targets, not mandatory contribution limits. Move corrected technical material into focused references rather than deleting it to reach a size target.
 
-Use the authoring repository's available documentation and context checks.
+In the MSBuild repository, run the offline context validator from the repository root:
+
+```powershell
+pwsh -NoProfile -File scripts\Validate-AgentContext.ps1
+```
 
 Documentation changes need local-link, metadata, scope, and content checks, not a product build. Static validation does not prove every runtime scenario. Add source-backed examples for newly understood hazards; do not turn unverified anecdotes, analyzer-version assumptions, or task-specific exceptions into universal rules.

--- a/scripts/Validate-AgentContext.ps1
+++ b/scripts/Validate-AgentContext.ps1
@@ -1,0 +1,261 @@
+#requires -Version 7.0
+
+<#
+.SYNOPSIS
+Checks repository agent-context entry points and local Markdown file links.
+.DESCRIPTION
+Read-only and offline. Checks required frontmatter fields, skill names, and local
+file targets outside code fences. Optional size targets are checked only when
+CheckBudgets is supplied. Does not evaluate
+instruction semantics, remote URLs, or Markdown anchor compatibility.
+#>
+[CmdletBinding()]
+param(
+    [string]$RepositoryRoot = (Split-Path $PSScriptRoot -Parent),
+    [switch]$CheckBudgets
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$root = (Resolve-Path -LiteralPath $RepositoryRoot).Path
+$errors = [System.Collections.Generic.List[string]]::new()
+$entries = [System.Collections.Generic.List[object]]::new()
+$markdownFiles = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+
+function Add-Entry
+{
+    param(
+        [string]$Path,
+        [string]$Kind,
+        [int]$MaxLines = 100,
+        [int]$MaxBytes = 6144
+    )
+
+    $entries.Add([pscustomobject]@{ Path = $Path; Kind = $Kind; MaxLines = $MaxLines; MaxBytes = $MaxBytes })
+}
+
+Add-Entry -Path (Join-Path $root 'AGENTS.md') -Kind 'root'
+Add-Entry -Path (Join-Path $root '.github\copilot-instructions.md') -Kind 'pointer' -MaxLines 20 -MaxBytes 1024
+
+if (Test-Path -LiteralPath (Join-Path $root '.git'))
+{
+    $pointerPath = Join-Path '.github' 'copilot-instructions.md'
+    $trackedPointer = & git -C $root ls-files --stage -- $pointerPath
+    if ($LASTEXITCODE -ne 0)
+    {
+        throw 'Unable to inspect the tracked Copilot instruction file type.'
+    }
+    if ($trackedPointer -match '^120000 ')
+    {
+        $errors.Add('The Copilot pointer is still tracked as a symlink. Record its regular-file type; editing an emulated Windows symlink would otherwise commit its prose as a broken link target.')
+    }
+}
+
+$skillsPath = Join-Path $root '.github\skills'
+foreach ($directory in Get-ChildItem -LiteralPath $skillsPath -Directory)
+{
+    $entry = Join-Path $directory.FullName 'SKILL.md'
+    if (!(Test-Path -LiteralPath $entry -PathType Leaf))
+    {
+        $errors.Add("Missing skill entry point: $entry")
+        continue
+    }
+
+    Add-Entry -Path $entry -Kind 'skill'
+}
+
+foreach ($file in Get-ChildItem -LiteralPath (Join-Path $root '.github\agents') -Filter '*.agent.md' -File)
+{
+    Add-Entry -Path $file.FullName -Kind 'agent'
+}
+
+foreach ($file in Get-ChildItem -LiteralPath (Join-Path $root '.github\instructions') -Filter '*.instructions.md' -File)
+{
+    Add-Entry -Path $file.FullName -Kind 'instruction' -MaxLines 80 -MaxBytes 4096
+}
+
+$pluginsPath = Join-Path $root 'plugins'
+if (Test-Path -LiteralPath $pluginsPath -PathType Container)
+{
+    foreach ($file in Get-ChildItem -LiteralPath $pluginsPath -Filter 'SKILL.md' -File -Recurse)
+    {
+        Add-Entry -Path $file.FullName -Kind 'skill'
+    }
+    foreach ($file in Get-ChildItem -LiteralPath $pluginsPath -Filter '*.agent.md' -File -Recurse)
+    {
+        Add-Entry -Path $file.FullName -Kind 'agent'
+    }
+}
+
+$skillNames = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::OrdinalIgnoreCase)
+foreach ($entry in $entries)
+{
+    $relative = [System.IO.Path]::GetRelativePath($root, $entry.Path)
+    if (!(Test-Path -LiteralPath $entry.Path -PathType Leaf))
+    {
+        $errors.Add("Missing entry point: $relative")
+        continue
+    }
+
+    $lines = [System.IO.File]::ReadAllLines($entry.Path)
+    $text = [System.IO.File]::ReadAllText($entry.Path)
+    $bytes = (Get-Item -LiteralPath $entry.Path).Length
+    if ($CheckBudgets -and ($lines.Count -gt $entry.MaxLines -or $bytes -gt $entry.MaxBytes))
+    {
+        $errors.Add("${relative}: $($lines.Count) lines / $bytes bytes exceeds $($entry.MaxLines) lines / $($entry.MaxBytes) bytes; move detail to focused references.")
+    }
+
+    if ($entry.Kind -in @('root', 'pointer'))
+    {
+        continue
+    }
+
+    $frontmatter = [regex]::Match($text, '\A---\r?\n(?<body>[\s\S]*?)\r?\n---(?:\r?\n|\z)')
+    if (!$frontmatter.Success)
+    {
+        $errors.Add("${relative}: missing YAML frontmatter.")
+        continue
+    }
+
+    $header = $frontmatter.Groups['body'].Value
+    $requiredFields = if ($entry.Kind -eq 'instruction') { @('applyTo') } else { @('name', 'description') }
+    foreach ($field in $requiredFields)
+    {
+        $fieldMatch = [regex]::Match($header, "(?m)^${field}:[ \t]*(?<value>[^\r\n]*)")
+        $value = $fieldMatch.Groups['value'].Value.Trim().Trim('"', "'")
+        $emptyBlock = $value -match '^[>|][-+]?$' -and
+            ![regex]::IsMatch($header, "(?m)^${field}:[ \t]*[>|][-+]?[ \t]*\r?\n[ \t]+\S")
+        if (!$fieldMatch.Success -or [string]::IsNullOrWhiteSpace($value) -or $value.StartsWith('#') -or $emptyBlock)
+        {
+            $errors.Add("${relative}: missing or empty '$field' metadata.")
+        }
+    }
+
+    if ($entry.Kind -eq 'skill')
+    {
+        $nameMatch = [regex]::Match($header, '(?m)^name:[ \t]*(?<name>[^\r\n]+)')
+        if ($nameMatch.Success)
+        {
+            $name = $nameMatch.Groups['name'].Value.Trim().Trim('"', "'")
+            $directoryName = Split-Path (Split-Path $entry.Path -Parent) -Leaf
+            if ($name -cne $directoryName -or $name -cnotmatch '^[a-z0-9]+(?:-[a-z0-9]+)*$')
+            {
+                $errors.Add("${relative}: skill name '$name' must be lowercase kebab-case and match '$directoryName'.")
+            }
+
+            if (!$skillNames.Add($name))
+            {
+                $errors.Add("${relative}: duplicate skill name '$name'.")
+            }
+        }
+    }
+}
+
+foreach ($file in Get-ChildItem -LiteralPath (Join-Path $root '.github') -Filter '*.md' -File -Recurse)
+{
+    [void]$markdownFiles.Add($file.FullName)
+}
+
+if (Test-Path -LiteralPath $pluginsPath -PathType Container)
+{
+    foreach ($file in Get-ChildItem -LiteralPath $pluginsPath -Filter '*.md' -File -Recurse)
+    {
+        [void]$markdownFiles.Add($file.FullName)
+    }
+}
+
+foreach ($relative in @('AGENTS.md', 'eng\common\AGENTS.md', 'src\MSBuildTaskHost\AGENTS.md', 'documentation\agent-context.md'))
+{
+    $path = Join-Path $root $relative
+    if (Test-Path -LiteralPath $path -PathType Leaf)
+    {
+        [void]$markdownFiles.Add($path)
+    }
+}
+
+$contextDocs = Join-Path $root 'documentation\agent-context'
+if (Test-Path -LiteralPath $contextDocs -PathType Container)
+{
+    foreach ($file in Get-ChildItem -LiteralPath $contextDocs -Filter '*.md' -File -Recurse)
+    {
+        [void]$markdownFiles.Add($file.FullName)
+    }
+}
+
+foreach ($path in $markdownFiles)
+{
+    $relative = [System.IO.Path]::GetRelativePath($root, $path)
+    $directory = Split-Path $path -Parent
+    $fenceCharacter = ''
+    $fenceLength = 0
+    $lineNumber = 0
+    foreach ($line in [System.IO.File]::ReadLines($path))
+    {
+        $lineNumber++
+        $fence = [regex]::Match($line, '^[ \t]*(?<fence>`{3,}|~{3,})')
+        if ($fence.Success)
+        {
+            $marker = $fence.Groups['fence'].Value
+            if ($fenceLength -eq 0)
+            {
+                $fenceCharacter = $marker.Substring(0, 1)
+                $fenceLength = $marker.Length
+            }
+            elseif ($marker.StartsWith($fenceCharacter) -and $marker.Length -ge $fenceLength)
+            {
+                $fenceLength = 0
+            }
+
+            continue
+        }
+
+        if ($fenceLength -ne 0)
+        {
+            continue
+        }
+
+        foreach ($link in [regex]::Matches($line, '!?\[[^\]\r\n]*\]\((?<target><[^>\r\n]+>|[^\s)]+)(?:[ \t]+["''][^)]*["''])?\)'))
+        {
+            $target = $link.Groups['target'].Value.Trim('<', '>')
+            if ($target -match '^(?:[a-z][a-z0-9+.-]*:|//|#)' -or $target -match '\{\{|\$\(')
+            {
+                continue
+            }
+
+            $fileTarget = [Uri]::UnescapeDataString(($target -split '[#?]', 2)[0])
+            if ([string]::IsNullOrEmpty($fileTarget))
+            {
+                continue
+            }
+
+            $fileTarget = $fileTarget.Replace('\', [System.IO.Path]::DirectorySeparatorChar).Replace('/', [System.IO.Path]::DirectorySeparatorChar)
+            $resolvedTarget = if ($fileTarget.StartsWith([System.IO.Path]::DirectorySeparatorChar))
+            {
+                Join-Path $root $fileTarget.TrimStart([System.IO.Path]::DirectorySeparatorChar)
+            }
+            else
+            {
+                Join-Path $directory $fileTarget
+            }
+
+            if (!(Test-Path -LiteralPath $resolvedTarget))
+            {
+                $errors.Add("${relative}:${lineNumber}: missing local link target '$target'.")
+            }
+        }
+    }
+}
+
+if ($errors.Count -gt 0)
+{
+    foreach ($message in $errors)
+    {
+        [Console]::Error.WriteLine($message)
+    }
+
+    [Console]::Error.WriteLine("Agent context validation failed: $($errors.Count) issue(s).")
+    exit 1
+}
+
+Write-Host "Agent context validation passed: $($entries.Count) entry points and $($markdownFiles.Count) Markdown files."


### PR DESCRIPTION
### Part 8 of 8

Introduce the shared routing guide, context-maintenance skill, task briefs and structural checker only after the guidance chapters. Size targets remain opt-in, not default contribution limits.

Depends on dotnet/msbuild#14968. Last chapter. Full index: dotnet/msbuild#14961.

This PR is based on `janprovaznik/context-07-health`. Files changed shows only this chapter. Review bottom-up; after the preceding chapter lands, retarget this PR to `main` before merging. Do not merge later chapters into temporary stack-base branches.

### Scope and evidence

The complete tree matches the prepared final content exactly. Structural validation and the offline collector suite pass. The checker does not enforce optional size targets by default.

Agentic-workflow changes remain separate. This stack does not include personal plugin overrides, plugin auto-activation changes, or SDK/feed version changes. The public descriptions use public repository evidence, not internal discussions or proprietary source.

### What the context numbers do and do not show

Git-blob bytes against the stack baseline:

| Surface | Before | Complete stack |
|---|---:|---:|
| AGENTS.md, with orientation restored | 10,554 | 8,259 |
| Expert-reviewer entry | 32,677 | 4,658 |
| Skill entry points | 198,073 (18) | 48,348 (20) |
| Context Markdown including references | 287,121 | 339,889 |

The full corpus grows 18.4%. The measurable change is 75.6% less text in skill entry bodies and conditional retrieval of detailed references, not deletion of all that material. If every reference is loaded, the loading advantage disappears. No controlled token-cost, latency, or task-quality improvement has been established.