### PR TITLE
Reduce allocations when logging project configuration descriptions

### DIFF
--- a/src/Build.UnitTests/Collections/CopyOnReadEnumerable_Tests.cs
+++ b/src/Build.UnitTests/Collections/CopyOnReadEnumerable_Tests.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System.Collections.Generic;
+using System.Threading;
 using Microsoft.Build.Collections;
 using Shouldly;
 using Xunit;
@@ -52,6 +53,54 @@ namespace Microsoft.Build.UnitTests.OM.Collections
                 actualCount++;
             }
             actualCount.ShouldBe(expectedCount);
+        }
+
+        [Fact]
+        public void FiltersBeforeCopyingAndPreservesSnapshotSemantics()
+        {
+            List<string> values = ["a", "b", "c"];
+            List<string> copied = [];
+            var enumerable = new CopyOnReadEnumerable<string, string>(values, values, value =>
+            {
+                Monitor.IsEntered(values).ShouldBeTrue();
+                copied.Add(value);
+                return value.ToUpperInvariant();
+            });
+            var filtered = enumerable.Filter(value =>
+            {
+                Monitor.IsEntered(values).ShouldBeTrue();
+                return value != "b";
+            });
+            copied.ShouldBeEmpty();
+
+            using var enumerator = filtered.GetEnumerator();
+            copied.ShouldBe(["a", "c"]);
+            values.Add("d");
+
+            enumerator.MoveNext().ShouldBeTrue();
+            enumerator.Current.ShouldBe("A");
+            enumerator.MoveNext().ShouldBeTrue();
+            enumerator.Current.ShouldBe("C");
+            enumerator.MoveNext().ShouldBeFalse();
+
+            filtered.ShouldBe(["A", "C", "D"]);
+            copied.ShouldBe(["a", "c", "a", "c", "d"]);
+            enumerable.ShouldBe(["A", "B", "C", "D"]);
+        }
+
+        [Fact]
+        public void FiltersWithNoMatchesDoNotCopyItems()
+        {
+            List<int> values = [1, 2, 3];
+            int copies = 0;
+            var enumerable = new CopyOnReadEnumerable<int, int>(values, values, value =>
+            {
+                copies++;
+                return value;
+            });
+
+            enumerable.Filter(static _ => false).ShouldBeEmpty();
+            copies.ShouldBe(0);
         }
     }
 }

--- a/src/Build.UnitTests/ConsoleLogger_Tests.cs
+++ b/src/Build.UnitTests/ConsoleLogger_Tests.cs
@@ -10,6 +10,7 @@ using System.Runtime.Versioning;
 using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Collections;
 using Microsoft.Build.Construction;
 using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
@@ -267,6 +268,66 @@ namespace Microsoft.Build.UnitTests
             p.Build().ShouldBeFalse();
             sc.ToString().ShouldContain("source_of_error : error : Hello from project 1 [" + project.ProjectFile + "::Number=1]");
             sc.ToString().ShouldContain("source_of_error : error : Hello from project 2 [" + project.ProjectFile + "::Number=2]");
+        }
+
+        [Theory]
+        [InlineData(0, "ProjectConfigurationDescription")]
+        [InlineData(1, "projectconfigurationdescription")]
+        [InlineData(2, "PROJECTCONFIGURATIONDESCRIPTION")]
+        public void ProjectConfigurationDescriptionDoesNotCopyUnrelatedItems(int descriptionCount, string itemType)
+        {
+            using var env = TestEnvironment.Create(_output);
+            var collection = env.CreateProjectCollection();
+            var project = new ProjectInstance(ProjectRootElement.Create(collection.Collection));
+            project.AddItem("Compile", "File.cs");
+            project.AddItem("Reference", "Reference.dll");
+
+            List<string> expectedDescriptions = [];
+            for (int i = 0; i < descriptionCount; i++)
+            {
+                string description = $"Configuration;{i}";
+                project.AddItem(itemType, description);
+                expectedDescriptions.Add(description);
+            }
+
+            List<string> copiedItemTypes = [];
+            var items = new CopyOnReadEnumerable<ProjectItemInstance, DictionaryEntry>(
+                project.Items,
+                new object(),
+                item =>
+                {
+                    copiedItemTypes.Add(item.ItemType);
+                    return new DictionaryEntry(item.ItemType, new TaskItem(item));
+                });
+            var logger = new ParallelConsoleLogger(LoggerVerbosity.Minimal, static _ => { }, null, null);
+            logger.Initialize(new EventSourceSink(), 2);
+            BuildEventContext context = new(1, 2, 3, 4);
+            var projectStarted = new ProjectStartedEventArgs(-1, null, null, "project.proj", null, null, items, context)
+            {
+                BuildEventContext = context
+            };
+
+            logger.ProjectStartedHandler(null, projectStarted);
+
+            copiedItemTypes.Count.ShouldBe(descriptionCount);
+            copiedItemTypes.ShouldAllBe(type => type == itemType);
+            if (descriptionCount == 0)
+            {
+                logger.propertyOutputMap.ShouldBeEmpty();
+            }
+            else
+            {
+                logger.propertyOutputMap[(context.NodeId, context.ProjectContextId)]
+                    .ShouldBe(string.Join(" ", expectedDescriptions));
+            }
+
+            copiedItemTypes.Clear();
+            foreach (DictionaryEntry item in items)
+            {
+                item.Value.ShouldBeOfType<TaskItem>();
+            }
+            copiedItemTypes.Count.ShouldBe(descriptionCount + 2);
+            logger.Shutdown();
         }
 
         [Theory]

