### PR TITLE
Fix leaving aborted nodes hanging around when build fail unexpectedly

### DIFF
--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2875,9 +2875,11 @@ namespace Microsoft.Build.Execution
                     }
                 }
 
-                _nodeManager!.ShutdownConnectedNodes(_buildParameters!.EnableNodeReuse);
-                _taskHostNodeManager!.ShutdownConnectedNodes(_buildParameters.EnableNodeReuse);
-
+                // We are aborting the build because a node exited unexpectedly.
+                // Do not reuse nodes, as their state may be compromised by attempts to shut down while the build is in-progress.
+                // Do not cleanly shut down the task host nodes here because we are aborting the task host will hear about it in time through the task building infrastructure.
+                _nodeManager!.ShutdownConnectedNodes(false);
+                
                 foreach (BuildSubmissionBase submission in _buildSubmissions.Values)
                 {
                     // The submission has not started

--- a/src/Build/BackEnd/BuildManager/BuildManager.cs
+++ b/src/Build/BackEnd/BuildManager/BuildManager.cs
@@ -2876,10 +2876,9 @@ namespace Microsoft.Build.Execution
                 }
 
                 // We are aborting the build because a node exited unexpectedly.
-                // Do not reuse nodes, as their state may be compromised by attempts to shut down while the build is in-progress.
-                // Do not cleanly shut down the task host nodes here because we are aborting the task host will hear about it in time through the task building infrastructure.
-                _nodeManager!.ShutdownConnectedNodes(false);
-                
+                // Do not reuse nodes, as their state may be compromised by attempts to shut down while the build is in progress.
+                // Do not shut down task host nodes here: during an abort they will be notified through the task execution infrastructure.
+                _nodeManager!.ShutdownConnectedNodes(enableReuse: false);
                 foreach (BuildSubmissionBase submission in _buildSubmissions.Values)
                 {
                     // The submission has not started


### PR DESCRIPTION
When build fail unexpectedly, MSBuild nodes are left hanging around. this change make them shutdown regardless off EnableNodeReuse flag - as I think this should not be the case, when the build fails.