### PR TITLE
Fix concurrent enumeration recording in globbing tests

### DIFF
--- a/src/Framework.UnitTests/Globbing/FileMatcherOptimized_Tests.cs
+++ b/src/Framework.UnitTests/Globbing/FileMatcherOptimized_Tests.cs
@@ -998,6 +998,37 @@ public sealed class FileMatcherOptimized_Tests : IDisposable
     }
 
     [Fact]
+    public void RecordingFileSystemPreservesConcurrentEnumerationCalls()
+    {
+        TransientTestFolder root = _environment.CreateFolder();
+        DirectRecordingFileSystem fileSystem = new(FileSystems.Default);
+        const int iterations = 4096;
+        List<(string Operation, string Path, string Pattern)> expected = [];
+
+        for (int i = 0; i < iterations; i++)
+        {
+            string pattern = i.ToString(CultureInfo.InvariantCulture);
+            expected.Add((nameof(IFileSystem.EnumerateFiles), root.Path, pattern));
+            expected.Add((nameof(IFileSystem.EnumerateDirectories), root.Path, pattern));
+            expected.Add((nameof(IFileSystem.EnumerateFileSystemEntries), root.Path, pattern));
+        }
+
+        Parallel.For(0, iterations, i =>
+        {
+            string pattern = i.ToString(CultureInfo.InvariantCulture);
+            fileSystem.EnumerateFiles(root.Path, pattern);
+            fileSystem.EnumerateDirectories(root.Path, pattern);
+            fileSystem.EnumerateFileSystemEntries(root.Path, pattern);
+        });
+
+        fileSystem.EnumerationCalls.Count.ShouldBe(expected.Count);
+        fileSystem.EnumerationCalls.OrderBy(call => call.Pattern, StringComparer.Ordinal)
+            .ThenBy(call => call.Operation, StringComparer.Ordinal)
+            .ShouldBe(expected.OrderBy(call => call.Pattern, StringComparer.Ordinal)
+                .ThenBy(call => call.Operation, StringComparer.Ordinal));
+    }
+
+    [Fact]
     public void AutoUsesChangeWaveFallback()
     {
         TransientTestFolder root = _environment.CreateFolder();
@@ -2266,7 +2297,7 @@ public sealed class FileMatcherOptimized_Tests : IDisposable
             _inner = inner;
         }
 
-        internal List<(string Operation, string Path, string Pattern)> EnumerationCalls { get; } = [];
+        internal ConcurrentQueue<(string Operation, string Path, string Pattern)> EnumerationCalls { get; } = new();
 
         public TextReader ReadFile(string path) => _inner.ReadFile(path);
         public Stream GetFileStream(string path, FileMode mode, FileAccess access, FileShare share) =>
@@ -2279,7 +2310,7 @@ public sealed class FileMatcherOptimized_Tests : IDisposable
             string searchPattern = "*",
             SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
-            EnumerationCalls.Add((nameof(EnumerateFiles), path, searchPattern));
+            EnumerationCalls.Enqueue((nameof(EnumerateFiles), path, searchPattern));
             return _inner.EnumerateFiles(path, searchPattern, searchOption);
         }
 
@@ -2288,7 +2319,7 @@ public sealed class FileMatcherOptimized_Tests : IDisposable
             string searchPattern = "*",
             SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
-            EnumerationCalls.Add((nameof(EnumerateDirectories), path, searchPattern));
+            EnumerationCalls.Enqueue((nameof(EnumerateDirectories), path, searchPattern));
             return _inner.EnumerateDirectories(path, searchPattern, searchOption);
         }
 
@@ -2297,7 +2328,7 @@ public sealed class FileMatcherOptimized_Tests : IDisposable
             string searchPattern = "*",
             SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
-            EnumerationCalls.Add((nameof(EnumerateFileSystemEntries), path, searchPattern));
+            EnumerationCalls.Enqueue((nameof(EnumerateFileSystemEntries), path, searchPattern));
             return _inner.EnumerateFileSystemEntries(path, searchPattern, searchOption);
         }
 


### PR DESCRIPTION
Related issue(s): Windows Core CI failure in `AutoUsesChangeWaveFallback`, observed while validating #14937.
<!-- Use "Fixes #..." only when this PR completes the linked issue. -->

### Context

<!-- What user-visible problem does this solve? -->

`RecordingFileSystem` records enumeration calls in an unsynchronized `List<T>`, but the legacy file matcher can invoke the same filesystem wrapper from parallel directory traversal. This makes the test fixture itself unsafe: an otherwise valid glob can fail intermittently or leave an incomplete record of enumeration calls.

