### PR TITLE
Ship TaskAnalyzer through Microsoft.Build.Framework

### DIFF
--- a/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
@@ -2110,7 +2110,7 @@ public class MultiThreadableTaskAnalyzerTests
     }
 
     [Fact]
-    public async Task Task_WithOnlyMultiThreadableInterface_DoesNotGetMtMigrationRulesByDefault()
+    public async Task Task_DeclaringMultiThreadableInterface_GetsMtMigrationRulesByDefault()
     {
         var diags = await GetDiagnosticsAsync("""
             using System;
@@ -2119,6 +2119,32 @@ public class MultiThreadableTaskAnalyzerTests
             public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
             {
                 public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute()
+                {
+                    File.Exists("foo.txt");
+                    _ = Environment.GetEnvironmentVariable("PATH");
+                    return true;
+                }
+            }
+            """);
+
+        diags.ShouldContain(d => d.Id == DiagnosticIds.FilePathRequiresAbsolute);
+        diags.ShouldContain(d => d.Id == DiagnosticIds.TaskEnvironmentRequired);
+    }
+
+    [Fact]
+    public async Task Task_InheritingMultiThreadableInterface_DoesNotGetMtMigrationRulesByDefault()
+    {
+        var diags = await GetDiagnosticsAsync("""
+            using System;
+            using System.IO;
+            using Microsoft.Build.Framework;
+            public abstract class MtBase : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; }
+            }
+            public class MyTask : MtBase
+            {
                 public override bool Execute()
                 {
                     File.Exists("foo.txt");

--- a/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
@@ -40,9 +40,7 @@ public class MultiThreadableTaskAnalyzerTests
             }
             """);
 
-        var diagnostic = diags.ShouldHaveSingleItem();
-        diagnostic.Id.ShouldBe(DiagnosticIds.CriticalError);
-        diagnostic.Severity.ShouldBe(DiagnosticSeverity.Info);
+        AssertCriticalInfoDiagnostics(diags, 1);
     }
 
     [Fact]
@@ -63,7 +61,7 @@ public class MultiThreadableTaskAnalyzerTests
             }
             """);
 
-        diags.Where(d => d.Id == DiagnosticIds.CriticalError).Count().ShouldBe(4);
+        AssertCriticalInfoDiagnostics(diags, 4);
     }
 
     [Fact]
@@ -81,7 +79,7 @@ public class MultiThreadableTaskAnalyzerTests
             }
             """);
 
-        diags.ShouldContain(d => d.Id == DiagnosticIds.CriticalError);
+        AssertCriticalInfoDiagnostics(diags, 1);
     }
 
     [Fact]
@@ -99,8 +97,7 @@ public class MultiThreadableTaskAnalyzerTests
             }
             """);
 
-        diags.ShouldContain(d => d.Id == DiagnosticIds.CriticalError);
-        diags.Length.ShouldBe(1);
+        AssertCriticalInfoDiagnostics(diags, 1);
     }
 
     [Fact]
@@ -118,7 +115,7 @@ public class MultiThreadableTaskAnalyzerTests
             }
             """);
 
-        diags.ShouldContain(d => d.Id == DiagnosticIds.CriticalError);
+        AssertCriticalInfoDiagnostics(diags, 1);
     }
 
     [Fact]
@@ -137,7 +134,7 @@ public class MultiThreadableTaskAnalyzerTests
             }
             """);
 
-        diags.Where(d => d.Id == DiagnosticIds.CriticalError).Count().ShouldBe(2);
+        AssertCriticalInfoDiagnostics(diags, 2);
     }
 
     [Fact]
@@ -156,7 +153,7 @@ public class MultiThreadableTaskAnalyzerTests
             }
             """);
 
-        diags.Where(d => d.Id == DiagnosticIds.CriticalError).Count().ShouldBe(2);
+        AssertCriticalInfoDiagnostics(diags, 2);
     }
 
     [Fact]
@@ -174,7 +171,7 @@ public class MultiThreadableTaskAnalyzerTests
             }
             """);
 
-        diags.ShouldContain(d => d.Id == DiagnosticIds.CriticalError);
+        AssertCriticalInfoDiagnostics(diags, 1);
     }
 
     [Fact]
@@ -193,7 +190,7 @@ public class MultiThreadableTaskAnalyzerTests
             }
             """);
 
-        diags.ShouldContain(d => d.Id == DiagnosticIds.CriticalError);
+        AssertCriticalInfoDiagnostics(diags, 1);
     }
 
     [Fact]
@@ -212,7 +209,7 @@ public class MultiThreadableTaskAnalyzerTests
             }
             """);
 
-        diags.Where(d => d.Id == DiagnosticIds.CriticalError).Count().ShouldBe(2);
+        AssertCriticalInfoDiagnostics(diags, 2);
     }
 
     [Theory]
@@ -248,6 +245,18 @@ public class MultiThreadableTaskAnalyzerTests
             new DiagnosticResult(DiagnosticIds.CriticalError, expectedSeverity).WithLocation(0));
 
         await test.RunAsync();
+    }
+
+    private static void AssertCriticalInfoDiagnostics(
+        System.Collections.Generic.IEnumerable<Diagnostic> diagnostics,
+        int expectedCount)
+    {
+        Diagnostic[] criticalDiagnostics = diagnostics
+            .Where(d => d.Id == DiagnosticIds.CriticalError)
+            .ToArray();
+
+        criticalDiagnostics.Length.ShouldBe(expectedCount);
+        criticalDiagnostics.ShouldAllBe(d => d.Severity == DiagnosticSeverity.Info);
     }
 
     // ═══════════════════════════════════════════════════════════════════════

--- a/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
@@ -22,11 +22,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer.Tests;
 public class MultiThreadableTaskAnalyzerTests
 {
     // ═══════════════════════════════════════════════════════════════════════
-    // MSBuildTask0001: Critical errors
+    // MSBuildTask0001: APIs that are never safe in tasks
     // ═══════════════════════════════════════════════════════════════════════
 
     [Fact]
-    public async Task ConsoleWriteLine_InAnyTask_ProducesError()
+    public async Task ConsoleWriteLine_InAnyTask_ProducesInfo()
     {
         var diags = await GetDiagnosticsAsync("""
             using System;
@@ -40,8 +40,9 @@ public class MultiThreadableTaskAnalyzerTests
             }
             """);
 
-        diags.ShouldContain(d => d.Id == DiagnosticIds.CriticalError);
-        diags.Length.ShouldBe(1);
+        var diagnostic = diags.ShouldHaveSingleItem();
+        diagnostic.Id.ShouldBe(DiagnosticIds.CriticalError);
+        diagnostic.Severity.ShouldBe(DiagnosticSeverity.Info);
     }
 
     [Fact]
@@ -66,7 +67,7 @@ public class MultiThreadableTaskAnalyzerTests
     }
 
     [Fact]
-    public async Task ConsoleOut_PropertyAccess_ProducesError()
+    public async Task ConsoleOut_PropertyAccess_ProducesDiagnostic()
     {
         var diags = await GetDiagnosticsAsync("""
             using System;
@@ -84,7 +85,7 @@ public class MultiThreadableTaskAnalyzerTests
     }
 
     [Fact]
