### PR TITLE
Remove .NET 3.5 Developer Tools from .vsconfig

### DIFF
--- a/.vsconfig
+++ b/.vsconfig
@@ -1,7 +1,6 @@
 {
   "version": "1.0",
   "components": [
-    "Microsoft.VisualStudio.Workload.ManagedDesktop",
-    "Microsoft.Net.Component.3.5.DeveloperTools"
+    "Microsoft.VisualStudio.Workload.ManagedDesktop"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ To get started with **Visual Studio 2026**:
 
 1. [Install Visual Studio 2026](https://visualstudio.microsoft.com/downloads/) with the components listed in [`.vsconfig`](.vsconfig):
    - **.NET desktop development** workload
-   - **.NET Framework 3.5 development tools** individual component
 2. [Install .NET Framework 3.5](https://learn.microsoft.com/dotnet/framework/install/dotnet-35-windows-11). A full MSBuild build includes outputs that require this.
 3. Ensure [long path support](https://learn.microsoft.com/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#enable-long-paths-in-windows-10-version-1607-and-later) is enabled at the Windows level.
 4. Open a `Developer Command Prompt for VS 2026` prompt.

--- a/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
+++ b/documentation/wiki/Building-Testing-and-Debugging-on-Full-Framework-MSBuild.md
@@ -4,7 +4,7 @@ These instructions refer to working with the `main` branch.
 
 ## Required Software
 
-**Latest Microsoft Visual Studio 2026**: You can download the Visual Studio Community edition from [visualstudio.microsoft.com/vs/community/](https://visualstudio.microsoft.com/vs/community/). Select the **.NET desktop development** workload and the **.NET Framework 3.5 development tools** individual component, as specified in [`.vsconfig`](../../.vsconfig).
+**Latest Microsoft Visual Studio 2026**: You can download the Visual Studio Community edition from [visualstudio.microsoft.com/vs/community/](https://visualstudio.microsoft.com/vs/community/). Select the components specified in [`.vsconfig`](../../.vsconfig).
 
 **.NET Framework 3.5** must also be installed on the Windows machine for the full build to succeed. `MSBuildTaskHost.exe` still targets .NET Framework 3.5; a newer .NET SDK or .NET Framework 4.x does not replace it.
 


### PR DESCRIPTION
We still target .NET 3.5, but the .NET SDK gets enough of the targeting pack through NuGet packages; with it removed I can still build and VS appeared to work (builds MSBuildTaskHost, IntelliSense looked fine).