### PR TITLE
Reduce allocations when matching composite globs

### DIFF
--- a/src/Build.UnitTests/Globbing/CompositeGlob_Tests.cs
+++ b/src/Build.UnitTests/Globbing/CompositeGlob_Tests.cs
@@ -2,8 +2,11 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Microsoft.Build.Globbing;
 using Microsoft.Build.Globbing.Extensions;
 using Xunit;
@@ -169,5 +172,179 @@ namespace Microsoft.Build.Engine.UnitTests.Globbing
             Assert.Same(glob2, composite.Globs.Skip(1).First());
             Assert.Equal(2, composite.Globs.Count());
         }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("File.cs")]
+        [InlineData("src/File.cs")]
+        [InlineData("src/../File.cs")]
+        [InlineData("../File.cs")]
+        [InlineData("obj/File.cs")]
+        [InlineData("src/File.vb")]
+        [InlineData("src/FILE.CS")]
+        [InlineData("src\\File.cs")]
+        [InlineData("src/./nested/../File.cs")]
+        [InlineData("src/\0File.cs")]
+        public void NestedMatchingPreservesIndependentNormalization(string input)
+        {
+            string root = Path.Combine(Path.GetTempPath(), "GlobRoot");
+            string otherRoot = Path.Combine(root, "other");
+            var glob = new CompositeGlob(
+                MSBuildGlob.Parse(root, "**/*.txt"),
+                new MSBuildGlobWithGaps(
+                    new CompositeGlob(
+                        MSBuildGlob.Parse(otherRoot, "**/*.vb"),
+                        MSBuildGlob.Parse(root, "**/*.cs")),
+                    MSBuildGlob.Parse(root, "**/obj/**"),
+                    MSBuildGlob.Parse(otherRoot, "**/bin/**")),
+                MSBuildGlob.Parse(root, "fallback/*"));
+
+            Assert.Equal(MatchIndependently(glob, input), glob.IsMatch(input));
+
+            if (input.IndexOf('\0') < 0)
+            {
+                string absoluteInput = Path.Combine(root, input);
+                Assert.Equal(MatchIndependently(glob, absoluteInput), glob.IsMatch(absoluteInput));
+            }
+        }
+
+        [Fact]
+        public void DifferentRootsDoNotShareNormalizedInput()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "GlobRoot");
+            string otherRoot = Path.Combine(root, "other");
+            var glob = new CompositeGlob(
+                MSBuildGlob.Parse(root, "**/*.txt"),
+                MSBuildGlob.Parse(otherRoot, Path.Combine(root, "*.cs")));
+
+            Assert.False(glob.IsMatch("File.cs"));
+            Assert.True(glob.IsMatch(Path.Combine(root, "File.cs")));
+        }
+
+        [Fact]
+        public void MatchContextReusesOnlyTheCurrentRootsNormalization()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "GlobRoot");
+            string otherRoot = Path.Combine(root, "other");
+            var context = new GlobMatchContext("File.cs");
+            string normalizedInput = context.GetNormalizedInput(root);
+
+            Assert.Same(normalizedInput, context.GetNormalizedInput(root));
+            Assert.Equal(Path.Combine(otherRoot, "File.cs"), context.GetNormalizedInput(otherRoot));
+            string normalizedAgain = context.GetNormalizedInput(root);
+            Assert.Equal(normalizedInput, normalizedAgain);
+
+            context.IsMatch(new CallbackGlob(_ => false));
+            Assert.NotSame(normalizedAgain, context.GetNormalizedInput(root));
+        }
+
+        [Fact]
+        public void CustomMatchersReceiveOriginalInputAndShortCircuit()
+        {
+            const string Input = "src/../File.cs";
+            string root = Path.Combine(Path.GetTempPath(), "GlobRoot");
+            var inputs = new List<string>();
+            var glob = new CompositeGlob(
+                MSBuildGlob.Parse(root, "**/*.txt"),
+                new CallbackGlob(input =>
+                {
+                    inputs.Add(input);
+                    return false;
+                }),
+                new MSBuildGlobWithGaps(
+                    MSBuildGlob.Parse(root, "**/*.cs"),
+                    new CallbackGlob(input =>
+                    {
+                        inputs.Add(input);
+                        return false;
+                    })),
+                new CallbackGlob(_ => throw new InvalidOperationException("Matching must short circuit.")));
+
+            Assert.True(glob.IsMatch(Input));
+            Assert.Equal(new[] { Input, Input }, inputs);
+        }
+
+        [Fact]
+        public void ContextAwareMatchersShareNormalization()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "GlobRoot");
+            MSBuildGlob match = MSBuildGlob.Parse(root, "**/*.cs");
+            string normalizedInput = null;
+            var glob = new CompositeGlob(
+                new ContextAwareGlob(match.TestOnlyGlobRoot, input => normalizedInput = input),
+                new MSBuildGlobWithGaps(
+                    match,
+                    new ContextAwareGlob(match.TestOnlyGlobRoot, input => Assert.Same(normalizedInput, input))));
+
+            Assert.True(glob.IsMatch("File.cs"));
+            Assert.Equal(Path.Combine(root, "File.cs"), normalizedInput);
+        }
+
+        [Fact]
+        public void DerivedMatchersKeepTheirInheritedImplementation()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "GlobRoot");
+            MSBuildGlob match = MSBuildGlob.Parse(root, "**/*.cs");
+
+            Assert.True(new CompositeGlob(new DerivedCompositeGlob(match)).IsMatch("File.cs"));
+            Assert.True(new CompositeGlob(new DerivedGlobWithGaps(match)).IsMatch("File.cs"));
+        }
+
+        [Fact]
+        public void EmptyCompositeDoesNotValidateInput()
+        {
+            Assert.False(new CompositeGlob().IsMatch(null));
+            Assert.True(new CompositeGlob(new CallbackGlob(input => input is null)).IsMatch(null));
+            Assert.Throws<ArgumentNullException>(() =>
+                new CompositeGlob(MSBuildGlob.Parse("*")).IsMatch(null));
+        }
+
+        [Fact]
+        public void MatchingDoesNotShareStateAcrossCalls()
+        {
+            string root = Path.Combine(Path.GetTempPath(), "GlobRoot");
+            var glob = new MSBuildGlobWithGaps(
+                MSBuildGlob.Parse(root, "**/*.cs"),
+                MSBuildGlob.Parse(root, "**/obj/**"));
+            var composite = new CompositeGlob(glob, MSBuildGlob.Parse(root, "**/*.vb"));
+            string[] inputs = { "src/File.cs", "obj/File.cs", "src/File.txt", "src/File.vb", "" };
+            bool[] expected = inputs.Select(input => MatchIndependently(composite, input)).ToArray();
+
+            Parallel.For(0, 1000, i =>
+            {
+                int index = i % inputs.Length;
+                Assert.Equal(expected[index], composite.IsMatch(inputs[index]));
+            });
+        }
+
+        private static bool MatchIndependently(IMSBuildGlob glob, string input)
+        {
+            return glob switch
+            {
+                CompositeGlob composite => composite.Globs.Any(child => MatchIndependently(child, input)),
+                MSBuildGlobWithGaps gaps => MatchIndependently(gaps.MainGlob, input) && !MatchIndependently(gaps.Gaps, input),
+                _ => glob.IsMatch(input)
+            };
+        }
+
+        private sealed class CallbackGlob(Func<string, bool> callback) : IMSBuildGlob
+        {
+            public bool IsMatch(string input) => callback(input);
+        }
+
+        private sealed class ContextAwareGlob(string root, Action<string> callback) : IMSBuildGlob, IContextAwareGlob
+        {
+            public bool IsMatch(string input) => throw new InvalidOperationException("The context-aware implementation must be used.");
+
+            bool IContextAwareGlob.IsMatch(ref GlobMatchContext context)
+            {
+                callback(context.GetNormalizedInput(root));
+                return false;
+            }
+        }
+
+        private sealed class DerivedCompositeGlob(IMSBuildGlob glob) : CompositeGlob(glob);
+
+        private sealed class DerivedGlobWithGaps(IMSBuildGlob glob) : MSBuildGlobWithGaps(glob);
     }
 }

