### PR TITLE
Compare file identities instead of counts in BuildFailureLogInvariant

### DIFF
--- a/src/UnitTests.Shared/TestEnvironment.cs
+++ b/src/UnitTests.Shared/TestEnvironment.cs
@@ -523,6 +523,7 @@ namespace Microsoft.Build.UnitTests
     {
         private const string MSBuildLogFiles = "MSBuild_*.txt";
         private readonly string[] _originalFiles;
+        private readonly DateTime _startTimeUtc = DateTime.UtcNow;
 
         public BuildFailureLogInvariant()
         {
@@ -574,10 +575,13 @@ namespace Microsoft.Build.UnitTests
         {
             var newFiles = GetMSBuildLogFiles();
 
-            int newFilesCount = newFiles.Length;
+            List<string> unexpectedFiles = new();
             foreach (FileInfo file in newFiles.Except(_originalFiles).Select(f => new FileInfo(f)))
             {
                 string contents = File.ReadAllText(file.FullName);
+
+                // Read the metadata before deleting the file, otherwise it is no longer available.
+                DateTime creationTimeUtc = file.CreationTimeUtc;
 
                 // Delete the file so we don't pollute the build machine
                 FileUtilities.DeleteNoThrow(file.FullName);
@@ -586,7 +590,6 @@ namespace Microsoft.Build.UnitTests
                 if (Regex.IsMatch(file.Name, @"MSBuild_NodeShutdown_\d+\.txt") &&
                     Regex.IsMatch(contents, @"Node shutting down with reason BuildComplete and exception:\s*"))
                 {
-                    newFilesCount--;
                     continue;
                 }
 
@@ -596,15 +599,30 @@ namespace Microsoft.Build.UnitTests
                     Regex.IsMatch(file.Name, @"MSBuild_CoordinatorTrace_PID_\d+\.txt"))
                 {
                     output.WriteLine($"{file.Name}: {contents}");
-                    newFilesCount--;
                     continue;
                 }
 
                 output.WriteLine($"Build Error File {file.Name}: {contents}");
+                unexpectedFiles.Add($"{file.Name} (pid: {GetPidDescription(file.Name)}, created: {creationTimeUtc:O})");
             }
 
-            // Assert file count is equal minus any files that were OK
-            Assert.Equal(_originalFiles.Length, newFilesCount);
+            // Compare the identities of the files rather than how many there are. Test assemblies run as concurrent
+            // processes that share the machine-wide temp folder, so a file present when this invariant was created can
+            // be deleted by an unrelated process at any time. Looking only at names which were not there before means
+            // such a deletion can neither fail this test nor cancel out a genuine crash dump.
+            unexpectedFiles.ShouldBeEmpty(
+                $"Unexpected MSBuild failure log file(s) appeared after this test started at {_startTimeUtc:O}: {string.Join("; ", unexpectedFiles)}");
+        }
+
+        /// <summary>
+        ///     Extracts the process ID embedded in an MSBuild log file name, e.g. MSBuild_pid-1234_{guid}.failure.txt,
+        ///     MSBuild_CommTrace_PID_1234.txt or MSBuild_NodeShutdown_1234.txt.
+        /// </summary>
+        private static string GetPidDescription(string fileName)
+        {
+            Match match = Regex.Match(fileName, @"(?:pid-|PID_|NodeShutdown_)(?<pid>\d+)", RegexOptions.IgnoreCase);
+
+            return match.Success ? match.Groups["pid"].Value : "unknown";
         }
     }
 

--- a/src/UnitTests.Shared/TestEnvironment.cs
+++ b/src/UnitTests.Shared/TestEnvironment.cs
@@ -576,7 +576,7 @@ namespace Microsoft.Build.UnitTests
             var newFiles = GetMSBuildLogFiles();
 
             List<string> unexpectedFiles = new();
-            foreach (FileInfo file in newFiles.Except(_originalFiles).Select(f => new FileInfo(f)))
+            foreach (FileInfo file in newFiles.Except(_originalFiles, StringComparer.OrdinalIgnoreCase).Select(f => new FileInfo(f)))
             {
                 string contents = File.ReadAllText(file.FullName);
 

--- a/src/UnitTests.Shared/TestEnvironment.cs
+++ b/src/UnitTests.Shared/TestEnvironment.cs
@@ -578,7 +578,23 @@ namespace Microsoft.Build.UnitTests
             List<string> unexpectedFiles = new();
             foreach (FileInfo file in newFiles.Except(_originalFiles, StringComparer.OrdinalIgnoreCase).Select(f => new FileInfo(f)))
             {
-                string contents = File.ReadAllText(file.FullName);
+                string contents;
+                try
+                {
+                    contents = File.ReadAllText(file.FullName);
+                }
+                catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+                {
+                    // A concurrently running test process globbed the same shared folder and deleted the file first.
+                    // Reporting it is that process's job, so there is nothing left for this one to classify.
+                    continue;
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+                {
+                    // The file is still there but cannot be read, so it cannot be recognised as benign. Fall through
+                    // and report it rather than risk dropping a crash dump.
+                    contents = $"<could not be read: {ex.Message}>";
+                }
 
                 // Read the metadata before deleting the file, otherwise it is no longer available.
                 DateTime creationTimeUtc = file.CreationTimeUtc;


### PR DESCRIPTION
## What happens today

Test assemblies run in parallel as separate processes. `BuildFailureLogInvariant` counts `MSBuild_*.txt` files across several temp locations at the start of every test and asserts the count is unchanged at the end.

Counting is fragile: any file that appears or disappears between the two scans changes the result, whichever process caused it.

- A file that was present at the start is gone at the end. The count drops and the test fails. The loop only inspects files that appeared, never files that vanished, so it cannot recognise the file as harmless — the only output is `Expected: 2, Actual: 1`.
- One file added and one file removed cancel out. The count matches, and a genuine crash dump goes unreported.

## The fix

Compare file identities instead of counts. Record the file names at test start, and at the end look only at names that were not there before.

A deleted file was on the original list, so it can never appear as a new name — deletions can no longer fail the test. A crash dump is always a new name, so it can no longer be cancelled out.

Both existing filters (clean node shutdown, communication traces) are unchanged, so abnormal shutdowns still fail as they do today. The failure message now names the files and includes the PID and timestamps.

## Two follow-ons in the same area

- **Case-insensitive comparison.** `GetMSBuildLogFiles` already de-dupes with `InvariantCultureIgnoreCase`, while `Except` used the ordinal default, so the two disagreed. These paths are case-insensitive on Windows, so differing casing between the two directory scans would make a file look new and fail the test. This cannot mask a crash: a dump name carries a PID and a GUID, so it cannot collide with a baseline file by case alone.

- **Tolerate a file being deleted before it is read.** `File.ReadAllText` ran unguarded between the glob and the delete. If the file is removed in that window, `ReadAllText` throws `FileNotFoundException` out of `AssertInvariant`, failing the test with a stack trace rather than a clean assert — the same fragility as above, with an uglier failure mode. `DeleteNoThrow` already swallowed IO errors, so only the read was exposed. A file that has vanished is skipped, because whichever process deleted it read it first and will report it; a file that is present but unreadable is still reported, because it cannot be recognised as benign and must not be silently dropped.

If a dump is observed and deleted by a process other than the one that produced it, the failure surfaces there rather than on the test that caused it. Nothing here changes that. The named-file message, with the PID and the timestamps, is what makes that diagnosable the next time it fires.