-    public async Task EnvironmentExit_ProducesError()
+    public async Task EnvironmentExit_ProducesDiagnostic()
     {
         var diags = await GetDiagnosticsAsync("""
             using System;
@@ -103,7 +104,7 @@ public class MultiThreadableTaskAnalyzerTests
     }
 
     [Fact]
-    public async Task EnvironmentFailFast_ProducesError()
+    public async Task EnvironmentFailFast_ProducesDiagnostic()
     {
         var diags = await GetDiagnosticsAsync("""
             using System;
@@ -121,7 +122,7 @@ public class MultiThreadableTaskAnalyzerTests
     }
 
     [Fact]
-    public async Task ThreadPoolSetMinMaxThreads_ProducesError()
+    public async Task ThreadPoolSetMinMaxThreads_ProducesDiagnostics()
     {
         var diags = await GetDiagnosticsAsync("""
             using System.Threading;
@@ -140,7 +141,7 @@ public class MultiThreadableTaskAnalyzerTests
     }
 
     [Fact]
-    public async Task CultureInfoDefaults_ProducesError()
+    public async Task CultureInfoDefaults_ProduceDiagnostics()
     {
         var diags = await GetDiagnosticsAsync("""
             using System.Globalization;
@@ -159,7 +160,7 @@ public class MultiThreadableTaskAnalyzerTests
     }
 
     [Fact]
-    public async Task ConsoleReadLine_ProducesError()
+    public async Task ConsoleReadLine_ProducesDiagnostic()
     {
         var diags = await GetDiagnosticsAsync("""
             using System;
@@ -177,7 +178,7 @@ public class MultiThreadableTaskAnalyzerTests
     }
 
     [Fact]
-    public async Task ProcessKill_InAnyTask_ProducesError()
+    public async Task ProcessKill_InAnyTask_ProducesDiagnostic()
     {
         var diags = await GetDiagnosticsAsync("""
             using System.Diagnostics;
@@ -212,6 +213,41 @@ public class MultiThreadableTaskAnalyzerTests
             """);
 
         diags.Where(d => d.Id == DiagnosticIds.CriticalError).Count().ShouldBe(2);
+    }
+
+    [Theory]
+    [InlineData("warning", DiagnosticSeverity.Warning)]
+    [InlineData("error", DiagnosticSeverity.Error)]
+    public async Task MSBuildTask0001_ConfiguredSeverity_OverridesInfoDefault(
+        string configuredSeverity,
+        DiagnosticSeverity expectedSeverity)
+    {
+        var test = new CSharpAnalyzerTest<MultiThreadableTaskAnalyzer, DefaultVerifier>
+        {
+            TestCode = """
+                using System;
+                public class MyTask : Microsoft.Build.Utilities.Task
+                {
+                    public override bool Execute()
+                    {
+                        {|#0:Console.WriteLine("hello")|};
+                        return true;
+                    }
+                }
+                """,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+        test.TestState.Sources.Add(("Stubs.cs", FrameworkStubs));
+        test.TestState.AnalyzerConfigFiles.Add(("/.editorconfig", $$"""
+            root = true
+
+            [*.cs]
+            dotnet_diagnostic.MSBuildTask0001.severity = {{configuredSeverity}}
+            """));
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult(DiagnosticIds.CriticalError, expectedSeverity).WithLocation(0));
+
+        await test.RunAsync();
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -1350,7 +1386,7 @@ public class MultiThreadableTaskAnalyzerTests
     // ═══════════════════════════════════════════════════════════════════════
 
     [Fact]
-    public async Task DirectorySetCurrentDirectory_ProducesCriticalError()
+    public async Task DirectorySetCurrentDirectory_ProducesDiagnostic()
     {
         var diags = await GetDiagnosticsAsync("""
             using System.IO;
@@ -1542,7 +1578,7 @@ public class MultiThreadableTaskAnalyzerTests
     }
 
     [Fact]
-    public async Task ConsoleSetOut_TypeLevelBan_ProducesError()
+    public async Task ConsoleSetOut_TypeLevelBan_ProducesDiagnostic()
     {
         var diags = await GetDiagnosticsAsync("""
             using System;
@@ -1560,7 +1596,7 @@ public class MultiThreadableTaskAnalyzerTests
     }
 
     [Fact]
-    public async Task ConsoleForegroundColor_TypeLevelBan_ProducesError()
+    public async Task ConsoleForegroundColor_TypeLevelBan_ProducesDiagnostic()
     {
         var diags = await GetDiagnosticsAsync("""
             using System;
@@ -1578,7 +1614,7 @@ public class MultiThreadableTaskAnalyzerTests
     }
 
     [Fact]
-    public async Task ConsoleTitle_TypeLevelBan_ProducesError()
+    public async Task ConsoleTitle_TypeLevelBan_ProducesDiagnostic()
     {
         var diags = await GetDiagnosticsAsync("""
             using System;

--- a/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/MultiThreadableTaskAnalyzerTests.cs
@@ -2485,6 +2485,33 @@ public class MultiThreadableTaskAnalyzerTests
     }
 
     [Fact]
+    public async Task DefaultConfiguration_InterfaceDeclaringDerivedTask_AnalyzesUnsafeBaseTaskMethod()
+    {
+        var diags = await GetAllDiagnosticsWithDefaultConfigurationAsync("""
+            using System;
+            using System.IO;
+            using Microsoft.Build.Framework;
+            public abstract class MyBaseTask : Microsoft.Build.Utilities.Task
+            {
+                protected bool UsesProcessState()
+                {
+                    _ = Environment.GetEnvironmentVariable("KEY");
+                    return File.Exists("relative.txt");
+                }
+            }
+            public class MyMtTask : MyBaseTask, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute() => UsesProcessState();
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.TaskEnvironmentRequired).ShouldHaveSingleItem();
+        diags.Where(d => d.Id == DiagnosticIds.FilePathRequiresAbsolute).ShouldHaveSingleItem();
+        diags.Where(d => d.Id == DiagnosticIds.TransitiveUnsafeCall).ShouldBeEmpty();
+    }
+
+    [Fact]
     public async Task DefaultConfiguration_MultiThreadableTask_ReportsOnlyDirectDiagnosticsForContributingNonTaskBase()
     {
         var diags = await GetAllDiagnosticsWithDefaultConfigurationAsync("""

--- a/src/TaskAnalyzer.Tests/TestHelpers.cs
+++ b/src/TaskAnalyzer.Tests/TestHelpers.cs
@@ -233,25 +233,6 @@ internal static class TestHelpers
     }
 
     /// <summary>
-    /// Runs the UnsupportedTaskItemTypeAnalyzer with an explicit severity configured for a single rule,
-    /// mirroring a <c>dotnet_diagnostic.&lt;ID&gt;.severity</c> entry in an .editorconfig.
-    /// </summary>
-    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetUnsupportedTaskItemTypeDiagnosticsWithConfiguredSeverityAsync(
-        string source,
-        string diagnosticId,
-        ReportDiagnostic reportDiagnostic)
-    {
-        var compilation = CreateCompilation(source);
-        compilation = compilation.WithOptions(compilation.Options.WithSpecificDiagnosticOptions(
-            ImmutableDictionary<string, ReportDiagnostic>.Empty.Add(diagnosticId, reportDiagnostic)));
-
-        var compilationWithAnalyzers = compilation.WithAnalyzers(
-            ImmutableArray.Create<DiagnosticAnalyzer>(new UnsupportedTaskItemTypeAnalyzer()));
-
-        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
-    }
-
-    /// <summary>
     /// Creates a compilation with the given source code and framework stubs.
     /// </summary>
     public static CSharpCompilation CreateCompilation(string source)

--- a/src/TaskAnalyzer.Tests/TestHelpers.cs
+++ b/src/TaskAnalyzer.Tests/TestHelpers.cs
@@ -233,6 +233,25 @@ internal static class TestHelpers
     }
 
     /// <summary>
+    /// Runs the UnsupportedTaskItemTypeAnalyzer with an explicit severity configured for a single rule,
+    /// mirroring a <c>dotnet_diagnostic.&lt;ID&gt;.severity</c> entry in an .editorconfig.
+    /// </summary>
+    public static async System.Threading.Tasks.Task<ImmutableArray<Diagnostic>> GetUnsupportedTaskItemTypeDiagnosticsWithConfiguredSeverityAsync(
+        string source,
+        string diagnosticId,
+        ReportDiagnostic reportDiagnostic)
+    {
+        var compilation = CreateCompilation(source);
+        compilation = compilation.WithOptions(compilation.Options.WithSpecificDiagnosticOptions(
+            ImmutableDictionary<string, ReportDiagnostic>.Empty.Add(diagnosticId, reportDiagnostic)));
+
+        var compilationWithAnalyzers = compilation.WithAnalyzers(
+            ImmutableArray.Create<DiagnosticAnalyzer>(new UnsupportedTaskItemTypeAnalyzer()));
+
+        return await compilationWithAnalyzers.GetAnalyzerDiagnosticsAsync();
+    }
+
+    /// <summary>
     /// Creates a compilation with the given source code and framework stubs.
     /// </summary>
     public static CSharpCompilation CreateCompilation(string source)

--- a/src/TaskAnalyzer.Tests/TransitiveCallChainAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/TransitiveCallChainAnalyzerTests.cs
@@ -505,7 +505,7 @@ public class TransitiveCallChainAnalyzerTests
     }
 
     [Fact]
-    public async Task DefaultConfiguration_InterfaceOnlyTask_DoesNotGetMtMigrationTransitiveDiagnostic()
+    public async Task DefaultConfiguration_TaskDeclaringInterface_GetsMtMigrationTransitiveDiagnostic()
     {
         var diags = await GetAllDiagnosticsWithDefaultConfigurationAsync("""
             using System;
@@ -517,6 +517,33 @@ public class TransitiveCallChainAnalyzerTests
             public class MyTask : Microsoft.Build.Utilities.Task, IMultiThreadableTask
             {
                 public TaskEnvironment TaskEnvironment { get; set; }
+                public override bool Execute()
+                {
+                    Helper.Run();
+                    return true;
+                }
+            }
+            """);
+
+        diags.Where(d => d.Id == DiagnosticIds.TransitiveUnsafeCall).ShouldHaveSingleItem();
+    }
+
+    [Fact]
+    public async Task DefaultConfiguration_TaskInheritingInterface_DoesNotGetMtMigrationTransitiveDiagnostic()
+    {
+        var diags = await GetAllDiagnosticsWithDefaultConfigurationAsync("""
+            using System;
+            using Microsoft.Build.Framework;
+            public static class Helper
+            {
+                public static void Run() => Environment.GetEnvironmentVariable("KEY");
+            }
+            public abstract class MtBase : Microsoft.Build.Utilities.Task, IMultiThreadableTask
+            {
+                public TaskEnvironment TaskEnvironment { get; set; }
+            }
+            public class MyTask : MtBase
+            {
                 public override bool Execute()
                 {
                     Helper.Run();

--- a/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
@@ -46,7 +46,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
     [InlineData("double")]
     [InlineData("decimal")]
     [InlineData("System.DateTime")]
-    public async Task ConvertChangeTypeType_ProducesWarning(string typeName)
+    public async Task ConvertChangeTypeType_ProducesInfoDiagnostic(string typeName)
     {
         var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync($$"""
             using Microsoft.Build.Framework;
@@ -60,7 +60,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
         diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
         Diagnostic diagnostic = diags.ShouldHaveSingleItem();
         diagnostic.Id.ShouldBe(DiagnosticIds.CultureSensitiveTaskItemType);
-        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
+        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Info);
         diagnostic.GetMessage().ShouldContain("Convert.ChangeType");
         diagnostic.GetMessage().ShouldContain("CultureInfo.InvariantCulture");
     }
@@ -117,7 +117,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
     // ═══════════════════════════════════════════════════════════════════════
 
     [Fact]
-    public async Task ConvertChangeTypeArray_ProducesWarning()
+    public async Task ConvertChangeTypeArray_ProducesInfoDiagnostic()
     {
         var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
             using Microsoft.Build.Framework;
@@ -130,7 +130,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
 
         Diagnostic diagnostic = diags.ShouldHaveSingleItem();
         diagnostic.Id.ShouldBe(DiagnosticIds.CultureSensitiveTaskItemType);
-        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
+        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Info);
     }
 
     [Fact]
@@ -150,7 +150,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
     }
 
     [Fact]
-    public async Task ConvertChangeTypeOutputProperty_ProducesWarning()
+    public async Task ConvertChangeTypeOutputProperty_ProducesInfoDiagnostic()
     {
         var diags = await GetUnsupportedTaskItemTypeDiagnosticsAsync("""
             using Microsoft.Build.Framework;
@@ -164,7 +164,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
 
         Diagnostic diagnostic = diags.ShouldHaveSingleItem();
         diagnostic.Id.ShouldBe(DiagnosticIds.CultureSensitiveTaskItemType);
-        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
+        diagnostic.Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Info);
     }
 
     [Fact]
@@ -202,7 +202,7 @@ public class UnsupportedTaskItemTypeAnalyzerTests
             """);
 
         diags.ShouldContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
-        diags.ShouldHaveSingleItem().Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
+        diags.ShouldHaveSingleItem().Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Info);
         diags[0].GetMessage().ShouldContain("Item");
         diags[0].GetMessage().ShouldContain("Guid");
         diags[0].GetMessage().ShouldContain("string, bool, AbsolutePath, FileInfo, DirectoryInfo");
@@ -242,9 +242,9 @@ public class UnsupportedTaskItemTypeAnalyzerTests
             """);
 
         diags.Where(d => d.Id == DiagnosticIds.UnsupportedTaskItemType).ShouldHaveSingleItem()
-            .Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
+            .Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Info);
         diags.Where(d => d.Id == DiagnosticIds.CultureSensitiveTaskItemType).ShouldHaveSingleItem()
-            .Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Warning);
+            .Severity.ShouldBe(Microsoft.CodeAnalysis.DiagnosticSeverity.Info);
     }
 
     [Fact]
@@ -380,5 +380,56 @@ public class UnsupportedTaskItemTypeAnalyzerTests
             """);
 
         diags.ShouldNotContain(d => d.Id == DiagnosticIds.UnsupportedTaskItemType);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // Configured severity overrides the Info defaults
+    // ═══════════════════════════════════════════════════════════════════════
+
+    [Theory]
+    [InlineData(ReportDiagnostic.Warn, DiagnosticSeverity.Warning)]
+    [InlineData(ReportDiagnostic.Error, DiagnosticSeverity.Error)]
+    public async Task UnsupportedTaskItemType_ConfiguredSeverity_OverridesInfoDefault(
+        ReportDiagnostic reportDiagnostic,
+        DiagnosticSeverity expectedSeverity)
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsWithConfiguredSeverityAsync(
+            """
+            using System;
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<Guid> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """,
+            DiagnosticIds.UnsupportedTaskItemType,
+            reportDiagnostic);
+
+        diags.Where(d => d.Id == DiagnosticIds.UnsupportedTaskItemType).ShouldHaveSingleItem()
+            .Severity.ShouldBe(expectedSeverity);
+    }
+
+    [Theory]
+    [InlineData(ReportDiagnostic.Warn, DiagnosticSeverity.Warning)]
+    [InlineData(ReportDiagnostic.Error, DiagnosticSeverity.Error)]
+    public async Task CultureSensitiveTaskItemType_ConfiguredSeverity_OverridesInfoDefault(
+        ReportDiagnostic reportDiagnostic,
+        DiagnosticSeverity expectedSeverity)
+    {
+        var diags = await GetUnsupportedTaskItemTypeDiagnosticsWithConfiguredSeverityAsync(
+            """
+            using Microsoft.Build.Framework;
+            public class MyTask : Microsoft.Build.Utilities.Task
+            {
+                public ITaskItem<int> Item { get; set; } = null!;
+                public override bool Execute() => true;
+            }
+            """,
+            DiagnosticIds.CultureSensitiveTaskItemType,
+            reportDiagnostic);
+
+        diags.Where(d => d.Id == DiagnosticIds.CultureSensitiveTaskItemType).ShouldHaveSingleItem()
+            .Severity.ShouldBe(expectedSeverity);
     }
 }

--- a/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
+++ b/src/TaskAnalyzer.Tests/UnsupportedTaskItemTypeAnalyzerTests.cs
@@ -4,6 +4,8 @@
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
 using Shouldly;
 using Xunit;
 using static Microsoft.Build.TaskAuthoring.Analyzer.Tests.TestHelpers;
@@ -387,49 +389,69 @@ public class UnsupportedTaskItemTypeAnalyzerTests
     // ═══════════════════════════════════════════════════════════════════════
 
     [Theory]
-    [InlineData(ReportDiagnostic.Warn, DiagnosticSeverity.Warning)]
-    [InlineData(ReportDiagnostic.Error, DiagnosticSeverity.Error)]
+    [InlineData("warning", DiagnosticSeverity.Warning)]
+    [InlineData("error", DiagnosticSeverity.Error)]
     public async Task UnsupportedTaskItemType_ConfiguredSeverity_OverridesInfoDefault(
-        ReportDiagnostic reportDiagnostic,
+        string configuredSeverity,
         DiagnosticSeverity expectedSeverity)
     {
-        var diags = await GetUnsupportedTaskItemTypeDiagnosticsWithConfiguredSeverityAsync(
+        await VerifyConfiguredSeverityAsync(
             """
             using System;
             using Microsoft.Build.Framework;
             public class MyTask : Microsoft.Build.Utilities.Task
             {
-                public ITaskItem<Guid> Item { get; set; } = null!;
+                public ITaskItem<Guid> {|#0:Item|} { get; set; } = null!;
                 public override bool Execute() => true;
             }
             """,
             DiagnosticIds.UnsupportedTaskItemType,
-            reportDiagnostic);
-
-        diags.Where(d => d.Id == DiagnosticIds.UnsupportedTaskItemType).ShouldHaveSingleItem()
-            .Severity.ShouldBe(expectedSeverity);
+            configuredSeverity,
+            expectedSeverity);
     }
 
     [Theory]
-    [InlineData(ReportDiagnostic.Warn, DiagnosticSeverity.Warning)]
-    [InlineData(ReportDiagnostic.Error, DiagnosticSeverity.Error)]
+    [InlineData("warning", DiagnosticSeverity.Warning)]
+    [InlineData("error", DiagnosticSeverity.Error)]
     public async Task CultureSensitiveTaskItemType_ConfiguredSeverity_OverridesInfoDefault(
-        ReportDiagnostic reportDiagnostic,
+        string configuredSeverity,
         DiagnosticSeverity expectedSeverity)
     {
-        var diags = await GetUnsupportedTaskItemTypeDiagnosticsWithConfiguredSeverityAsync(
+        await VerifyConfiguredSeverityAsync(
             """
             using Microsoft.Build.Framework;
             public class MyTask : Microsoft.Build.Utilities.Task
             {
-                public ITaskItem<int> Item { get; set; } = null!;
+                public ITaskItem<int> {|#0:Item|} { get; set; } = null!;
                 public override bool Execute() => true;
             }
             """,
             DiagnosticIds.CultureSensitiveTaskItemType,
-            reportDiagnostic);
+            configuredSeverity,
+            expectedSeverity);
+    }
 
-        diags.Where(d => d.Id == DiagnosticIds.CultureSensitiveTaskItemType).ShouldHaveSingleItem()
-            .Severity.ShouldBe(expectedSeverity);
+    private static async Task VerifyConfiguredSeverityAsync(
+        string source,
+        string diagnosticId,
+        string configuredSeverity,
+        DiagnosticSeverity expectedSeverity)
+    {
+        var test = new CSharpAnalyzerTest<UnsupportedTaskItemTypeAnalyzer, DefaultVerifier>
+        {
+            TestCode = source,
+            ReferenceAssemblies = ReferenceAssemblies.Net.Net80,
+        };
+        test.TestState.Sources.Add(("Stubs.cs", FrameworkStubs));
+        test.TestState.AnalyzerConfigFiles.Add(("/.editorconfig", $$"""
+            root = true
+
+            [*.cs]
+            dotnet_diagnostic.{{diagnosticId}}.severity = {{configuredSeverity}}
+            """));
+        test.ExpectedDiagnostics.Add(
+            new DiagnosticResult(diagnosticId, expectedSeverity).WithLocation(0));
+
+        await test.RunAsync();
     }
 }

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -2,7 +2,7 @@
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-MSBuildTask0001 | MSBuild.TaskAuthoring | Error | APIs that must not be used in any MSBuild task (Environment.Exit, Console.*, etc.)
+MSBuildTask0001 | MSBuild.TaskAuthoring | Info | APIs that must not be used in any MSBuild task (Environment.Exit, Console.*, etc.)
 MSBuildTask0002 | MSBuild.TaskAuthoring | Warning | APIs that should use TaskEnvironment alternatives
 MSBuildTask0003 | MSBuild.TaskAuthoring | Warning | File APIs that need absolute paths
 MSBuildTask0004 | MSBuild.TaskAuthoring | Warning | APIs that may cause issues in multithreaded task execution

--- a/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
+++ b/src/TaskAnalyzer/AnalyzerReleases.Unshipped.md
@@ -10,8 +10,8 @@ MSBuildTask0005 | MSBuild.TaskAuthoring | Warning | Transitive unsafe API usage 
 MSBuildTask0006 | MSBuild.TaskAuthoring | Info | Prefer typed path parameter (AbsolutePath/FileInfo/DirectoryInfo) over string (code fix available)
 MSBuildTask0007 | MSBuild.TaskAuthoring | Info | Prefer ITaskItem<T> over manual ItemSpec parsing (code fix available)
 MSBuildTask0008 | MSBuild.TaskAuthoring | Info | Initialize a relative default path in Execute() so TaskEnvironment can root it when the property is retyped (code fix available)
-MSBuildTask0009 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that MSBuild cannot bind as a task parameter
-MSBuildTask0010 | MSBuild.TaskAuthoring | Warning | ITaskItem<T> used with a type argument T that MSBuild parses through Convert.ChangeType
+MSBuildTask0009 | MSBuild.TaskAuthoring | Info | ITaskItem<T> used with a type argument T that MSBuild cannot bind as a task parameter
+MSBuildTask0010 | MSBuild.TaskAuthoring | Info | ITaskItem<T> used with a type argument T that MSBuild parses through Convert.ChangeType
 MSBuildTask0011 | MSBuild.TaskAuthoring | Info | Prefer constructor injection for TaskEnvironment
 MSBuildTask0012 | MSBuild.TaskAuthoring | Warning | TaskEnvironment property is never assigned by MSBuild because the task does not implement IMultiThreadableTask
 MSBuildTask0013 | MSBuild.TaskAuthoring | Info | Task declares IMultiThreadableTask but is not marked with [MSBuildMultiThreadableTask] (disabled by default)

--- a/src/TaskAnalyzer/BannedApiDefinitions.cs
+++ b/src/TaskAnalyzer/BannedApiDefinitions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
     {
         internal enum ApiCategory
         {
-            /// <summary>MSBuildTask0001: Critical errors - no safe alternative.</summary>
+            /// <summary>MSBuildTask0001: Never-safe APIs - no safe alternative.</summary>
             CriticalError,
             /// <summary>MSBuildTask0002: Requires TaskEnvironment replacement.</summary>
             TaskEnvironment,
@@ -45,7 +45,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
         {
             return ImmutableArray.Create(
                 // ══════════════════════════════════════════════════════════════
-                // MSBuildTask0001: Critical errors - no safe alternative
+                // MSBuildTask0001: Never-safe APIs - no safe alternative
                 // Console.* is handled at the TYPE level in the analyzer.
                 // ══════════════════════════════════════════════════════════════
 

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             title: "ITaskItem<T> used with unsupported type argument",
             messageFormat: "Task property '{0}' uses ITaskItem<{1}> but MSBuild cannot automatically parse '{1}' from item metadata. Use one of the directly parsed types: {2}.",
             category: "MSBuild.TaskAuthoring",
-            defaultSeverity: DiagnosticSeverity.Warning,
+            defaultSeverity: DiagnosticSeverity.Info,
             isEnabledByDefault: true,
             description: "MSBuild can only bind ITaskItem<T> properties when T is a supported type. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.");
 
@@ -99,7 +99,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             title: "ITaskItem<T> type argument relies on culture-sensitive conversion",
             messageFormat: "Task property '{0}' uses ITaskItem<{1}>, which MSBuild parses through Convert.ChangeType using CultureInfo.InvariantCulture. Use ITaskItem<string> and parse explicitly with a chosen culture.",
             category: "MSBuild.TaskAuthoring",
-            defaultSeverity: DiagnosticSeverity.Warning,
+            defaultSeverity: DiagnosticSeverity.Info,
             isEnabledByDefault: true,
             description: "ITaskItem<T> type arguments parsed through Convert.ChangeType use CultureInfo.InvariantCulture. Bind the item as a string and parse it explicitly with the intended culture.");
 

--- a/src/TaskAnalyzer/DiagnosticDescriptors.cs
+++ b/src/TaskAnalyzer/DiagnosticDescriptors.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             title: "API is never safe in MSBuild task implementations",
             messageFormat: "'{0}' must not be used in MSBuild tasks: {1}",
             category: "MSBuild.TaskAuthoring",
-            defaultSeverity: DiagnosticSeverity.Error,
+            defaultSeverity: DiagnosticSeverity.Info,
             isEnabledByDefault: true,
             description: "This API has no safe alternative in MSBuild tasks. It affects the entire process or interferes with build infrastructure.");
 

--- a/src/TaskAnalyzer/MultiThreadableTaskAnalyzer.cs
+++ b/src/TaskAnalyzer/MultiThreadableTaskAnalyzer.cs
@@ -16,7 +16,10 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
     /// <summary>
     /// Roslyn analyzer that detects unsafe API usage in MSBuild task implementations.
     /// 
-    /// By default, MSBuildTask0002 and MSBuildTask0003 apply only to MT-scoped code.
+    /// By default, MSBuildTask0002 and MSBuildTask0003 apply only to MT-scoped code: a type carrying
+    /// [MSBuildMultiThreadableTask] or [MSBuildMultiThreadableTaskAnalyzed], or a task that declares
+    /// IMultiThreadableTask in its own base list. The declared interface signals analyzer migration intent
+    /// only -- runtime routing still depends on [MSBuildMultiThreadableTask].
     /// The "msbuild_task_analyzer.run_mt_analyzers_on_all_tasks" option enables these rules for all tasks.
     ///   (MSBuildTask0001 and MSBuildTask0004 always fire on all tasks regardless)
     /// 
@@ -50,9 +53,11 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             var absolutePathType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.AbsolutePathFullName);
             var iTaskItemType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskItemFullName);
             var consoleType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ConsoleFullName);
+            var multiThreadableTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.IMultiThreadableTaskFullName);
             var contributingMultiThreadableTaskBaseTypes = FindContributingMultiThreadableTaskBaseTypes(
                 compilationContext.Compilation,
-                iTaskType);
+                iTaskType,
+                multiThreadableTaskType);
 
             // Build symbol lookup for banned APIs
             var bannedApiLookup = BuildBannedApiLookup(compilationContext.Compilation);
@@ -69,6 +74,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 if (!IsDirectlyAnalyzedType(
                     namedType,
                     iTaskType,
+                    multiThreadableTaskType,
                     contributingMultiThreadableTaskBaseTypes,
                     out bool analyzeAsMultiThreadable))
                 {

--- a/src/TaskAnalyzer/MultiThreadableTaskDeclarationAnalyzer.cs
+++ b/src/TaskAnalyzer/MultiThreadableTaskDeclarationAnalyzer.cs
@@ -124,35 +124,10 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     ReportOnType(context, DiagnosticDescriptors.TaskEnvironmentNeverAssigned, type);
                 }
             }
-            else if (!hasAttribute && DeclaresMultiThreadableTaskInterface(type, multiThreadableTaskType))
+            else if (!hasAttribute && SharedAnalyzerHelpers.DeclaresMultiThreadableTaskInterface(type, multiThreadableTaskType))
             {
                 ReportOnType(context, DiagnosticDescriptors.MissingMultiThreadableTaskAttribute, type);
             }
-        }
-
-        /// <summary>
-        /// Reports whether the type opts into <c>IMultiThreadableTask</c> in its own base list, rather
-        /// than merely inheriting it.
-        /// <para>
-        /// <c>ToolTask</c> implements <c>IMultiThreadableTask</c>, so every <c>ToolTask</c>-derived task in
-        /// the ecosystem satisfies the interface without its author having declared anything. Treating an
-        /// inherited implementation as intent would report thousands of untouched tasks, which is the same
-        /// reason <c>TaskRouter</c> cannot use the interface as a routing signal.
-        /// </para>
-        /// </summary>
-        private static bool DeclaresMultiThreadableTaskInterface(
-            INamedTypeSymbol type,
-            INamedTypeSymbol multiThreadableTaskType)
-        {
-            foreach (INamedTypeSymbol declaredInterface in type.Interfaces)
-            {
-                if (SymbolEqualityComparer.Default.Equals(declaredInterface, multiThreadableTaskType))
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         private static bool HasMultiThreadableTaskAttribute(INamedTypeSymbol type, INamedTypeSymbol attributeType)

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -31,7 +31,7 @@ Inheriting `IMultiThreadableTask` from a base class does not make a task MT-scop
 
 | ID | Rule | Default state | Severity | Reported for by default |
 |---|---|---|---|---|
-| **MSBuildTask0001** | API is never safe in an MSBuild task | Enabled | Error | All task implementations and MT-scoped helpers |
+| **MSBuildTask0001** | API is never safe in an MSBuild task | Enabled | Info | All task implementations and MT-scoped helpers |
 | **MSBuildTask0002** | API requires a `TaskEnvironment` alternative | Enabled | Warning | MT-scoped code only |
 | **MSBuildTask0003** | File system API requires an absolute path | Enabled | Warning | MT-scoped code only |
 | **MSBuildTask0004** | API requires review for MT execution | Enabled | Warning | All task implementations and MT-scoped helpers |
@@ -108,9 +108,9 @@ The migration option and severity configuration have different purposes:
 
 ## Diagnostic Rule Details
 
-### MSBuildTask0001 — Critical: No Safe Alternative
+### MSBuildTask0001 — No Safe Alternative
 
-These APIs affect the entire process or interfere with build infrastructure. They are **errors** and should never appear in any MSBuild task.
+These APIs affect the entire process or interfere with build infrastructure and should never appear in any MSBuild task. The rule defaults to Info to avoid breaking builds that consume a newer analyzer package. Repositories can enforce it as a warning or error through `dotnet_diagnostic.MSBuildTask0001.severity`.
 
 | API | Why it's banned |
 |---|---|
@@ -546,9 +546,8 @@ The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classe
 
 ### Severity Levels
 
-- **MSBuildTask0001** has a default severity of **Error**. These APIs are never safe in an MSBuild task.
 - **MSBuildTask0002–MSBuildTask0005, MSBuildTask0012, and MSBuildTask0014** have a default severity of **Warning**.
-- **MSBuildTask0006–MSBuildTask0011** have a default severity of **Info**. MSBuildTask0009 and MSBuildTask0010 are guidance for task authors who are not doing MT migration, so they default to **Info** rather than **Warning**.
+- **MSBuildTask0001 and MSBuildTask0006–MSBuildTask0011** have a default severity of **Info**. MSBuildTask0001, MSBuildTask0009, and MSBuildTask0010 default to **Info** rather than a stronger severity to avoid breaking builds that consume a newer analyzer package.
 - Any of these defaults can be raised or lowered with `dotnet_diagnostic.<ID>.severity` in an .editorconfig.
 - **MSBuildTask0013** has a severity of **Info**, but the rule is disabled by default.
 

--- a/src/TaskAnalyzer/README.md
+++ b/src/TaskAnalyzer/README.md
@@ -19,10 +19,13 @@ By default, MT migration rules MSBuildTask0002 and MSBuildTask0003 apply only to
 MT-scoped code includes these types:
 
 - A task with `[MSBuildMultiThreadableTask]` applied directly.
+- A task that declares `IMultiThreadableTask` in its own base list.
 - A helper with `[MSBuildMultiThreadableTaskAnalyzed]` applied directly.
 - A source base class that contributes implementation code to one of these tasks.
 
-`IMultiThreadableTask` only enables `TaskEnvironment` injection. It does not route a task to the MT environment and does not enable MT migration rules by itself.
+A **directly declared** `IMultiThreadableTask` is an *analyzer* signal of migration intent only. It does not change runtime routing: `[MSBuildMultiThreadableTask]` remains the attribute that routes a task to the MT environment, and `IMultiThreadableTask` on its own only enables `TaskEnvironment` injection.
+
+Inheriting `IMultiThreadableTask` from a base class does not make a task MT-scoped. `ToolTask` implements the interface, so every `ToolTask`-derived task in the ecosystem satisfies it without its author having declared anything. Detection therefore inspects the interfaces declared directly on the task (`INamedTypeSymbol.Interfaces`), never the inherited set (`AllInterfaces`).
 
 ### Default rule matrix
 
@@ -36,8 +39,8 @@ MT-scoped code includes these types:
 | **MSBuildTask0006** | Prefer a typed path property | Enabled | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly |
 | **MSBuildTask0007** | Prefer `ITaskItem<T>` | Enabled | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly |
 | **MSBuildTask0008** | Initialize a relative path default in `Execute()` | Enabled | Info | Tasks with `[MSBuildMultiThreadableTask]` applied directly |
-| **MSBuildTask0009** | `ITaskItem<T>` uses an unsupported type | Enabled | Warning | All task implementations that use an unsupported `ITaskItem<T>` type |
-| **MSBuildTask0010** | `ITaskItem<T>` uses culture-sensitive conversion | Enabled | Warning | All task implementations that use culture-sensitive `ITaskItem<T>` conversion |
+| **MSBuildTask0009** | `ITaskItem<T>` uses an unsupported type | Enabled | Info | All task implementations that use an unsupported `ITaskItem<T>` type |
+| **MSBuildTask0010** | `ITaskItem<T>` uses culture-sensitive conversion | Enabled | Info | All task implementations that use culture-sensitive `ITaskItem<T>` conversion |
 | **MSBuildTask0011** | Prefer `TaskEnvironment` constructor injection | Enabled | Info | Concrete `IMultiThreadableTask` implementations without constructor injection |
 | **MSBuildTask0012** | MSBuild does not assign the `TaskEnvironment` property | Enabled | Warning | Concrete tasks with `[MSBuildMultiThreadableTask]` and an unassigned `TaskEnvironment` property |
 | **MSBuildTask0013** | The task does not have `[MSBuildMultiThreadableTask]` | **Disabled** | Info | Concrete tasks that declare `IMultiThreadableTask` directly but do not have `[MSBuildMultiThreadableTask]` |
@@ -358,19 +361,19 @@ For a reference-typed target (`FileInfo`/`DirectoryInfo`) the guard is a null-co
 
 ### MSBuildTask0009 — Unsupported `ITaskItem<T>` Type Argument
 
-When a task property is typed as `ITaskItem<T>` or `ITaskItem<T>[]` but `T` is not supported by MSBuild's task parameter binder, a **Warning** is emitted. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter.
+When a task property is typed as `ITaskItem<T>` or `ITaskItem<T>[]` but `T` is not supported by MSBuild's task parameter binder, an **Info** diagnostic is emitted. Using an unsupported type will cause a runtime failure when MSBuild tries to bind the parameter. Raise the rule with `dotnet_diagnostic.MSBuildTask0009.severity = warning` to have it break a `TreatWarningsAsErrors` build.
 
 **Directly parsed type arguments:** `string`, `bool`, `AbsolutePath`, `FileInfo`, `DirectoryInfo`.
 
 The binder also accepts `char`, numeric primitives, `decimal`, and `DateTime`, but MSBuildTask0010 rejects those types because they rely on `Convert.ChangeType`.
 
 ```csharp
-// ⚠️ MSBuildTask0009: Task property 'Id' uses ITaskItem<Guid> but 'Guid' is not supported
+// ℹ️ MSBuildTask0009: Task property 'Id' uses ITaskItem<Guid> but 'Guid' is not supported
 public class MyTask : Task
 {
-    public ITaskItem<System.Guid> Id { get; set; }       // warning
-    public ITaskItem<System.TimeSpan>[] Durations { get; set; }  // warning
-    public ITaskItem<int> Count { get; set; }             // MSBuildTask0010 warning
+    public ITaskItem<System.Guid> Id { get; set; }       // MSBuildTask0009
+    public ITaskItem<System.TimeSpan>[] Durations { get; set; }  // MSBuildTask0009
+    public ITaskItem<int> Count { get; set; }             // MSBuildTask0010
 }
 ```
 
@@ -380,13 +383,13 @@ No code fix is offered for MSBuildTask0009 — the resolution depends on the int
 
 ### MSBuildTask0010 — Culture-Sensitive `ITaskItem<T>` Conversion
 
-MSBuild binds `ITaskItem<T>` for `char`, numeric primitives, `decimal`, and `DateTime` through `Convert.ChangeType` using `CultureInfo.InvariantCulture`. Because this implicit conversion may not match the task's intended culture, the analyzer reports a **Warning** whenever one of these types is used.
+MSBuild binds `ITaskItem<T>` for `char`, numeric primitives, `decimal`, and `DateTime` through `Convert.ChangeType` using `CultureInfo.InvariantCulture`. Because this implicit conversion may not match the task's intended culture, the analyzer reports an **Info** diagnostic whenever one of these types is used. Raise the rule with `dotnet_diagnostic.MSBuildTask0010.severity = warning` when a codebase wants it enforced.
 
 ```csharp
 public class MyTask : Task
 {
-    public ITaskItem<int> Count { get; set; }       // warning
-    public ITaskItem<DateTime>[] Dates { get; set; } // warning
+    public ITaskItem<int> Count { get; set; }       // MSBuildTask0010
+    public ITaskItem<DateTime>[] Dates { get; set; } // MSBuildTask0010
 }
 ```
 
@@ -520,19 +523,20 @@ A concrete task that MSBuild cannot construct — no public parameterless constr
 
 See [Default Rules and Configuration](#default-rules-and-configuration) for the default-state matrix and copy-ready configuration.
 
-By default, MT migration warnings do not affect regular tasks. The analyzer recognizes `[MSBuildMultiThreadableTask]` as the task routing opt-in and `[MSBuildMultiThreadableTaskAnalyzed]` as an analyzer-only opt-in.
+By default, MT migration warnings do not affect regular tasks. The analyzer recognizes `[MSBuildMultiThreadableTask]` as the task routing opt-in, `[MSBuildMultiThreadableTaskAnalyzed]` as an analyzer-only opt-in, and a directly declared `IMultiThreadableTask` interface as a declaration of migration intent. Only the attribute affects runtime routing; the other two signals are read by the analyzer alone.
 
 | Type | Rules Applied |
 |---|---|
 | Regular class implementing `ITask` | MSBuildTask0001, MSBuildTask0004, MSBuildTask0009–MSBuildTask0010, and MSBuildTask0005 for transitive MSBuildTask0001/0004 violations |
 | Concrete `ITask` class with `[MSBuildMultiThreadableTask]` applied directly | MSBuildTask0001–MSBuildTask0010; MSBuildTask0011 and MSBuildTask0012 apply only when their conditions match |
-| Concrete class implementing `IMultiThreadableTask` without the attribute | MSBuildTask0001, MSBuildTask0004, MSBuildTask0009–MSBuildTask0011, and MSBuildTask0005 for transitive MSBuildTask0001/0004 violations; MSBuildTask0013 is available but disabled by default |
+| Class that declares `IMultiThreadableTask` directly, without the attribute | MSBuildTask0001–MSBuildTask0005, MSBuildTask0009–MSBuildTask0011; MSBuildTask0006–MSBuildTask0008 still require the attribute, and MSBuildTask0013 is available but disabled by default |
+| Class that only inherits `IMultiThreadableTask` from a base class | MSBuildTask0001, MSBuildTask0004, MSBuildTask0009–MSBuildTask0011, and MSBuildTask0005 for transitive MSBuildTask0001/0004 violations — inheriting the interface is not migration intent |
 | Helper class with `[MSBuildMultiThreadableTaskAnalyzed]` | Direct MSBuildTask0001–MSBuildTask0004 analysis; MSBuildTask0005 reports only when a task reaches the helper |
 | Regular class (no task interface or attribute) | Not analyzed |
 | Class with `[MSBuildMultiThreadableTask]` that does not implement `ITask` | MSBuildTask0014 |
 | Abstract class with `[MSBuildMultiThreadableTask]` | MSBuildTask0014 |
 
-Base classes of an `ITask` with `[MSBuildMultiThreadableTask]` or `[MSBuildMultiThreadableTaskAnalyzed]` applied directly are analyzed as part of that task's implementation.
+Base classes of an `ITask` that is MT-scoped — through `[MSBuildMultiThreadableTask]`, `[MSBuildMultiThreadableTaskAnalyzed]`, or a directly declared `IMultiThreadableTask` — are analyzed as part of that task's implementation.
 
 MSBuildTask0006–MSBuildTask0008 apply only when the `[MSBuildMultiThreadableTask]` attribute is applied **directly** to the task class. The attribute is `Inherited = false`, so a task that merely derives from a base class implementing `IMultiThreadableTask` (or carrying the attribute) has not itself opted into multithreaded support and is not subject to these three rules. Input properties are collected from the task class **and its base classes**, so an `ITaskItem`/`string` input declared on a shared base task is still analyzed.
 
@@ -543,8 +547,9 @@ The `[MSBuildMultiThreadableTaskAnalyzed]` attribute allows opting helper classe
 ### Severity Levels
 
 - **MSBuildTask0001** has a default severity of **Error**. These APIs are never safe in an MSBuild task.
-- **MSBuildTask0002–MSBuildTask0005, MSBuildTask0009, MSBuildTask0010, MSBuildTask0012, and MSBuildTask0014** have a default severity of **Warning**.
-- **MSBuildTask0006–MSBuildTask0008 and MSBuildTask0011** have a default severity of **Info**.
+- **MSBuildTask0002–MSBuildTask0005, MSBuildTask0012, and MSBuildTask0014** have a default severity of **Warning**.
+- **MSBuildTask0006–MSBuildTask0011** have a default severity of **Info**. MSBuildTask0009 and MSBuildTask0010 are guidance for task authors who are not doing MT migration, so they default to **Info** rather than **Warning**.
+- Any of these defaults can be raised or lowered with `dotnet_diagnostic.<ID>.severity` in an .editorconfig.
 - **MSBuildTask0013** has a severity of **Info**, but the rule is disabled by default.
 
 ## Code Fixes

--- a/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
+++ b/src/TaskAnalyzer/SharedAnalyzerHelpers.cs
@@ -38,8 +38,19 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 enabled;
         }
 
+        /// <summary>
+        /// Reports whether the type opts into MT migration analysis, through
+        /// <c>[MSBuildMultiThreadableTask]</c>, <c>[MSBuildMultiThreadableTaskAnalyzed]</c>, or by declaring
+        /// <c>IMultiThreadableTask</c> in its own base list.
+        /// <para>
+        /// The declared interface is a migration-intent signal for the analyzer only. It does not change
+        /// runtime routing: <c>[MSBuildMultiThreadableTask]</c> remains the attribute that routes a task to
+        /// the MT environment.
+        /// </para>
+        /// </summary>
         internal static bool IsMtAnalysisOptIn(
             INamedTypeSymbol type,
+            INamedTypeSymbol? multiThreadableTaskType,
             out bool hasAnalyzedAttribute)
         {
             bool hasMultiThreadableAttribute = false;
@@ -66,18 +77,53 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             }
 
             return hasMultiThreadableAttribute ||
-                hasAnalyzedAttribute;
+                hasAnalyzedAttribute ||
+                DeclaresMultiThreadableTaskInterface(type, multiThreadableTaskType);
+        }
+
+        /// <summary>
+        /// Reports whether the type opts into <c>IMultiThreadableTask</c> in its own base list, rather
+        /// than merely inheriting it.
+        /// <para>
+        /// <c>ToolTask</c> implements <c>IMultiThreadableTask</c>, so every <c>ToolTask</c>-derived task in
+        /// the ecosystem satisfies the interface without its author having declared anything. Treating an
+        /// inherited implementation as intent would report thousands of untouched tasks, which is the same
+        /// reason <c>TaskRouter</c> cannot use the interface as a routing signal. Detection therefore
+        /// inspects <see cref="INamedTypeSymbol.Interfaces"/> and never
+        /// <see cref="INamedTypeSymbol.AllInterfaces"/>.
+        /// </para>
+        /// </summary>
+        internal static bool DeclaresMultiThreadableTaskInterface(
+            INamedTypeSymbol type,
+            INamedTypeSymbol? multiThreadableTaskType)
+        {
+            if (multiThreadableTaskType is null)
+            {
+                return false;
+            }
+
+            foreach (INamedTypeSymbol declaredInterface in type.Interfaces)
+            {
+                if (SymbolEqualityComparer.Default.Equals(declaredInterface.OriginalDefinition, multiThreadableTaskType))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         internal static bool IsDirectlyAnalyzedType(
             INamedTypeSymbol type,
             INamedTypeSymbol iTaskType,
+            INamedTypeSymbol? multiThreadableTaskType,
             ImmutableHashSet<INamedTypeSymbol> contributingMultiThreadableTaskBaseTypes,
             out bool analyzeAsMultiThreadable)
         {
             bool isTask = ImplementsInterface(type, iTaskType);
             bool hasMultiThreadableOptIn = IsMtAnalysisOptIn(
                 type,
+                multiThreadableTaskType,
                 out bool hasAnalyzedAttribute);
             bool contributesToMultiThreadableTask =
                 contributingMultiThreadableTaskBaseTypes.Contains(type.OriginalDefinition);
@@ -88,20 +134,23 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
 
         internal static ImmutableHashSet<INamedTypeSymbol> FindContributingMultiThreadableTaskBaseTypes(
             Compilation compilation,
-            INamedTypeSymbol iTaskType)
+            INamedTypeSymbol iTaskType,
+            INamedTypeSymbol? multiThreadableTaskType)
         {
             var builder = ImmutableHashSet.CreateBuilder<INamedTypeSymbol>(SymbolEqualityComparer.Default);
             CollectContributingMultiThreadableTaskBaseTypes(
                 compilation.Assembly.GlobalNamespace,
                 builder,
-                iTaskType);
+                iTaskType,
+                multiThreadableTaskType);
             return builder.ToImmutable();
         }
 
         private static void CollectContributingMultiThreadableTaskBaseTypes(
             INamespaceOrTypeSymbol container,
             ImmutableHashSet<INamedTypeSymbol>.Builder result,
-            INamedTypeSymbol iTaskType)
+            INamedTypeSymbol iTaskType,
+            INamedTypeSymbol? multiThreadableTaskType)
         {
             foreach (ISymbol member in container.GetMembers())
             {
@@ -110,7 +159,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     CollectContributingMultiThreadableTaskBaseTypes(
                         childNamespace,
                         result,
-                        iTaskType);
+                        iTaskType,
+                        multiThreadableTaskType);
                     continue;
                 }
 
@@ -122,6 +172,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 if (ImplementsInterface(type, iTaskType) &&
                     IsMtAnalysisOptIn(
                         type,
+                        multiThreadableTaskType,
                         out bool hasAnalyzedAttribute) &&
                     (!type.IsAbstract || hasAnalyzedAttribute))
                 {
@@ -136,7 +187,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                 CollectContributingMultiThreadableTaskBaseTypes(
                     type,
                     result,
-                    iTaskType);
+                    iTaskType,
+                    multiThreadableTaskType);
             }
         }
 

--- a/src/TaskAnalyzer/TransitiveCallChainAnalyzer.cs
+++ b/src/TaskAnalyzer/TransitiveCallChainAnalyzer.cs
@@ -56,12 +56,14 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             var absolutePathType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.AbsolutePathFullName);
             var iTaskItemType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ITaskItemFullName);
             var consoleType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.ConsoleFullName);
+            var multiThreadableTaskType = compilationContext.Compilation.GetTypeByMetadataName(WellKnownTypeNames.IMultiThreadableTaskFullName);
 
             var bannedApiLookup = BuildBannedApiLookup(compilationContext.Compilation);
             var filePathTypes = ResolveFilePathTypes(compilationContext.Compilation);
             var contributingMultiThreadableTaskBaseTypes = FindContributingMultiThreadableTaskBaseTypes(
                 compilationContext.Compilation,
-                iTaskType);
+                iTaskType,
+                multiThreadableTaskType);
 
             // Thread-safe collections for building the graph across concurrent operation callbacks
             var callGraph = new ConcurrentDictionary<ISymbol, ConcurrentBag<ISymbol>>(SymbolEqualityComparer.Default);
@@ -74,7 +76,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             {
                 ScanOperation(opCtx, callGraph, directViolations, bannedApiLookup, filePathTypes,
                     taskEnvironmentType, absolutePathType, iTaskItemType, consoleType, iTaskType,
-                    contributingMultiThreadableTaskBaseTypes, directAnalysisStateCache);
+                    multiThreadableTaskType, contributingMultiThreadableTaskBaseTypes, directAnalysisStateCache);
             },
             OperationKind.Invocation,
             OperationKind.ObjectCreation,
@@ -85,7 +87,8 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             compilationContext.RegisterCompilationEndAction(endCtx =>
             {
                 AnalyzeTransitiveViolations(endCtx, callGraph, directViolations, iTaskType,
-                    bannedApiLookup, filePathTypes, taskEnvironmentType, absolutePathType, iTaskItemType, consoleType);
+                    multiThreadableTaskType, bannedApiLookup, filePathTypes, taskEnvironmentType, absolutePathType,
+                    iTaskItemType, consoleType);
             });
         }
 
@@ -103,6 +106,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             INamedTypeSymbol? iTaskItemType,
             INamedTypeSymbol? consoleType,
             INamedTypeSymbol iTaskType,
+            INamedTypeSymbol? multiThreadableTaskType,
             ImmutableHashSet<INamedTypeSymbol> contributingMultiThreadableTaskBaseTypes,
             ConcurrentDictionary<INamedTypeSymbol, DirectAnalysisState> directAnalysisStateCache)
         {
@@ -125,6 +129,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
                     bool isDirectlyAnalyzed = IsDirectlyAnalyzedType(
                         containingType,
                         iTaskType,
+                        multiThreadableTaskType,
                         contributingMultiThreadableTaskBaseTypes,
                         out bool analyzeAsMultiThreadable);
                     directAnalysisState = new DirectAnalysisState(
@@ -278,6 +283,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             ConcurrentDictionary<ISymbol, ConcurrentBag<ISymbol>> callGraph,
             ConcurrentDictionary<ISymbol, ConcurrentBag<ViolationInfo>> directViolations,
             INamedTypeSymbol iTaskType,
+            INamedTypeSymbol? multiThreadableTaskType,
             Dictionary<ISymbol, BannedApiEntry> bannedApiLookup,
             ImmutableHashSet<INamedTypeSymbol> filePathTypes,
             INamedTypeSymbol? taskEnvironmentType,
@@ -312,6 +318,7 @@ namespace Microsoft.Build.TaskAuthoring.Analyzer
             {
                 bool isMultiThreadableTask = IsMtAnalysisOptIn(
                         taskType,
+                        multiThreadableTaskType,
                         out _);
 
                 var executeImplementation = iTaskExecuteMethod is null


### PR DESCRIPTION
This PR ships the TaskAnalyzer as part of the Microsoft.Build.Framework package, under nalyzers/dotnet/cs, so consumers do not need a direct analyzer package reference.

It also flips the analyzer project to shipping configuration and updates the README to match the packaged delivery model.

Fixes #15035