### PR TITLE
Try a transient server before falling back for busy MT builds

### DIFF
--- a/documentation/MSBuild-Server.md
+++ b/documentation/MSBuild-Server.md
@@ -20,10 +20,11 @@ When a build is multithreaded (`/mt`), the server node is launched with [Server 
 MSBuild Server is a form of node reuse: the whole point of the server is to stay resident between builds so later builds reuse its warmed-up process and caches. Consequently:
 
 - **Node reuse on (the default).** The server is eligible and, after a build, returns to listening so the next compatible client reuses it.
+- **Node reuse on with `/mt` while the resident is busy.** The client makes one attempt to launch and connect to a private, short-lived server, including when another client is already launching the resident. The build keeps its original node-reuse setting, but this private server exits after serving it. If the private server cannot be launched or connected, the client retains the existing in-process fallback. Non-multithreaded builds continue to fall back directly.
 - **Node reuse off (`-nodeReuse:false` / `-nr:false`) without `/mt`.** Keeping a process resident contradicts the no-reuse intent, so the build does not use the server at all (it runs entirely in the launching process). See `ServerShouldNotRunWhenNodeReuseEqualsFalse`.
 - **Node reuse off *with* `/mt`.** A `/mt` build needs the server for a different reason: multithreaded project execution runs inside the server process, which is where Server GC is applied (see [Garbage collection](#garbage-collection)). So a `/mt` build still engages the server even when node reuse is off - but it must honor the no-reuse request by **not** leaving the server resident afterwards. This is a *short-lived* server: a fresh process that tears itself down after the build.
 
-The client makes a single, response-file-aware determination and sets the `ShutdownAfterBuild` flag on the `ServerNodeBuildCommand` packet if server needs shutdown.
+The client determines the requested mode and node-reuse setting from the response-file-aware command-line parse. It sets the `ShutdownAfterBuild` flag on the `ServerNodeBuildCommand` packet for a short-lived server, whether requested by `/mt -nodeReuse:false` or used after resident-server contention. The in-process fallback does not acquire Server GC merely because `/mt` was requested.
 
 ## Diagnostics: server lifecycle messages
 
@@ -35,7 +36,8 @@ The server node uses same IPC approach as current worker nodes - named pipes. Th
 
 1. Try to connect to server
    - If server is not running, start new instance
-   - If server is busy or the connection is broken, fall back to previous build behavior
+   - If the resident is busy, try one private server for a multithreaded build; otherwise fall back to in-process execution
+   - If server acquisition still fails, fall back to in-process execution; do not retry a build already submitted to a server
 2. Initiate handshake
 2. Issue build command with `ServerNodeBuildCommand` packet
 3. Read packets from pipe

--- a/src/MSBuild.UnitTests/MSBuildClientApp_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildClientApp_Tests.cs
@@ -1,0 +1,196 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#if !NETFRAMEWORK
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Threading;
+using Microsoft.Build.BackEnd;
+using Microsoft.Build.CommandLine;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Internal;
+using Microsoft.Build.Logging;
+using Microsoft.Build.Shared;
+using Microsoft.Build.UnitTests;
+using Microsoft.Build.UnitTests.Shared;
+using Shouldly;
+using Xunit;
+
+namespace Microsoft.Build.Engine.UnitTests;
+
+public sealed class MSBuildClientApp_Tests
+{
+    private readonly ITestOutputHelper _output;
+
+    public MSBuildClientApp_Tests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void BusyResidentUsesTransientServer(bool launchContention, bool buildFails)
+    {
+        using TestEnvironment env = CreateEnvironment();
+        ServerNodeHandshake handshake = CreateResidentHandshake();
+        using Mutex? running = launchContention
+            ? null
+            : new(initiallyOwned: false, $@"Global\msbuild-server-running-{handshake.ComputeHash()}");
+        using Mutex contention = HoldResidentContention(handshake, launchContention);
+        TransientTestFile result = env.CreateFile(".txt");
+        TransientTestFile binlog = env.CreateFile(".binlog");
+        TransientTestFile project = CreateProbeProject(env, result.Path);
+
+        MSBuildClientApp.Execute(
+            ["MSBuild.exe", project.Path, "-mt", "-nodeReuse:true", $"-p:FailBuild={buildFails}", $"-bl:{binlog.Path}"],
+            RunnerUtilities.BootstrapMSBuildExecutablePath,
+            multiThreaded: true,
+            shutdownServerAfterBuild: false,
+            CancellationToken.None).ShouldBe(buildFails ? MSBuildApp.ExitType.BuildError : MSBuildApp.ExitType.Success);
+
+        string[] probe = File.ReadAllText(result.Path).Trim().Split('|');
+        int serverPid = int.Parse(probe[0]);
+        serverPid.ShouldNotBe(Environment.ProcessId, "The busy resident must not force the MT build into its client.");
+        env.WithTransientProcess(serverPid);
+        if (Environment.ProcessorCount > 1)
+        {
+            bool.Parse(probe[1]).ShouldBeTrue("The private server must launch with Server GC.");
+        }
+
+        MSBuildServerLifecycleEventArgs lifecycle = ReadLifecycle(binlog.Path);
+        lifecycle.Kind.ShouldBe(MSBuildServerLifecycleKind.Spawned);
+        lifecycle.ShortLived.ShouldBeTrue();
+        lifecycle.ProcessId.ShouldBe(serverPid);
+        lifecycle.ReasonCode.ShouldBeNull();
+        WaitForProcessExit(serverPid)
+            .ShouldBeTrue("The overflow server must exit even though the build requested node reuse.");
+    }
+
+    [Theory]
+    [InlineData(false, false, false)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(true, true, false)]
+    [InlineData(false, true, true)]
+    [InlineData(true, true, true)]
+    public void BusyResidentRetainsInProcessFallback(bool launchContention, bool multiThreaded, bool cancelled)
+    {
+        using TestEnvironment env = CreateEnvironment();
+        ServerNodeHandshake handshake = CreateResidentHandshake();
+        using Mutex? running = launchContention
+            ? null
+            : new(initiallyOwned: false, $@"Global\msbuild-server-running-{handshake.ComputeHash()}");
+        using Mutex contention = HoldResidentContention(handshake, launchContention);
+        TransientTestFile result = env.CreateFile(".txt");
+        TransientTestFile binlog = env.CreateFile(".binlog");
+        TransientTestFile project = CreateProbeProject(env, result.Path);
+        string missingMSBuild = Path.Combine(env.CreateFolder().Path, "missing", "MSBuild.exe");
+        using CancellationTokenSource cancellation = new();
+        if (cancelled)
+        {
+            cancellation.Cancel();
+        }
+
+        MSBuildClientApp.Execute(
+            ["MSBuild.exe", project.Path, $"-mt:{multiThreaded}", "-nodeReuse:true", $"-bl:{binlog.Path}"],
+            missingMSBuild,
+            multiThreaded,
+            shutdownServerAfterBuild: false,
+            cancellation.Token).ShouldBe(MSBuildApp.ExitType.Success);
+
+        string[] probe = File.ReadAllText(result.Path).Trim().Split('|');
+        int.Parse(probe[0]).ShouldBe(Environment.ProcessId);
+        MSBuildServerLifecycleEventArgs lifecycle = ReadLifecycle(binlog.Path);
+        lifecycle.Kind.ShouldBe(MSBuildServerLifecycleKind.NotUsed);
+        lifecycle.ReasonCode.ShouldBe(multiThreaded && !cancelled
+            ? MSBuildApp.ServerNotUsedReasonCodeServerCrashed
+            : MSBuildApp.ServerNotUsedReasonCodeServerBusy);
+    }
+
+    private TestEnvironment CreateEnvironment()
+    {
+        TestEnvironment env = TestEnvironment.Create(_output);
+        foreach (var variable in RunnerUtilities.GetBootstrapMSBuildEnvironmentVariables())
+        {
+            env.SetEnvironmentVariable(variable.Key, variable.Value);
+        }
+
+        // The tools root participates in the handshake, so the in-process client must use the server's layout.
+        BuildEnvironmentHelper.ResetInstance_ForUnitTestsOnly(new BuildEnvironment(
+            BuildEnvironmentMode.Standalone,
+            RunnerUtilities.BootstrapMSBuildExecutablePath,
+            runningTests: true,
+            runningInMSBuildExe: false,
+            runningInVisualStudio: false,
+            visualStudioPath: null));
+
+        env.SetEnvironmentVariable("MSBUILDNODEHANDSHAKESALT", Guid.NewGuid().ToString("N"));
+        env.SetEnvironmentVariable("DOTNET_gcServer", null);
+        env.SetEnvironmentVariable("COMPlus_gcServer", null);
+        env.SetEnvironmentVariable("MSBUILDDISABLENODEREUSE", null);
+        return env;
+    }
+
+    private static ServerNodeHandshake CreateResidentHandshake() => new(
+        CommunicationsUtilities.GetHandshakeOptions(
+            taskHost: false,
+            taskHostParameters: TaskHostParameters.Empty,
+            architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture()));
+
+    private static Mutex HoldResidentContention(ServerNodeHandshake handshake, bool launchContention) =>
+        new(
+            initiallyOwned: false,
+            launchContention
+                ? $@"Global\msbuild-server-launch-{handshake.ComputeHash()}"
+                : $@"Global\msbuild-server-busy-{handshake.ComputeHash()}");
+
+    private static TransientTestFile CreateProbeProject(TestEnvironment env, string resultPath) =>
+        env.CreateFile("probe.proj", $"""
+            <Project>
+              <UsingTask TaskName="ProcessIdTask" AssemblyFile="{Assembly.GetExecutingAssembly().Location}" />
+              <Target Name="Probe">
+                <ProcessIdTask>
+                  <Output PropertyName="PID" TaskParameter="Pid" />
+                  <Output PropertyName="SERVERGC" TaskParameter="IsServerGC" />
+                </ProcessIdTask>
+                <WriteLinesToFile File="{resultPath}" Lines="$(PID)|$(SERVERGC)" />
+                <Error Text="Expected test failure" Condition="'$(FailBuild)' == 'true'" />
+              </Target>
+            </Project>
+            """);
+
+    private static MSBuildServerLifecycleEventArgs ReadLifecycle(string binlog)
+    {
+        List<MSBuildServerLifecycleEventArgs> events = [];
+        BinaryLogReplayEventSource replay = new();
+        replay.AnyEventRaised += (_, args) =>
+        {
+            if (args is MSBuildServerLifecycleEventArgs lifecycle)
+            {
+                events.Add(lifecycle);
+            }
+        };
+        replay.Replay(binlog);
+        return events.ShouldHaveSingleItem();
+    }
+
+    private static bool WaitForProcessExit(int processId)
+    {
+        try
+        {
+            using Process process = Process.GetProcessById(processId);
+            return process.WaitForExit(10_000);
+        }
+        catch (ArgumentException)
+        {
+            return true;
+        }
+    }
+}
+#endif

--- a/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
+++ b/src/MSBuild.UnitTests/MSBuildServer_Tests.cs
@@ -9,9 +9,11 @@ using System.Resources;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Build.BackEnd;
 using Microsoft.Build.CommandLine;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
+using Microsoft.Build.Internal;
 using Microsoft.Build.Server;
 using Microsoft.Build.Shared;
 using Microsoft.Build.UnitTests;
@@ -135,6 +137,21 @@ namespace Microsoft.Build.Engine.UnitTests
             if (warmServer)
             {
                 launchClient.Execute(CancellationToken.None).MSBuildAppExitTypeString.ShouldBe("Success");
+                _env.WithTransientProcess(pidField.GetValue(launchClient).ShouldBeOfType<int>());
+
+                // The build result arrives before the server releases its busy mutex.
+                // Wait for admission before testing debugger behavior on that same resident.
+                ServerNodeHandshake handshake = new(CommunicationsUtilities.GetHandshakeOptions(
+                    taskHost: false,
+                    taskHostParameters: TaskHostParameters.Empty,
+                    architectureFlagToSet: XMakeAttributes.GetCurrentMSBuildArchitecture()));
+                string busyMutexName = $@"Global\msbuild-server-busy-{handshake.ComputeHash()}";
+                SpinWait.SpinUntil(() =>
+                {
+                    bool busy = Mutex.TryOpenExisting(busyMutexName, out Mutex? mutex);
+                    mutex?.Dispose();
+                    return !busy;
+                }, 10000).ShouldBeTrue("The warmup build must release the resident before the debugger request.");
             }
 
             _env.SetEnvironmentVariable("MSBUILDDEBUGONSTART", "5");
@@ -152,7 +169,10 @@ namespace Microsoft.Build.Engine.UnitTests
                 build = Task.Run(() => debugClient.Execute(CancellationToken.None));
                 SpinWait.SpinUntil(() => pidField.GetValue(launchClient) is int || build.IsCompleted, 10000).ShouldBeTrue();
                 int pid = pidField.GetValue(launchClient).ShouldBeOfType<int>();
-                _env.WithTransientProcess(pid);
+                if (!warmServer)
+                {
+                    _env.WithTransientProcess(pid);
+                }
                 server = Process.GetProcessById(pid);
                 SpinWait.SpinUntil(() =>
                 {
@@ -161,6 +181,12 @@ namespace Microsoft.Build.Engine.UnitTests
                         return output.ToString().Contains($"PID {pid}") || build.IsCompleted;
                     }
                 }, 10000).ShouldBeTrue();
+                if (build.IsCompleted)
+                {
+                    MSBuildClientExitResult result = await build;
+                    _output.WriteLine($"Debug request completed with {result.MSBuildClientExitType}: {result.MSBuildAppExitTypeString}");
+                    _output.WriteLine(output.ToString());
+                }
                 build.IsCompleted.ShouldBeFalse("the server must wait before evaluating the project");
                 lock (synchronizedOutput)
                 {

--- a/src/MSBuild/MSBuildClientApp.cs
+++ b/src/MSBuild/MSBuildClientApp.cs
@@ -5,6 +5,7 @@ using System;
 using System.Globalization;
 using System.Threading;
 using Microsoft.Build.Framework.Telemetry;
+using Microsoft.Build.Internal;
 using Microsoft.Build.Server;
 using Microsoft.Build.Shared;
 
@@ -19,7 +20,8 @@ namespace Microsoft.Build.CommandLine
     /// This class implements client for MSBuild server. It
     /// 1. starts the MSBuild server in a separate process if it does not yet exist.
     /// 2. establishes a connection with MSBuild server and sends a build request.
-    /// 3. if server is busy, it falls back to old build behavior.
+    /// 3. if the resident server is busy, it tries a transient server for multithreaded builds.
+    /// 4. if no server is available, it falls back to an in-process build.
     /// </summary>
     internal static class MSBuildClientApp
     {
@@ -68,6 +70,17 @@ namespace Microsoft.Build.CommandLine
         {
             MSBuildClient msbuildClient = new MSBuildClient(commandLineArgs, msbuildLocation, multiThreaded, shutdownServerAfterBuild);
             MSBuildClientExitResult exitResult = msbuildClient.Execute(cancellationToken);
+
+            if (exitResult.MSBuildClientExitType == MSBuildClientExitType.ServerBusy &&
+                multiThreaded &&
+                !shutdownServerAfterBuild &&
+                !cancellationToken.IsCancellationRequested)
+            {
+                // Retry admission once with a private identity, preserving the build's node-reuse setting.
+                CommunicationsUtilities.Trace("Resident server is busy; trying a transient server for the multithreaded build.");
+                MSBuildClient transientClient = new(commandLineArgs, msbuildLocation, multiThreaded, shutdownServerAfterBuild: true);
+                exitResult = transientClient.Execute(cancellationToken);
+            }
 
             if (exitResult.MSBuildClientExitType == MSBuildClientExitType.ServerBusy ||
                 exitResult.MSBuildClientExitType == MSBuildClientExitType.UnableToConnect ||

--- a/src/MSBuild/MSBuildClientApp.cs
+++ b/src/MSBuild/MSBuildClientApp.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Build.CommandLine
 
             if (exitResult.MSBuildClientExitType == MSBuildClientExitType.ServerBusy &&
                 multiThreaded &&
+                // if we started a transient server we don't want to fall back to a transient server
                 !shutdownServerAfterBuild &&
                 !cancellationToken.IsCancellationRequested)
             {


### PR DESCRIPTION
Related issue(s): Follow-up to #14647.
<!-- Use "Fixes #..." only when this PR completes the linked issue. -->

### Context

<!-- What user-visible problem does this solve? -->
Two overlapping plain `-mt` builds still contend for the resident server. The second currently falls back into its client, losing the Server GC selected when launching an MT server. #14647 isolated explicitly transient builds but did not change this resident-busy path.

### Changes Made

<!-- Summarize the approach and meaningful changes. -->
When resident admission returns `ServerBusy` for a reusable MT request, make one attempt to launch and connect to a private transient server using the existing per-invocation identity and shutdown machinery.

Keep the original command line and node-reuse setting. Skip the extra attempt when cancellation is already requested. If transient acquisition fails, retain the existing in-process fallback and report the transient attempt's failure reason. A build already executed by a server is never replayed.

Add deterministic coverage for busy and launch-contended residents, Server GC, transient exit and binlog lifecycle events, failed-build result propagation, failed-launch fallback, non-MT behavior, and pre-cancelled requests. Update the server documentation.

Fix the warm-server debugger test's admission race exposed in Linux CI: receiving the warmup result does not mean the resident has released its busy mutex. Wait for that mutex to disappear before submitting the debugger request, register the resident for cleanup before waiting, and report the client exit type if the request unexpectedly finishes. The original debugger assertions remain intact.

### Compatibility

<!-- Delete if not applicable. Note affected modes/platforms and changes to defaults,
diagnostics, APIs or protocols, including compatibility between older and newer hosts. -->
Scoped to experimental, opt-in MT behavior; no additional ChangeWave. Non-MT routing, explicitly disabled server use, and `-mt -nr:false` remain unchanged. No new user-facing diagnostics, public APIs, or wire-format changes. The final in-process fallback remains available and does not guarantee Server GC. The Linux follow-up changes test synchronization only, not production admission behavior.

### Testing

<!-- Give relevant evidence, including commands/results and any coverage gaps.
For MT/lifecycle changes, consider repeated builds, cancellation and mixed-version hosts
where relevant; a full matrix is not required for every change. -->
- CLI/test builds succeeded for `net11.0` and `net472`.
- Original focused Windows group: all 12 cases passed (ten retry/fallback cases plus concurrent-transient and resident-survival regressions). Post-Linux-fix Windows group: all 12 cases passed (ten retry/fallback cases plus warm/cold debugger cases).
- Linux, pinned SDK `11.0.100-rc.1.26420.103`: 20 single-CPU, coverage-enabled runs passed all 280 selected cases, including 20 warm and 20 cold debugger cases, 40 in-process debugger opt-out cases, and 200 retry/fallback cases. No skipped cases.
- Controlled Linux handoff experiment: temporarily delayed the server after sending its result but before releasing its busy mutex. The original warm debugger test failed with `ServerBusy`; with the same delay, the synchronized test passed. Removed the diagnostic delay, rebuilt, and warm/cold cases passed again. No diagnostic delay is part of this PR. The unmodified baseline did not fail naturally in 20 runs; the controlled experiment demonstrates the race mechanism rather than claiming a natural reproduction of the CI run.
- Repeated the overlapping plain `-mt` experiment with node reuse left at its default. `GCSettings.IsServerGC` was read inside the build process, not a TaskHost, with no GC environment overrides.

| Binaries | First build | Concurrent second build |
| --- | --- | --- |
| Daily SDK `11.0.100-rc.2.26459.117` | Resident, Server GC `True` | Client/in-process, Server GC `False` |
| Local bootstrap with this change | Resident PID 384996, Server GC `True` | Private server PID 390232, Server GC `True` |

The second changed build's diagnostic log records a server started for this build only; its process has a unique `/serverinstanceid` and exits afterward.

CI build 1591186's Linux Core failure was `ServerOnlyDebuggingWaitsBeforeEvaluation(warmServer: True)`; the cold case and all ten new retry/fallback cases passed. The follow-up above addresses its result-before-idle race. Fresh CI is pending after the fix.

Earlier local caveat: `MultiThreadedServerProcessUsesServerGC`, which launches from the unit-test output layout, failed in isolation with an uncontended `UnableToConnect`. It does not enter the new busy-retry branch. The bootstrap-based coverage and live probe pass; that separate layout failure is not changed here. No full local suite was run.

### Dependencies and Follow-up

<!-- Delete if none. Link companion PRs and required merge order, plus tracking issues
for any remaining downstream integration, backport, documentation or partner acceptance. -->
Uses the already-merged #14647 transient-server infrastructure. Full TaskHost ownership and handling a resident originally started with Workstation GC remain outside this change.