### PR TITLE
Isolate the MSBuild debug-log directory per test process

### DIFF
--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -250,7 +250,7 @@ namespace Microsoft.Build.UnitTests
 
             // Use a process-specific debug path, nested under the ambient one (Arcade sets it build-wide)
             //  This is so multiple test projects can be run in parallel without sharing the same debug directory
-            string ambientDebugPath = Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
+            string ambientDebugPath = FileUtilities.TrimAndStripAnyQuotes(Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH"));
             if (!string.IsNullOrEmpty(ambientDebugPath))
             {
                 _testEnvironment.SetEnvironmentVariable(

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Build.UnitTests
                     "MSBUILDDEBUGPATH",
                     Path.Combine(ambientDebugPath, $"test_{EnvironmentUtilities.CurrentProcessId}"));
 
-                // Lets re-resolve FrameworkDebugUtils.DebugPath, which is cached, so it picks up new MSBUILDDEBUGPATH
+                // Let's re-resolve FrameworkDebugUtils.DebugPath, which is cached, so it picks up new MSBUILDDEBUGPATH
                 FrameworkDebugUtils.SetDebugPath();
             }
 

--- a/src/Shared/UnitTests/TestAssemblyInfo.cs
+++ b/src/Shared/UnitTests/TestAssemblyInfo.cs
@@ -248,6 +248,19 @@ namespace Microsoft.Build.UnitTests
             _testEnvironment.SetEnvironmentVariable("MSBuildExtensionsPath32", null);
             _testEnvironment.SetEnvironmentVariable("MSBuildExtensionsPath64", null);
 
+            // Use a process-specific debug path, nested under the ambient one (Arcade sets it build-wide)
+            //  This is so multiple test projects can be run in parallel without sharing the same debug directory
+            string ambientDebugPath = Environment.GetEnvironmentVariable("MSBUILDDEBUGPATH");
+            if (!string.IsNullOrEmpty(ambientDebugPath))
+            {
+                _testEnvironment.SetEnvironmentVariable(
+                    "MSBUILDDEBUGPATH",
+                    Path.Combine(ambientDebugPath, $"test_{EnvironmentUtilities.CurrentProcessId}"));
+
+                // Lets re-resolve FrameworkDebugUtils.DebugPath, which is cached, so it picks up new MSBUILDDEBUGPATH
+                FrameworkDebugUtils.SetDebugPath();
+            }
+
             // Use a project-specific temporary path
             //  This is so multiple test projects can be run in parallel without sharing the same temp directory
             var subdirectory = Path.GetRandomFileName();


### PR DESCRIPTION
Related issue(s):

### Context

`BuildFailureLogInvariant` flakes in `msbuild-pr` CI, in both directions (`Expected: 1, Actual: 2` and `Expected: 2, Actual: 1`).

It scans three directories for `MSBuild_*.txt`. Two are process-private; the third — `FrameworkDebugUtils.DebugPath`, added by #14224 — resolves to the single build-wide folder Arcade sets via `MSBUILDDEBUGPATH`. Test assemblies run in parallel as separate processes, and `AssertInvariant` deletes files it considers new *before* applying its benign-file filters, so they destroy each other's files.

### Changes Made

Give each test process a `test_<pid>` subfolder, applying the isolation pattern already used for the temp path just below it.

Nested under the Arcade path so the logs are still published as a CI artifact. No-op when the variable is unset.

`BuildFailureLogInvariant` is deliberately unchanged: once all three scanned directories are process-private, its existing logic is correct as written.