The reported Windows Core job failed in the net472/x86 Framework tests with an `AggregateException` containing `IndexOutOfRangeException` failures from `List<T>.Add` in `RecordingFileSystem.EnumerateFiles` and `EnumerateDirectories`. The same test passed on retry without a code change; retrying does not remove the underlying race.

#### Step-by-step failure mode

1. `AutoUsesChangeWaveFallback` sets `MSBUILDDISABLEFEATURESFROMVERSION` to `Wave18_11`, resets change-wave state, and verifies that a matcher backed by `DirectRecordingFileSystem` selects the legacy implementation.
2. The test invokes `GetFiles` with a recursive `**/*.cs` glob over a directory tree.
3. When the available parallelism is at least two, `FileMatcher.GetFilesRecursive` uses `Parallel.ForEach` to traverse subdirectories.
4. Multiple workers call enumeration methods on the same `DirectRecordingFileSystem`. Those methods are inherited from `RecordingFileSystem` and append to the same `EnumerationCalls` list without synchronization.
5. Concurrent `List<T>.Add` operations race on shared size, capacity, and backing-array state. This can lose recorded entries or produce an invalid array access.
6. Exceptions thrown by traversal workers are surfaced through `Parallel.ForEach` as an `AggregateException`, failing the test.

The historical exception stacks identify this path. The new regression independently reproduced lost writes before the fix: **12,283 calls recorded instead of 12,288** on net472/x86. Concurrent corruption is therefore reproduced; the exact instruction-level interleaving behind the historical `IndexOutOfRangeException` is inferred, not reproduced.

### Changes Made

<!-- Summarize the approach and meaningful changes. -->

- Replace the private fixture's `List<(string Operation, string Path, string Pattern)>` with `ConcurrentQueue` and change all three recording sites to `Enqueue`: `EnumerateFiles`, `EnumerateDirectories`, and `EnumerateFileSystemEntries`.
- Add `RecordingFileSystemPreservesConcurrentEnumerationCalls`, which invokes all three methods through `DirectRecordingFileSystem` in a bounded `Parallel.For`, then checks the total count and exact recorded tuples without assuming cross-thread ordering.

A concurrent queue makes every recording write thread-safe while preserving sequential FIFO behavior and the existing enumeration-based assertions. It avoids adding locks around filesystem operations or changing production traversal. The fix is confined to `src/Framework.UnitTests/Globbing/FileMatcherOptimized_Tests.cs`.

### Compatibility

<!-- Delete if not applicable. Note affected modes/platforms and changes to defaults,
diagnostics, APIs or protocols, including compatibility between older and newer hosts. -->

Test-only change. No production behavior, defaults, diagnostics, APIs, protocols, or change-wave behavior changes. No changes targeting the separate macOS or Windows Full incidents.

### Testing

<!-- Give relevant evidence, including commands/results and any coverage gaps.
For MT/lifecycle changes, consider repeated builds, cancellation and mixed-version hosts
where relevant; a full matrix is not required for every change. -->

- **Before fix:** the new regression failed on net472/x86 with 12,283 actual entries versus 12,288 expected.
- **Full repository build:** `.\build.cmd -v quiet -msbuildEngine dotnet` passed with zero warnings/errors.
- **Affected test class:** `.\.dotnet\dotnet.exe test "$PWD\src\Framework.UnitTests\Microsoft.Build.Framework.UnitTests.csproj" --no-build -- --filter-class "Microsoft.Build.UnitTests.Globbing.FileMatcherOptimized_Tests"` passed on net472/x86 and net11.0/x64: **220 passed, 39 skipped, zero failures**.
- **Framework Release tests:** `.\.dotnet\dotnet.exe test "$PWD\src\Framework.UnitTests\Microsoft.Build.Framework.UnitTests.csproj" -c Release -- --no-progress` passed: **2,237 passed, 73 skipped, zero failures** across both target frameworks.
- **Bootstrap checks:** environment activation, SDK version, MSBuild help, and bootstrap `dotnet build src\Samples\Dependency\Dependency.csproj -v:q` passed.

Validation used the repository-pinned .NET SDK because the installed Visual Studio MSBuild was older than the SDK's minimum supported version. Bootstrap copy locks from local build/compiler servers were cleared before the successful Release run; no repository configuration changes were needed. The concurrency regression is scheduling-dependent and does not force the historical exception interleaving.