--- a/src/Build/Globbing/CompositeGlob.cs
+++ b/src/Build/Globbing/CompositeGlob.cs
@@ -4,7 +4,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 
 namespace Microsoft.Build.Globbing
 {
@@ -12,7 +11,7 @@ namespace Microsoft.Build.Globbing
     ///     A composite glob that returns a match for an input if any of its
     ///     inner globs match the input (disjunction).
     /// </summary>
-    public class CompositeGlob : IMSBuildGlob
+    public class CompositeGlob : IMSBuildGlob, IContextAwareGlob
     {
         private readonly ImmutableArray<IMSBuildGlob> _globs;
 
@@ -58,10 +57,25 @@ namespace Microsoft.Build.Globbing
         /// <inheritdoc />
         public bool IsMatch(string stringToMatch)
         {
-            // Threadpools are a scarce resource in Visual Studio, do not use them.
-            // return Globs.AsParallel().Any(g => g.IsMatch(stringToMatch));
+            var context = new GlobMatchContext(stringToMatch);
+            return IsMatch(ref context);
+        }
 
-            return _globs.Any(static (glob, str) => glob.IsMatch(str), stringToMatch);
+        bool IContextAwareGlob.IsMatch(ref GlobMatchContext context) => IsMatch(ref context);
+
+        private bool IsMatch(ref GlobMatchContext context)
+        {
+            // Do not be tempted to turn this into a LINQ query or to parallelize it. This is a very hot allocation path,
+            // and thread pool threads are a scarce resource in Visual Studio.
+            foreach (IMSBuildGlob glob in _globs)
+            {
+                if (context.IsMatch(glob))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/src/Build/Globbing/GlobMatchContext.cs
+++ b/src/Build/Globbing/GlobMatchContext.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System;
+
+namespace Microsoft.Build.Globbing;
+
+/// <summary>
+/// Reuses path normalization within a single composite match without retaining input paths.
+/// </summary>
+internal struct GlobMatchContext(string stringToMatch)
+{
+    private string? _globRoot;
+    private string? _normalizedInput;
+
+    internal string StringToMatch { get; } = stringToMatch;
+
+    internal string GetNormalizedInput(string globRoot)
+    {
+        if (_normalizedInput is null || !string.Equals(_globRoot, globRoot, StringComparison.Ordinal))
+        {
+            _normalizedInput = MSBuildGlob.NormalizeMatchInput(globRoot, StringToMatch);
+            _globRoot = globRoot;
+        }
+
+        return _normalizedInput;
+    }
+
+    internal bool IsMatch(IMSBuildGlob glob)
+    {
+        if (glob is IContextAwareGlob contextAwareGlob)
+        {
+            return contextAwareGlob.IsMatch(ref this);
+        }
+
+        // Custom matchers may change ambient path resolution.
+        _normalizedInput = null;
+        return glob.IsMatch(StringToMatch);
+    }
+}

--- a/src/Build/Globbing/IContextAwareGlob.cs
+++ b/src/Build/Globbing/IContextAwareGlob.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace Microsoft.Build.Globbing;
+
+/// <summary>
+/// Matches globs using path normalization shared within a single matching operation.
+/// </summary>
+internal interface IContextAwareGlob
+{
+    bool IsMatch(ref GlobMatchContext context);
+}

--- a/src/Build/Globbing/MSBuildGlob.cs
+++ b/src/Build/Globbing/MSBuildGlob.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Build.Globbing
     ///     - wildcard directory part: "**/*test*/**/" in "a/b/**/*test*/**/*.cs"
     ///     - file name part: "*.cs" in "a/b/**/*test*/**/*.cs"
     /// </summary>
-    public class MSBuildGlob : IMSBuildGlob
+    public class MSBuildGlob : IMSBuildGlob, IContextAwareGlob
     {
         private readonly struct GlobState
         {
@@ -93,6 +93,15 @@ namespace Microsoft.Build.Globbing
         /// <inheritdoc />
         public bool IsMatch(string stringToMatch)
         {
+            var context = new GlobMatchContext(stringToMatch);
+            return IsMatch(ref context);
+        }
+
+        bool IContextAwareGlob.IsMatch(ref GlobMatchContext context) => IsMatch(ref context);
+
+        private bool IsMatch(ref GlobMatchContext context)
+        {
+            string stringToMatch = context.StringToMatch;
             ArgumentNullException.ThrowIfNull(stringToMatch);
 
             if (!IsLegal)
@@ -105,13 +114,13 @@ namespace Microsoft.Build.Globbing
                 return false;
             }
 
-            var normalizedString = NormalizeMatchInput(stringToMatch);
+            string normalizedString = context.GetNormalizedInput(_state.Value.GlobRoot);
 
             return _state.Value.Regex.IsMatch(normalizedString);
         }
 
         /// <summary>
-        ///     Similar to <see cref="IsMatch" /> but also provides the match groups for the glob parts
+        ///     Similar to <see cref="IsMatch(string)" /> but also provides the match groups for the glob parts
         /// </summary>
         /// <param name="stringToMatch"></param>
         /// <returns></returns>
@@ -124,7 +133,7 @@ namespace Microsoft.Build.Globbing
                 return MatchInfoResult.Empty;
             }
 
-            string normalizedInput = NormalizeMatchInput(stringToMatch);
+            string normalizedInput = NormalizeMatchInput(_state.Value.GlobRoot, stringToMatch);
 
             FileMatcher.GetRegexMatchInfo(
                 normalizedInput,
@@ -140,9 +149,9 @@ namespace Microsoft.Build.Globbing
             return new MatchInfoResult(isMatch, fixedDirectoryPart, wildcardDirectoryPart, filenamePart);
         }
 
-        private string NormalizeMatchInput(string stringToMatch)
+        internal static string NormalizeMatchInput(string globRoot, string stringToMatch)
         {
-            var rootedInput = Path.Combine(_state.Value.GlobRoot, stringToMatch);
+            var rootedInput = Path.Combine(globRoot, stringToMatch);
             var normalizedInput = FileUtilities.GetFullPathNoThrow(rootedInput);
 
             // Degenerate case when the string to match is empty.
@@ -161,7 +170,7 @@ namespace Microsoft.Build.Globbing
         /// </summary>
         /// <param name="globRoot">
         ///     The root of the glob.
-        ///     The fixed directory part of the glob and the match arguments (<see cref="IsMatch" /> and <see cref="MatchInfo" />)
+        ///     The fixed directory part of the glob and the match arguments (<see cref="IsMatch(string)" /> and <see cref="MatchInfo" />)
         ///     will get normalized against this root.
         ///     If empty, the current working directory is used.
         ///     Cannot be null, and cannot contain invalid path arguments.

--- a/src/Build/Globbing/MSBuildGlobWithGaps.cs
+++ b/src/Build/Globbing/MSBuildGlobWithGaps.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Build.Globbing
     /// )
     ///     </code>
     /// </summary>
-    public class MSBuildGlobWithGaps : IMSBuildGlob
+    public class MSBuildGlobWithGaps : IMSBuildGlob, IContextAwareGlob
     {
         /// <summary>
         ///     The main glob used for globbing operations.
@@ -71,7 +71,12 @@ namespace Microsoft.Build.Globbing
         /// <inheritdoc />
         public bool IsMatch(string stringToMatch)
         {
-            return MainGlob.IsMatch(stringToMatch) && !Gaps.IsMatch(stringToMatch);
+            var context = new GlobMatchContext(stringToMatch);
+            return IsMatch(ref context);
         }
+
+        bool IContextAwareGlob.IsMatch(ref GlobMatchContext context) => IsMatch(ref context);
+
+        private bool IsMatch(ref GlobMatchContext context) => context.IsMatch(MainGlob) && !context.IsMatch(Gaps);
     }
 }

--- a/src/Build/Microsoft.Build.csproj
+++ b/src/Build/Microsoft.Build.csproj
@@ -554,6 +554,8 @@
     <Compile Include="Evaluation\Expander\ArgumentParser.cs" />
     <Compile Include="Evaluation\Expander\WellKnownFunctions.cs" />
     <Compile Include="Globbing\CompositeGlob.cs" />
+    <Compile Include="Globbing\GlobMatchContext.cs" />
+    <Compile Include="Globbing\IContextAwareGlob.cs" />
     <Compile Include="Globbing\Extensions\MSBuildGlobExtensions.cs" />
     <Compile Include="Globbing\Visitor\GlobVisitor.cs" />
     <Compile Include="Globbing\MSBuildGlobWithGaps.cs" />


### PR DESCRIPTION
Matching a filename against composite include/exclude globs repeatedly allocates normalized copies of the same path. Reuse normalization for consecutive globs with the same root during a single match, without retaining filenames between calls. Preserve matching order, short-circuiting, and custom `IMSBuildGlob` implementations.

Allocation-stack comparison for the Visual Studio OrchardCore build workload, using the original PR revision `0d7bea47` against baseline `d257108c`:

| Allocation stacks | Baseline (MB) | Changed build (MB) | Reduction |
|---|---:|---:|---:|
| Glob path normalization | 132.7 | 40.6 | 69% |
| Glob matching, including children | 157.1 | 63.2 | 60% |