### PR TITLE
Recognize AbsolutePath.Value canonicalization in task analyzers

### DIFF
--- a/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
@@ -1,8 +1,12 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
 using Shouldly;
 using Xunit;
 using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
@@ -578,6 +582,124 @@ public class MultiThreadableTaskAnalyzerTests
             """);
 
         diags.ShouldNotContain(d => d.Id == DiagnosticIds.FilePathRequiresAbsolute);
+    }
+
+    [Theory]
+    [InlineData("all")]
+    [InlineData("multithreadable_only")]
+    public async Task GetFullPathOfAbsolutePathValue_NoDiagnostics(string scope)
+    {
+        const string source = """
+            using System.IO;
+            using Microsoft.Build.Framework;
+            using IOPath = System.IO.Path;
+
+            [MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = new TaskEnvironment();
+                public override bool Execute()
+                {
+                    AbsolutePath path = TaskEnvironment.GetAbsolutePath("relative.txt");
+                    AbsolutePath? nullablePath = path;
+                    string canonical = Path.GetFullPath(path.Value);
+                    File.Exists(canonical);
+                    File.Exists(IOPath.GetFullPath(path: TaskEnvironment.GetAbsolutePath("other.txt").Value));
+                    File.Exists(Path.GetFullPath(nullablePath.Value.Value));
+                    File.Exists(Path.GetFullPath((string)path.Value));
+                    return true;
+                }
+            }
+            """;
+
+        CreateCompilation(source).GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ShouldBeEmpty();
+        var diags = await GetDiagnosticsWithScopeAsync(source, scope);
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("\"relative.txt\"")]
+    [InlineData("path.OriginalValue")]
+    [InlineData("other.Value")]
+    [InlineData("text")]
+    [InlineData("path.Value.Substring(1)")]
+    [InlineData("Path.Combine(path.Value, \"relative.txt\")")]
+    [InlineData("path.Value, path.Value")]
+    public async Task GetFullPathWithoutAbsolutePathValue_StillProducesDiagnostic(string arguments)
+    {
+        var source = $$"""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            public class OtherPath { public string Value => "relative.txt"; }
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    AbsolutePath path = new TaskEnvironment().GetAbsolutePath("relative.txt");
+                    var other = new OtherPath();
+                    string text = path.Value;
+                    text = "relative.txt";
+                    _ = Path.GetFullPath({{arguments}});
+                    return true;
+                }
+            }
+            """;
+
+        CreateCompilation(source).GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ShouldBeEmpty();
+        var diags = await GetDiagnosticsAsync(source);
+
+        diags.ShouldHaveSingleItem().Id.ShouldBe(DiagnosticIds.TaskEnvironmentRequired);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task GetFullPathLookalike_DoesNotProveAnAbsoluteResult(bool useMetadataReference)
+    {
+        const string lookalikeSource = """
+            namespace System.IO
+            {
+                public static class Path
+                {
+                    public static string GetFullPath(string path) => "relative.txt";
+                }
+            }
+            """;
+        const string source = """
+            using System.IO;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    AbsolutePath path = new TaskEnvironment().GetAbsolutePath("relative.txt");
+                    File.Exists(Path.GetFullPath(path.Value));
+                    return true;
+                }
+            }
+            """;
+
+        var compilation = CreateCompilation(useMetadataReference
+            ? "extern alias lookalike; using Path = lookalike::System.IO.Path;\n" + source
+            : source + lookalikeSource);
+        if (useMetadataReference)
+        {
+            var lookalikeCompilation = CSharpCompilation.Create(
+                "PathLookalike",
+                [CSharpSyntaxTree.ParseText(lookalikeSource)],
+                GetCoreReferences(),
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+            using var image = new MemoryStream();
+            lookalikeCompilation.Emit(image).Success.ShouldBeTrue();
+            compilation = compilation.AddReferences(MetadataReference.CreateFromImage(
+                image.ToArray(), MetadataReferenceProperties.Assembly.WithAliases(["lookalike"])));
+        }
+
+        compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ShouldBeEmpty();
+        var diags = await compilation.WithAnalyzers([new MultiThreadableTaskAnalyzer()]).GetAnalyzerDiagnosticsAsync();
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.FilePathRequiresAbsolute);
     }
 
     [Fact]

--- a/src/TaskAnalyzer.Tests/TransitiveCallChainAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/TransitiveCallChainAnalyzerTests.cs
@@ -129,6 +129,92 @@ public class TransitiveCallChainAnalyzerTests
         transitive.ShouldBeEmpty();
     }
 
+    [Theory]
+    [InlineData("all", "GetCanonicalForm")]
+    [InlineData("multithreadable_only", "GetCanonicalForm")]
+    [InlineData("all", "Normalize")]
+    [InlineData("multithreadable_only", "Normalize")]
+    public async Task AbsolutePathCanonicalizationPolyfill_NoDiagnostics(string scope, string methodName)
+    {
+        var source = $$"""
+            using System.IO;
+            using Microsoft.Build.Framework;
+
+            public static class AbsolutePathExtensions
+            {
+                public static AbsolutePath {{methodName}}(this AbsolutePath path) =>
+                    new AbsolutePath(Path.GetFullPath(path.Value));
+
+                public static bool Exists(AbsolutePath path) =>
+                    File.Exists(Path.GetFullPath(path.Value));
+            }
+
+            [MSBuildMultiThreadableTask]
+            public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; } = new TaskEnvironment();
+                public override bool Execute()
+                {
+                    AbsolutePath path = TaskEnvironment.GetAbsolutePath("relative.txt");
+                    File.Exists(path.{{methodName}}());
+                    File.Exists(AbsolutePathExtensions.{{methodName}}(path));
+                    AbsolutePathExtensions.Exists(path);
+                    return true;
+                }
+            }
+            """;
+
+        var compilation = CreateCompilation(source);
+        compilation.GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ShouldBeEmpty();
+        var options = new AnalyzerOptions([], new TestAnalyzerConfigOptionsProvider(new()
+        {
+            [SharedAnalyzerHelpers.ScopeOptionKey] = scope
+        }));
+        var diags = await compilation.WithAnalyzers(
+            [new MultiThreadableTaskAnalyzer(), new TransitiveCallChainAnalyzer()], options).GetAnalyzerDiagnosticsAsync();
+
+        diags.ShouldBeEmpty();
+    }
+
+    [Theory]
+    [InlineData("path.OriginalValue")]
+    [InlineData("relative")]
+    [InlineData("other.Value")]
+    public async Task CanonicalizationPolyfillWithUnsafeInput_StillProducesDiagnostic(string argument)
+    {
+        var source = $$"""
+            using System.IO;
+            using Microsoft.Build.Framework;
+            public class OtherPath { public string Value => "relative.txt"; }
+            public static class AbsolutePathExtensions
+            {
+                public static AbsolutePath GetCanonicalForm(this AbsolutePath path)
+                {
+                    var other = new OtherPath();
+                    string relative = path.Value;
+                    relative = "relative.txt";
+                    return new AbsolutePath(Path.GetFullPath({{argument}}));
+                }
+            }
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public override bool Execute()
+                {
+                    AbsolutePath path = new TaskEnvironment().GetAbsolutePath("relative.txt");
+                    File.Exists(path.GetCanonicalForm());
+                    return true;
+                }
+            }
+            """;
+
+        CreateCompilation(source).GetDiagnostics().Where(d => d.Severity == DiagnosticSeverity.Error).ShouldBeEmpty();
+        var diags = await GetAllDiagnosticsAsync(source);
+
+        var diagnostic = diags.ShouldHaveSingleItem();
+        diagnostic.Id.ShouldBe(DiagnosticIds.TransitiveUnsafeCall);
+        diagnostic.GetMessage().ShouldContain("Path.GetFullPath");
+    }
+
     [Fact]
     public async Task RecursiveCallChain_DoesNotStackOverflow()
     {

--- a/src/TaskAnalyzer/MultiThreadableTaskAnalyzer.cs
+++ b/src/TaskAnalyzer/MultiThreadableTaskAnalyzer.cs
@@ -165,6 +165,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             // Check banned API lookup (handles MSBuildTask0001, 0002, 0004)
             if (bannedApiLookup.TryGetValue(referencedSymbol, out var entry))
             {
+                if (IsAbsolutePathCanonicalization(context.Operation, absolutePathType))
+                {
+                    return;
+                }
+
                 // MSBuildTask0002 (TaskEnvironment) is gated by scope setting
                 if (entry.Category == BannedApiDefinitions.ApiCategory.TaskEnvironment && !reportEnvironmentRules)
                 {

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -65,6 +65,15 @@ These APIs access process-global state that varies per task in multithreaded mod
 | `Process.Start()` (all overloads) | `TaskEnvironment.GetProcessStartInfo()` |
 | `new ProcessStartInfo()` (all overloads) | `TaskEnvironment.GetProcessStartInfo()` |
 
+**Canonicalization exception:** `Path.GetFullPath(path.Value)` is accepted when `path.Value`
+is the instance property of the resolved `Microsoft.Build.Framework.AbsolutePath` type.
+This is the normalization operation used by `AbsolutePath.GetCanonicalForm()` itself:
+it canonicalizes an already fully qualified value rather than resolving a relative path
+against the process working directory. The exception applies to direct calls and
+source helpers/polyfills reached through MSBuildTask0005, and the resulting string is
+recognized as absolute by MSBuildTask0003. No helper method name is whitelisted.
+`OriginalValue`, unrelated `Value` properties, and unproven string locals are not exempt.
+
 ### MSBuildTask0003 — File Paths Must Be Absolute
 
 File system APIs that accept a path parameter will resolve relative paths against the process working directory — which is shared and unpredictable in multithreaded mode.

--- a/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
+++ b/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
@@ -142,10 +142,14 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 return false;
             }
 
+            if (!SymbolEqualityComparer.Default.Equals(property.ContainingType, absolutePathType))
+            {
+                return false;
+            }
+
             // Resolve Path from the intrinsic string's assembly, not a source or referenced lookalike.
             var pathType = invocation.TargetMethod.ReturnType.ContainingAssembly?.GetTypeByMetadataName("System.IO.Path");
-            return SymbolEqualityComparer.Default.Equals(property.ContainingType, absolutePathType) &&
-                SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, pathType);
+            return SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, pathType);
         }
 
         /// <summary>

--- a/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
+++ b/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
@@ -114,6 +114,41 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         }
 
         /// <summary>
+        /// Recognizes the normalization operation used by AbsolutePath.GetCanonicalForm and its polyfills.
+        /// Unlike arbitrary strings, AbsolutePath.Value is already fully qualified.
+        /// </summary>
+        internal static bool IsAbsolutePathCanonicalization(IOperation operation, INamedTypeSymbol? absolutePathType)
+        {
+            if (absolutePathType is null ||
+                operation is not IInvocationOperation invocation ||
+                invocation.TargetMethod.Name != "GetFullPath" ||
+                invocation.TargetMethod.ReturnType.SpecialType != SpecialType.System_String ||
+                invocation.Arguments.Length != 1)
+            {
+                return false;
+            }
+
+            var argument = invocation.Arguments[0].Value;
+            while (argument is IConversionOperation { Conversion.IsIdentity: true } conversion)
+            {
+                argument = conversion.Operand;
+            }
+
+            if (argument is not IPropertyReferenceOperation
+                {
+                    Property: { Name: "Value", IsStatic: false, Type.SpecialType: SpecialType.System_String } property
+                })
+            {
+                return false;
+            }
+
+            // Resolve Path from the intrinsic string's assembly, not a source or referenced lookalike.
+            var pathType = invocation.TargetMethod.ReturnType.ContainingAssembly?.GetTypeByMetadataName("System.IO.Path");
+            return SymbolEqualityComparer.Default.Equals(property.ContainingType, absolutePathType) &&
+                SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, pathType);
+        }
+
+        /// <summary>
         /// Recursively checks if an operation represents a safely-wrapped path.
         /// </summary>
         internal static bool IsWrappedSafely(
@@ -194,7 +229,12 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
                 // Check: Path.GetFullPath(safe) — safe only when input is already absolute.
                 // If input is relative, GetFullPath resolves against CWD (wrong in MT).
-                // The GetFullPath call itself is still flagged by MSBuildTask0002 regardless.
+                // Only the specific AbsolutePath.Value normalization also exempts the GetFullPath call.
+                if (IsAbsolutePathCanonicalization(invocation, absolutePathType))
+                {
+                    return true;
+                }
+
                 if (invocation.TargetMethod.Name == "GetFullPath" &&
                     invocation.TargetMethod.ContainingType?.ToDisplayString() == "System.IO.Path" &&
                     invocation.Arguments.Length >= 1 &&

--- a/src/TaskAnalyzer/TransitiveCallChainAnalyzer.cs
+++ b/src/TaskAnalyzer/TransitiveCallChainAnalyzer.cs
@@ -178,6 +178,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             // Check if this is a banned API call → record as a direct violation
             if (bannedApiLookup.TryGetValue(referencedSymbol, out var entry))
             {
+                if (IsAbsolutePathCanonicalization(context.Operation, absolutePathType))
+                {
+                    return;
+                }
+
                 var displayName = referencedSymbol.ToDisplayString(SymbolDisplayFormat.CSharpShortErrorMessageFormat);
                 var violation = new ViolationInfo(entry.Category.ToString(), displayName, entry.Message, context.Operation.Syntax.GetLocation());
                 directViolations.GetOrAdd(callerKey, _ => new ConcurrentBag<ViolationInfo>()).Add(violation);


### PR DESCRIPTION
Fixes #14955

### Context

`Path.GetFullPath(absolutePath.Value)` canonicalizes an already fully qualified value; it does not resolve a relative path against the process working directory. This is the underlying BCL operation used by MSBuild itself. [`AbsolutePath.GetCanonicalForm()`](https://github.com/dotnet/msbuild/blob/0588816d4ba089398b2fc6700ca6f1de2ca981ae/src/Framework/PathHelpers/AbsolutePath.cs#L187-L190) returns:

```csharp
return new AbsolutePath(System.IO.Path.GetFullPath(Value), OriginalValue, ignoreRootedCheck: true);
```

The analyzer already accepts native `GetCanonicalForm()` results through their `AbsolutePath` type. However, writing the normalization directly in a task produces MSBuildTask0002, and writing it in a source polyfill/helper produces MSBuildTask0005. This prevents downlevel consumers such as Arcade from implementing the operation without suppression.

The exception belongs at `Path.GetFullPath(AbsolutePath.Value)`, not at a helper named `GetCanonicalForm`.

### Changes Made

- Share recognition of the one-argument BCL `Path.GetFullPath` call over the resolved `Microsoft.Build.Framework.AbsolutePath` instance string `Value` property between direct and transitive analysis.
- Preserve the normalized result's absolute-path proof for MSBuildTask0003 consumers.
- Resolve BCL `Path` through the intrinsic string type's assembly, rejecting source-defined and aliased-metadata lookalikes rather than comparing display names.
- Cover both scopes, identity casts, nullable path access, aliases/named arguments, extension/static helper calls, and downstream I/O.
- Keep diagnostics for `OriginalValue`, unrelated `Value` properties, unproven/reassigned strings, transformed inputs, and other overloads. No helper name whitelist or general-purpose dataflow exemption is added.
- Document the narrow exception.

### Testing

Built `TaskAnalyzer.Tests.csproj` and ran `MultiThreadableTaskAnalyzerTests`, `TransitiveCallChainAnalyzerTests`, and `MultiThreadableTaskCodeFixProviderTests`: **143 passed, zero failed or skipped**.

Used Arcade as the real-project reproduction at [`f1ce2c65fd8036c495df221b7257e2680e15b4a2`](https://github.com/dotnet/arcade/commit/f1ce2c65fd8036c495df221b7257e2680e15b4a2), retaining its **Framework/Utilities 18.8.2** references and existing **`multithreadable_only` configuration**. Rebuilt the actual Templating project using isolated variants of `GenerateFileFromTemplate`, with I/O rooted and retained as `AbsolutePath`. A compile-item overlay kept the original Arcade snapshot unchanged.

| Real Arcade task variant | Before | After |
| --- | --- | --- |
| Direct `Path.GetFullPath(outputPath.Value)` | One MSBuildTask0002 | No TaskAnalyzer diagnostics |
| Same operation inside `GetCanonicalForm` extension | One MSBuildTask0005 | No TaskAnalyzer diagnostics |

No suppressions or broad-scope overrides were used. Compiler logs confirm the 18.8.2 references and the locally built analyzer. Both variants were rebuilt after tightening BCL symbol identity.

### Notes

- Red-team review found the initial type-name comparison could accept a user-defined `System.IO.Path`. This was fixed and covered for source and referenced lookalikes; the follow-up review found no remaining actionable or blocking issues.
- This only removes false positives under the existing `AbsolutePath` contract. It adds no runtime/API changes, diagnostic IDs, or severity changes, so no ChangeWave is needed.
- This is not a blanket Arcade migration or a promise of exact runtime parity for every downlevel polyfill. Older-host rooting behavior (fixed separately by #13788) and preservation of `OriginalValue` remain separate compatibility concerns. No Arcade production changes are included.