--- a/src/Build/Collections/CopyOnReadEnumerable.cs
+++ b/src/Build/Collections/CopyOnReadEnumerable.cs
@@ -49,6 +49,15 @@ namespace Microsoft.Build.Collections
             _selector = selector;
         }
 
+        /// <summary>
+        /// Filters the backing collection before copying and projecting its items.
+        /// The predicate and selector run under the same lock when the result is enumerated.
+        /// </summary>
+        internal CopyOnReadEnumerable<TSource, TResult> Filter(Func<TSource, bool> predicate)
+        {
+            return new CopyOnReadEnumerable<TSource, TResult>(_backingEnumerable.Where(predicate), _syncRoot, _selector);
+        }
+
         #region IEnumerable<T> Members
 
         /// <summary>

--- a/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
+++ b/src/Build/Logging/ParallelLogger/ParallelConsoleLogger.cs
@@ -6,7 +6,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using Microsoft.Build.Collections;
 using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Shared;
 using ColorResetter = Microsoft.Build.Logging.ColorResetter;
@@ -607,6 +609,13 @@ namespace Microsoft.Build.BackEnd.Logging
             if (items == null)
             {
                 return null;
+            }
+
+            if (items is CopyOnReadEnumerable<ProjectItemInstance, DictionaryEntry> copyOnReadItems)
+            {
+                // Filter before the selector snapshots every item and its metadata.
+                items = copyOnReadItems.Filter(static item =>
+                    string.Equals(item.ItemType, ItemMetadataNames.ProjectConfigurationDescription, StringComparison.OrdinalIgnoreCase));
             }
 
             ReuseableStringBuilder projectConfigurationDescription = null;

--- a/src/MSBuild.Benchmarks/ProjectConfigurationDescriptionBenchmark.cs
+++ b/src/MSBuild.Benchmarks/ProjectConfigurationDescriptionBenchmark.cs
@@ -1,0 +1,62 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections;
+using BenchmarkDotNet.Attributes;
+using Microsoft.Build.BackEnd.Logging;
+using Microsoft.Build.Collections;
+using Microsoft.Build.Construction;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+using TaskItem = Microsoft.Build.Execution.ProjectItemInstance.TaskItem;
+
+namespace MSBuild.Benchmarks;
+
+[MemoryDiagnoser]
+public class ProjectConfigurationDescriptionBenchmark
+{
+    private ProjectCollection _projectCollection = null!;
+    private ProjectStartedEventArgs _projectStarted = null!;
+
+    [Params(0, 2)]
+    public int DescriptionCount { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _projectCollection = new ProjectCollection();
+        ProjectInstance project = new(ProjectRootElement.Create(_projectCollection));
+        for (int i = 0; i < 10_000; i++)
+        {
+            project.AddItem("Compile", $"File{i}.cs");
+        }
+
+        for (int i = 0; i < DescriptionCount; i++)
+        {
+            project.AddItem("ProjectConfigurationDescription", $"Configuration{i}");
+        }
+
+        var items = new CopyOnReadEnumerable<ProjectItemInstance, DictionaryEntry>(
+            project.Items,
+            new object(),
+            static item => new DictionaryEntry(item.ItemType, new TaskItem(item)));
+        BuildEventContext context = new(1, 2, 3, 4);
+        _projectStarted = new ProjectStartedEventArgs(-1, string.Empty, string.Empty, "project.proj", null, null, items, context)
+        {
+            BuildEventContext = context
+        };
+    }
+
+    [Benchmark]
+    public void ProjectStarted()
+    {
+        var logger = new ParallelConsoleLogger(LoggerVerbosity.Minimal, static _ => { }, null, null);
+        logger.Initialize(new EventSourceSink(), 2);
+        logger.ProjectStartedHandler(null, _projectStarted);
+        logger.Shutdown();
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _projectCollection.Dispose();
+}


### PR DESCRIPTION
Reading project configuration descriptions copies every project item before discarding unrelated items. Only matching descriptions now incur snapshot allocations; locking, ordering, metadata isolation, and other consumers remain unchanged.

In the focused x64 .NET Framework benchmark with 10,000 unrelated items, allocations fall from about 1,024 KiB to 5 KiB per project-start event. This is not an end-to-end build measurement.